### PR TITLE
Add Asm.Umbraco, Asm.Umbraco.Authentication, and security middleware for Asm.AspNetCore

### DIFF
--- a/Asm.slnx
+++ b/Asm.slnx
@@ -61,6 +61,9 @@
     <Project Path="tests/Asm.Tests/Asm.Tests.csproj">
       <BuildType Solution="Release 64|*" Project="Release" />
     </Project>
+    <Project Path="tests/Asm.Umbraco.Tests/Asm.Umbraco.Tests.csproj">
+      <BuildType Solution="Release 64|*" Project="Release" />
+    </Project>
     <Project Path="tests/Asm.Win32.Tests/Asm.Win32.Tests.csproj">
       <BuildType Solution="Release 64|*" Project="Release" />
     </Project>

--- a/Asm.slnx
+++ b/Asm.slnx
@@ -64,6 +64,9 @@
     <Project Path="tests/Asm.Umbraco.Tests/Asm.Umbraco.Tests.csproj">
       <BuildType Solution="Release 64|*" Project="Release" />
     </Project>
+    <Project Path="tests/Asm.Umbraco.Authentication.Tests/Asm.Umbraco.Authentication.Tests.csproj">
+      <BuildType Solution="Release 64|*" Project="Release" />
+    </Project>
     <Project Path="tests/Asm.Win32.Tests/Asm.Win32.Tests.csproj">
       <BuildType Solution="Release 64|*" Project="Release" />
     </Project>

--- a/Asm.slnx
+++ b/Asm.slnx
@@ -116,6 +116,9 @@
   <Project Path="src/Asm.Umbraco/Asm.Umbraco.csproj">
     <BuildType Solution="Release 64|*" Project="Release" />
   </Project>
+  <Project Path="src/Asm.Umbraco.Authentication/Asm.Umbraco.Authentication.csproj">
+    <BuildType Solution="Release 64|*" Project="Release" />
+  </Project>
   <Project Path="src/Asm.Win32/Asm.Win32.csproj">
     <BuildType Solution="Release 64|*" Project="Release" />
   </Project>

--- a/Asm.slnx
+++ b/Asm.slnx
@@ -113,6 +113,9 @@
   <Project Path="src/Asm.Testing.Domain/Asm.Testing.Domain.csproj">
     <BuildType Solution="Release 64|*" Project="Release" />
   </Project>
+  <Project Path="src/Asm.Umbraco/Asm.Umbraco.csproj">
+    <BuildType Solution="Release 64|*" Project="Release" />
+  </Project>
   <Project Path="src/Asm.Win32/Asm.Win32.csproj">
     <BuildType Solution="Release 64|*" Project="Release" />
   </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -46,7 +46,7 @@
     <PackageVersion Include="Reqnroll.xUnit.v3" Version="3.3.3" />
     <PackageVersion Include="Seq.Extensions.Logging" Version="9.0.0" />
     <PackageVersion Include="Serilog" Version="4.3.1" />
-    <PackageVersion Include="Serilog.AspNetCore" Version="8.0.3" />
+    <PackageVersion Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageVersion Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
@@ -55,6 +55,7 @@
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.5" />
     <PackageVersion Include="Umbraco.Cms.Api.Management" Version="17.3.4" />
     <PackageVersion Include="Umbraco.Cms.Core" Version="17.3.4" />
+    <PackageVersion Include="Umbraco.Cms.Web.Common" Version="17.3.4" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.v3.assert" Version="3.2.2" />
     <PackageVersion Include="xunit.v3.common" Version="3.2.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,26 +5,26 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- .NET 10 versions -->
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.4" Condition="'$(TargetFramework)' == 'net10.0'" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Memory" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.4" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.4" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.4" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.4" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.4" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.4" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.4" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Memory" Version="10.0.4" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.4" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.4" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.4" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.4" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.4" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.4" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.4" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.4" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.4" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.4" Condition="'$(TargetFramework)' == 'net10.0'" />
     <PackageVersion Include="Serilog.Extensions.Hosting" Version="10.0.0" Condition="'$(TargetFramework)' == 'net10.0'" />
     <!-- Non-Microsoft packages (version-agnostic) -->
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.4.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,7 @@
   <ItemGroup>
     <!-- .NET 10 versions -->
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
@@ -51,6 +52,9 @@
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageVersion Include="Serilog.Sinks.Seq" Version="9.0.0" />
     <PackageVersion Include="Serilog.Sinks.Trace" Version="4.0.0" />
+    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.5" />
+    <PackageVersion Include="Umbraco.Cms.Api.Management" Version="17.3.4" />
+    <PackageVersion Include="Umbraco.Cms.Core" Version="17.3.4" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.v3.assert" Version="3.2.2" />
     <PackageVersion Include="xunit.v3.common" Version="3.2.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -55,6 +55,7 @@
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.5" />
     <PackageVersion Include="Umbraco.Cms.Api.Management" Version="17.3.4" />
     <PackageVersion Include="Umbraco.Cms.Core" Version="17.3.4" />
+    <PackageVersion Include="Umbraco.Cms.Infrastructure" Version="17.3.4" />
     <PackageVersion Include="Umbraco.Cms.Web.Common" Version="17.3.4" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.v3.assert" Version="3.2.2" />

--- a/src/Asm.AspNetCore/Extensions/IApplicationBuilderExtensions.cs
+++ b/src/Asm.AspNetCore/Extensions/IApplicationBuilderExtensions.cs
@@ -1,5 +1,7 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Asm.AspNetCore.Middleware;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Builder;
 
@@ -53,4 +55,41 @@ public static class IApplicationBuilderExtensions
 
             await next();
         });
+
+    /// <summary>
+    /// Adds <see cref="SecurityHeadersMiddleware"/> to the pipeline with the supplied options.
+    /// </summary>
+    /// <param name="app">The application builder.</param>
+    /// <param name="configure">Callback to configure the security headers.</param>
+    /// <returns>The application builder.</returns>
+    public static IApplicationBuilder UseSecurityHeaders(
+        this IApplicationBuilder app,
+        Action<SecurityHeadersOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        var options = new SecurityHeadersOptions();
+        configure(options);
+
+        return app.UseMiddleware<SecurityHeadersMiddleware>(Options.Create(options));
+    }
+
+    /// <summary>
+    /// Adds <see cref="CanonicalUrlMiddleware"/> to the pipeline.
+    /// </summary>
+    /// <param name="app">The application builder.</param>
+    /// <param name="configure">Optional callback to configure canonicalisation options.</param>
+    /// <returns>The application builder.</returns>
+    public static IApplicationBuilder UseCanonicalUrls(
+        this IApplicationBuilder app,
+        Action<CanonicalUrlOptions>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+
+        var options = new CanonicalUrlOptions();
+        configure?.Invoke(options);
+
+        return app.UseMiddleware<CanonicalUrlMiddleware>(Options.Create(options));
+    }
 }

--- a/src/Asm.AspNetCore/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Asm.AspNetCore/Extensions/IServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Asm.AspNetCore.Security;
+﻿using Asm.AspNetCore.Reporting;
+using Asm.AspNetCore.Security;
 using Asm.Security;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 
@@ -26,5 +27,29 @@ public static class IServiceCollectionExtensions
     {
         services.AddHttpContextAccessor();
         return services.AddScoped<IPrincipalProvider, HttpContextPrincipalProvider>();
+    }
+
+    /// <summary>
+    /// Registers <see cref="SecurityReportingOptions"/> in the service collection.
+    /// When registered, <see cref="Asm.AspNetCore.Middleware.SecurityHeadersMiddleware"/> automatically
+    /// emits <c>Reporting-Endpoints</c> and <c>Report-To</c> headers.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configure">Optional callback to customise options.</param>
+    /// <returns>The service collection.</returns>
+    public static IServiceCollection AddSecurityReporting(
+        this IServiceCollection services,
+        Action<SecurityReportingOptions>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        var options = new SecurityReportingOptions();
+        configure?.Invoke(options);
+
+        // Registered as a singleton (not via services.Configure<T>) so that
+        // SecurityHeadersMiddleware can detect its absence — IOptions<T> is always
+        // resolvable and wouldn't signal "reporting not configured".
+        services.AddSingleton(options);
+        return services;
     }
 }

--- a/src/Asm.AspNetCore/Middleware/CanonicalUrlMiddleware.cs
+++ b/src/Asm.AspNetCore/Middleware/CanonicalUrlMiddleware.cs
@@ -1,0 +1,99 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+
+namespace Asm.AspNetCore.Middleware;
+
+/// <summary>
+/// Enforces a canonical URL form — lowercase path, no trailing slash — via 301 redirects.
+/// </summary>
+public class CanonicalUrlMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly CanonicalUrlOptions _options;
+
+    /// <summary>
+    /// Creates a new <see cref="CanonicalUrlMiddleware"/>.
+    /// </summary>
+    public CanonicalUrlMiddleware(RequestDelegate next, IOptions<CanonicalUrlOptions> options)
+    {
+        _next = next;
+        _options = options.Value;
+    }
+
+    /// <summary>
+    /// Processes the request, emitting 301 redirects to enforce the canonical URL form.
+    /// </summary>
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var path = context.Request.Path.Value;
+        var queryString = context.Request.QueryString.Value;
+
+        if (IsExempt(path) || string.IsNullOrEmpty(path))
+        {
+            await _next(context);
+            return;
+        }
+
+        if (_options.ForceLowercase && HasUpper(path) && !HasExcludedExtension(path))
+        {
+            context.Response.StatusCode = StatusCodes.Status301MovedPermanently;
+            context.Response.Headers.Location = path.ToLowerInvariant() + queryString;
+            return;
+        }
+
+        if (_options.RemoveTrailingSlash && path.Length > 1 && path.EndsWith('/'))
+        {
+            var trimmed = path.TrimEnd('/');
+            var physicalPath = context.Request.PathBase.Add(context.Request.Path).Value;
+            var isDirectory = Directory.Exists(physicalPath);
+            var isFile = File.Exists(physicalPath);
+
+            if (!isDirectory && !isFile)
+            {
+                context.Response.StatusCode = StatusCodes.Status301MovedPermanently;
+                context.Response.Headers.Location = trimmed + queryString;
+                return;
+            }
+        }
+
+        await _next(context);
+    }
+
+    private bool IsExempt(string? path)
+    {
+        if (string.IsNullOrEmpty(path) || _options.ExemptPathPrefixes.Count == 0)
+        {
+            return false;
+        }
+
+        foreach (var prefix in _options.ExemptPathPrefixes)
+        {
+            if (path.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static bool HasUpper(string path)
+    {
+        foreach (var c in path)
+        {
+            if (char.IsUpper(c)) return true;
+        }
+        return false;
+    }
+
+    private bool HasExcludedExtension(string path)
+    {
+        foreach (var ext in _options.LowercaseExcludedExtensions)
+        {
+            if (path.EndsWith(ext, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/Asm.AspNetCore/Middleware/CanonicalUrlOptions.cs
+++ b/src/Asm.AspNetCore/Middleware/CanonicalUrlOptions.cs
@@ -1,0 +1,31 @@
+namespace Asm.AspNetCore.Middleware;
+
+/// <summary>
+/// Options for <see cref="CanonicalUrlMiddleware"/>.
+/// </summary>
+public record CanonicalUrlOptions
+{
+    /// <summary>
+    /// When true, redirects paths containing uppercase characters to their lowercase form
+    /// (using 301 Moved Permanently).
+    /// </summary>
+    public bool ForceLowercase { get; set; } = true;
+
+    /// <summary>
+    /// File extensions that are exempt from lowercase redirection.
+    /// Matched case-insensitively; leading dot required.
+    /// </summary>
+    public IReadOnlyList<string> LowercaseExcludedExtensions { get; set; } = [".pdf"];
+
+    /// <summary>
+    /// When true, redirects paths ending in <c>/</c> to their trimmed form,
+    /// unless the path resolves to a physical file or directory.
+    /// </summary>
+    public bool RemoveTrailingSlash { get; set; } = true;
+
+    /// <summary>
+    /// Request path prefixes that bypass canonicalisation entirely.
+    /// Match is case-insensitive.
+    /// </summary>
+    public IReadOnlyList<string> ExemptPathPrefixes { get; set; } = [];
+}

--- a/src/Asm.AspNetCore/Middleware/SecurityHeadersMiddleware.cs
+++ b/src/Asm.AspNetCore/Middleware/SecurityHeadersMiddleware.cs
@@ -1,0 +1,112 @@
+using Asm.AspNetCore.Reporting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+
+namespace Asm.AspNetCore.Middleware;
+
+/// <summary>
+/// Adds a configurable set of security response headers to HTML responses and, optionally,
+/// strips server-fingerprint headers from all responses.
+/// </summary>
+/// <remarks>
+/// If <see cref="SecurityReportingOptions"/> is registered in DI (via
+/// <c>AddSecurityReporting()</c>), the middleware also emits <c>Reporting-Endpoints</c> and
+/// <c>Report-To</c> headers referencing the configured reporting routes.
+/// </remarks>
+public class SecurityHeadersMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly SecurityHeadersOptions _options;
+    private readonly SecurityReportingOptions? _reportingOptions;
+
+    /// <summary>
+    /// Creates a new <see cref="SecurityHeadersMiddleware"/>.
+    /// </summary>
+    /// <param name="next">The next middleware in the pipeline.</param>
+    /// <param name="options">The security-headers options.</param>
+    /// <param name="reportingOptions">Optional reporting options. When present (i.e.
+    /// <c>AddSecurityReporting()</c> was called), the middleware emits
+    /// <c>Reporting-Endpoints</c> and <c>Report-To</c> headers.</param>
+    public SecurityHeadersMiddleware(
+        RequestDelegate next,
+        IOptions<SecurityHeadersOptions> options,
+        SecurityReportingOptions? reportingOptions = null)
+    {
+        _next = next;
+        _options = options.Value;
+        _reportingOptions = reportingOptions;
+    }
+
+    /// <summary>
+    /// Processes the request and attaches security headers to the response.
+    /// </summary>
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (IsExempt(context.Request.Path.Value))
+        {
+            await _next(context);
+            return;
+        }
+
+        context.Response.OnStarting(() =>
+        {
+            if (_options.RemoveServerHeaders)
+            {
+                context.Response.Headers.Remove("X-Powered-By");
+                context.Response.Headers.Remove("X-AspNet-Version");
+                context.Response.Headers.Remove("X-AspNetMvc-Version");
+                context.Response.Headers.Remove("Server");
+            }
+
+            var contentType = context.Response.ContentType;
+            if (contentType == null || !contentType.StartsWith("text/html", StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.CompletedTask;
+            }
+
+            foreach (var (name, value) in _options.Headers)
+            {
+                context.Response.Headers.Append(name, value);
+            }
+
+            if (_options.DynamicHeaders is { } dynamic)
+            {
+                foreach (var (name, value) in dynamic(context))
+                {
+                    context.Response.Headers.Append(name, value);
+                }
+            }
+
+            if (_reportingOptions is { } reporting)
+            {
+                context.Response.Headers.Append(
+                    "Reporting-Endpoints",
+                    SecurityReportingHeaderBuilder.BuildReportingEndpoints(context, reporting));
+                context.Response.Headers.Append(
+                    "Report-To",
+                    SecurityReportingHeaderBuilder.BuildReportTo(context, reporting));
+            }
+
+            return Task.CompletedTask;
+        });
+
+        await _next(context);
+    }
+
+    private bool IsExempt(string? path)
+    {
+        if (string.IsNullOrEmpty(path) || _options.ExemptPathPrefixes.Count == 0)
+        {
+            return false;
+        }
+
+        foreach (var prefix in _options.ExemptPathPrefixes)
+        {
+            if (path.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/Asm.AspNetCore/Middleware/SecurityHeadersOptions.cs
+++ b/src/Asm.AspNetCore/Middleware/SecurityHeadersOptions.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Http;
+
+namespace Asm.AspNetCore.Middleware;
+
+/// <summary>
+/// Options for <see cref="SecurityHeadersMiddleware"/>.
+/// </summary>
+public record SecurityHeadersOptions
+{
+    /// <summary>
+    /// When true, removes server-fingerprint response headers
+    /// (<c>X-Powered-By</c>, <c>X-AspNet-Version</c>, <c>X-AspNetMvc-Version</c>, <c>Server</c>).
+    /// Defaults to true.
+    /// </summary>
+    public bool RemoveServerHeaders { get; set; } = true;
+
+    /// <summary>
+    /// Request paths (by prefix) that should bypass security-header processing entirely.
+    /// Match is case-insensitive. Defaults to empty.
+    /// </summary>
+    public IReadOnlyList<string> ExemptPathPrefixes { get; set; } = [];
+
+    /// <summary>
+    /// Static headers added to all HTML responses (after fingerprint stripping).
+    /// </summary>
+    public IDictionary<string, string> Headers { get; set; }
+        = new Dictionary<string, string>(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Optional callback producing additional headers computed per-request (e.g., containing
+    /// the request scheme or host). Merged after <see cref="Headers"/>.
+    /// </summary>
+    public Func<HttpContext, IDictionary<string, string>>? DynamicHeaders { get; set; }
+}

--- a/src/Asm.AspNetCore/Reporting/IEndpointRouteBuilderExtensions.cs
+++ b/src/Asm.AspNetCore/Reporting/IEndpointRouteBuilderExtensions.cs
@@ -1,0 +1,60 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Asm.AspNetCore.Reporting;
+
+namespace Microsoft.AspNetCore.Routing;
+
+/// <summary>
+/// Endpoint-routing extensions for mapping the security-reporting endpoints.
+/// </summary>
+public static class IEndpointRouteBuilderExtensions
+{
+    /// <summary>
+    /// Logger category used for integrity-report messages.
+    /// </summary>
+    public const string IntegrityLoggerCategory = "Asm.AspNetCore.Reporting.Integrity";
+
+    /// <summary>
+    /// Logger category used for CSP report messages.
+    /// </summary>
+    public const string CspLoggerCategory = "Asm.AspNetCore.Reporting.Csp";
+
+    /// <summary>
+    /// Maps the security-reporting endpoints.
+    /// Requires <see cref="IServiceCollectionExtensions.AddSecurityReporting"/>
+    /// to have been called.
+    /// </summary>
+    /// <param name="endpoints">The endpoint-route builder.</param>
+    /// <returns>The endpoint-convention builder for further configuration.</returns>
+    public static IEndpointConventionBuilder MapSecurityReporting(this IEndpointRouteBuilder endpoints)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+
+        var options = endpoints.ServiceProvider.GetRequiredService<SecurityReportingOptions>();
+        var loggerFactory = endpoints.ServiceProvider.GetRequiredService<ILoggerFactory>();
+        var integrityLogger = loggerFactory.CreateLogger(IntegrityLoggerCategory);
+        var cspLogger = loggerFactory.CreateLogger(CspLoggerCategory);
+
+        var group = endpoints.MapGroup(options.RoutePrefix.TrimStart('/').TrimEnd('/'));
+
+        group.MapPost(options.IntegrityRoute.TrimStart('/'), async (HttpContext ctx) =>
+        {
+            using var reader = new StreamReader(ctx.Request.Body);
+            var body = await reader.ReadToEndAsync();
+            integrityLogger.LogWarning("Integrity Report ({ContentType}): {Report}", ctx.Request.ContentType, body);
+            return Results.NoContent();
+        });
+
+        group.MapPost(options.CspRoute.TrimStart('/'), async (HttpContext ctx) =>
+        {
+            using var reader = new StreamReader(ctx.Request.Body);
+            var body = await reader.ReadToEndAsync();
+            cspLogger.LogWarning("CSP Report ({ContentType}): {Report}", ctx.Request.ContentType, body);
+            return Results.NoContent();
+        });
+
+        return group;
+    }
+}

--- a/src/Asm.AspNetCore/Reporting/IEndpointRouteBuilderExtensions.cs
+++ b/src/Asm.AspNetCore/Reporting/IEndpointRouteBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
@@ -11,14 +12,10 @@ namespace Microsoft.AspNetCore.Routing;
 /// </summary>
 public static class IEndpointRouteBuilderExtensions
 {
-    /// <summary>
-    /// Logger category used for integrity-report messages.
-    /// </summary>
+    /// <summary>Logger category used for integrity-report messages.</summary>
     public const string IntegrityLoggerCategory = "Asm.AspNetCore.Reporting.Integrity";
 
-    /// <summary>
-    /// Logger category used for CSP report messages.
-    /// </summary>
+    /// <summary>Logger category used for CSP report messages.</summary>
     public const string CspLoggerCategory = "Asm.AspNetCore.Reporting.Csp";
 
     /// <summary>
@@ -39,22 +36,73 @@ public static class IEndpointRouteBuilderExtensions
 
         var group = endpoints.MapGroup(options.RoutePrefix.TrimStart('/').TrimEnd('/'));
 
-        group.MapPost(options.IntegrityRoute.TrimStart('/'), async (HttpContext ctx) =>
-        {
-            using var reader = new StreamReader(ctx.Request.Body);
-            var body = await reader.ReadToEndAsync();
-            integrityLogger.LogWarning("Integrity Report ({ContentType}): {Report}", ctx.Request.ContentType, body);
-            return Results.NoContent();
-        });
+        group.MapPost(options.IntegrityRoute.TrimStart('/'),
+            (Func<HttpContext, Task<IResult>>)(async ctx => await HandleReportAsync(ctx, integrityLogger, "Integrity Report", options.MaxBodyBytes)));
 
-        group.MapPost(options.CspRoute.TrimStart('/'), async (HttpContext ctx) =>
-        {
-            using var reader = new StreamReader(ctx.Request.Body);
-            var body = await reader.ReadToEndAsync();
-            cspLogger.LogWarning("CSP Report ({ContentType}): {Report}", ctx.Request.ContentType, body);
-            return Results.NoContent();
-        });
+        group.MapPost(options.CspRoute.TrimStart('/'),
+            (Func<HttpContext, Task<IResult>>)(async ctx => await HandleReportAsync(ctx, cspLogger, "CSP Report", options.MaxBodyBytes)));
 
         return group;
+    }
+
+    private static async Task<IResult> HandleReportAsync(
+        HttpContext ctx,
+        ILogger logger,
+        string reportLabel,
+        int maxBodyBytes)
+    {
+        if (ctx.Request.ContentLength is long declaredLength && declaredLength > maxBodyBytes)
+        {
+            return Results.StatusCode(StatusCodes.Status413PayloadTooLarge);
+        }
+
+        var (body, truncated) = await ReadBoundedAsync(ctx.Request.Body, maxBodyBytes);
+
+        if (truncated)
+        {
+            return Results.StatusCode(StatusCodes.Status413PayloadTooLarge);
+        }
+
+        var contentType = SanitiseForLog(ctx.Request.ContentType);
+        var safeBody = SanitiseForLog(body);
+        logger.LogWarning("{Label} ({ContentType}): {Report}", reportLabel, contentType, safeBody);
+        return Results.NoContent();
+    }
+
+    private static async Task<(string Body, bool Truncated)> ReadBoundedAsync(Stream stream, int maxBytes)
+    {
+        using var ms = new MemoryStream();
+        var buffer = new byte[8192];
+        var total = 0;
+        int read;
+        while ((read = await stream.ReadAsync(buffer)) > 0)
+        {
+            total += read;
+            if (total > maxBytes)
+            {
+                return (string.Empty, true);
+            }
+            await ms.WriteAsync(buffer.AsMemory(0, read));
+        }
+        return (Encoding.UTF8.GetString(ms.ToArray()), false);
+    }
+
+    private static string SanitiseForLog(string? input)
+    {
+        if (string.IsNullOrEmpty(input))
+        {
+            return string.Empty;
+        }
+
+        var sb = new StringBuilder(input.Length);
+        foreach (var c in input)
+        {
+            // Keep printable and tab (tab is common in JSON whitespace); drop other control chars.
+            if (c == '\t' || !char.IsControl(c))
+            {
+                sb.Append(c);
+            }
+        }
+        return sb.ToString();
     }
 }

--- a/src/Asm.AspNetCore/Reporting/SecurityReportingHeaderBuilder.cs
+++ b/src/Asm.AspNetCore/Reporting/SecurityReportingHeaderBuilder.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Http;
+
+namespace Asm.AspNetCore.Reporting;
+
+/// <summary>
+/// Builds the <c>Reporting-Endpoints</c> and <c>Report-To</c> header values for the
+/// configured security-reporting endpoints.
+/// </summary>
+public static class SecurityReportingHeaderBuilder
+{
+    /// <summary>
+    /// Builds the <c>Reporting-Endpoints</c> header value.
+    /// </summary>
+    public static string BuildReportingEndpoints(HttpContext ctx, SecurityReportingOptions options)
+    {
+        var integrityUrl = BuildEndpointUrl(ctx, options.RoutePrefix, options.IntegrityRoute);
+        var cspUrl = BuildEndpointUrl(ctx, options.RoutePrefix, options.CspRoute);
+        return $"{options.IntegrityGroupName}=\"{integrityUrl}\", {options.CspGroupName}=\"{cspUrl}\"";
+    }
+
+    /// <summary>
+    /// Builds the <c>Report-To</c> header value (legacy multi-group JSON form).
+    /// </summary>
+    public static string BuildReportTo(HttpContext ctx, SecurityReportingOptions options)
+    {
+        var integrityUrl = BuildEndpointUrl(ctx, options.RoutePrefix, options.IntegrityRoute);
+        var cspUrl = BuildEndpointUrl(ctx, options.RoutePrefix, options.CspRoute);
+        return $"{{\"group\":\"{options.IntegrityGroupName}\",\"max_age\":{options.MaxAgeSeconds},\"endpoints\":[{{\"url\":\"{integrityUrl}\"}}]}}, "
+             + $"{{\"group\":\"{options.CspGroupName}\",\"max_age\":{options.MaxAgeSeconds},\"endpoints\":[{{\"url\":\"{cspUrl}\"}}]}}";
+    }
+
+    private static string BuildEndpointUrl(HttpContext ctx, string routePrefix, string route) =>
+        $"{ctx.Request.Scheme}://{ctx.Request.Host}/{routePrefix.TrimStart('/').TrimEnd('/')}/{route.TrimStart('/')}";
+}

--- a/src/Asm.AspNetCore/Reporting/SecurityReportingOptions.cs
+++ b/src/Asm.AspNetCore/Reporting/SecurityReportingOptions.cs
@@ -1,0 +1,40 @@
+namespace Asm.AspNetCore.Reporting;
+
+/// <summary>
+/// Options governing the security-reporting endpoints and the associated
+/// <c>Reporting-Endpoints</c> / <c>Report-To</c> response headers.
+/// </summary>
+public record SecurityReportingOptions
+{
+    /// <summary>
+    /// Route prefix for the reporting endpoints. Defaults to <c>"reporting"</c>.
+    /// </summary>
+    public string RoutePrefix { get; set; } = "reporting";
+
+    /// <summary>
+    /// Route segment for the integrity-violation endpoint. Appended to <see cref="RoutePrefix"/>.
+    /// </summary>
+    public string IntegrityRoute { get; set; } = "integrity";
+
+    /// <summary>
+    /// Route segment for the Content Security Policy report endpoint. Appended to <see cref="RoutePrefix"/>.
+    /// </summary>
+    public string CspRoute { get; set; } = "csp";
+
+    /// <summary>
+    /// Group name used for the integrity reporting endpoint in the
+    /// <c>Reporting-Endpoints</c> header and the <c>Report-To</c> group entry.
+    /// </summary>
+    public string IntegrityGroupName { get; set; } = "integrity-endpoint";
+
+    /// <summary>
+    /// Group name used for the CSP reporting endpoint in the
+    /// <c>Reporting-Endpoints</c> header and the <c>Report-To</c> group entry.
+    /// </summary>
+    public string CspGroupName { get; set; } = "csp-endpoint";
+
+    /// <summary>
+    /// <c>max_age</c> value (in seconds) emitted in the <c>Report-To</c> groups. Defaults to 24 hours.
+    /// </summary>
+    public int MaxAgeSeconds { get; set; } = 86400;
+}

--- a/src/Asm.AspNetCore/Reporting/SecurityReportingOptions.cs
+++ b/src/Asm.AspNetCore/Reporting/SecurityReportingOptions.cs
@@ -37,4 +37,11 @@ public record SecurityReportingOptions
     /// <c>max_age</c> value (in seconds) emitted in the <c>Report-To</c> groups. Defaults to 24 hours.
     /// </summary>
     public int MaxAgeSeconds { get; set; } = 86400;
+
+    /// <summary>
+    /// Maximum accepted request body size for a single report, in bytes.
+    /// Requests exceeding this are rejected with HTTP 413 and no body is logged.
+    /// Defaults to 65536 (64 KiB), which is generous for standards-compliant CSP reports.
+    /// </summary>
+    public int MaxBodyBytes { get; set; } = 65536;
 }

--- a/src/Asm.Umbraco.Authentication/Asm.Umbraco.Authentication.csproj
+++ b/src/Asm.Umbraco.Authentication/Asm.Umbraco.Authentication.csproj
@@ -12,6 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Asm.Umbraco.Authentication.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Asm.Umbraco\Asm.Umbraco.csproj" />
   </ItemGroup>
 

--- a/src/Asm.Umbraco.Authentication/Asm.Umbraco.Authentication.csproj
+++ b/src/Asm.Umbraco.Authentication/Asm.Umbraco.Authentication.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>Back-office authentication helpers for Umbraco CMS (Microsoft Entra ID).</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" />
+    <PackageReference Include="Umbraco.Cms.Api.Management" />
+    <PackageReference Include="Umbraco.Cms.Infrastructure" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Asm.Umbraco\Asm.Umbraco.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Asm.Umbraco.Authentication/EntraId/EntraIdBackOfficeOptions.cs
+++ b/src/Asm.Umbraco.Authentication/EntraId/EntraIdBackOfficeOptions.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Authentication.MicrosoftAccount;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core;
+
+namespace Asm.Umbraco.Authentication.EntraId;
+
+/// <summary>
+/// Configures <see cref="MicrosoftAccountOptions"/> with Entra ID tenant-scoped endpoints
+/// for the Umbraco back-office external-login scheme.
+/// </summary>
+internal sealed class EntraIdBackOfficeOptions(IOptions<EntraIdOptions> entraIdOptions)
+    : IConfigureNamedOptions<MicrosoftAccountOptions>
+{
+    public void Configure(string? name, MicrosoftAccountOptions options)
+    {
+        if (name == Constants.Security.BackOfficeExternalAuthenticationTypePrefix + EntraIdLoginOptions.SchemeName)
+        {
+            Configure(options);
+        }
+    }
+
+    public void Configure(MicrosoftAccountOptions options)
+    {
+        var entraId = entraIdOptions.Value;
+        options.CallbackPath = "/signin-oidc";
+        options.ClientId = entraId.ClientId;
+        options.ClientSecret = entraId.ClientSecret;
+        options.TokenEndpoint = $"https://login.microsoftonline.com/{entraId.TenantId}/oauth2/v2.0/token";
+        options.AuthorizationEndpoint = $"https://login.microsoftonline.com/{entraId.TenantId}/oauth2/v2.0/authorize";
+    }
+}

--- a/src/Asm.Umbraco.Authentication/EntraId/EntraIdLoginOptions.cs
+++ b/src/Asm.Umbraco.Authentication/EntraId/EntraIdLoginOptions.cs
@@ -1,0 +1,41 @@
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Api.Management.Security;
+using Umbraco.Cms.Core;
+
+namespace Asm.Umbraco.Authentication.EntraId;
+
+/// <summary>
+/// Configures the Umbraco back-office external-login provider for Microsoft Entra ID.
+/// </summary>
+internal sealed class EntraIdLoginOptions : IConfigureNamedOptions<BackOfficeExternalLoginProviderOptions>
+{
+    /// <summary>
+    /// The scheme name (without Umbraco's back-office prefix) used for the Entra ID login provider.
+    /// </summary>
+    public const string SchemeName = "OpenIdConnect";
+
+    public void Configure(string? name, BackOfficeExternalLoginProviderOptions options)
+    {
+        if (name == Constants.Security.BackOfficeExternalAuthenticationTypePrefix + SchemeName)
+        {
+            Configure(options);
+        }
+    }
+
+    public void Configure(BackOfficeExternalLoginProviderOptions options)
+    {
+        options.AutoLinkOptions = new ExternalSignInAutoLinkOptions(
+            autoLinkExternalAccount: true,
+            defaultUserGroups: [Constants.Security.EditorGroupKey.ToString()],
+            defaultCulture: null)
+        {
+            OnAutoLinking = (autoLinkUser, loginInfo) =>
+            {
+                autoLinkUser.IsApproved = true;
+            },
+            OnExternalLogin = (user, loginInfo) => true,
+        };
+
+        options.DenyLocalLogin = false;
+    }
+}

--- a/src/Asm.Umbraco.Authentication/EntraId/EntraIdManifestReader.cs
+++ b/src/Asm.Umbraco.Authentication/EntraId/EntraIdManifestReader.cs
@@ -1,0 +1,33 @@
+using Umbraco.Cms.Core.Manifest;
+using Umbraco.Cms.Infrastructure.Manifest;
+
+namespace Asm.Umbraco.Authentication.EntraId;
+
+/// <summary>
+/// Supplies the back-office authentication-provider manifest for Entra ID
+/// programmatically, avoiding the need for an <c>App_Plugins</c> folder in consumers.
+/// </summary>
+internal sealed class EntraIdManifestReader : IPackageManifestReader
+{
+    public Task<IEnumerable<PackageManifest>> ReadPackageManifestsAsync()
+    {
+        var manifest = new PackageManifest
+        {
+            Name = "Asm.Umbraco.Authentication.EntraId",
+            AllowPublicAccess = true,
+            Extensions =
+            [
+                new
+                {
+                    type = "authProvider",
+                    alias = "Asm.AuthProvider.EntraId",
+                    name = "Microsoft Entra ID Auth Provider",
+                    forProviderName = global::Umbraco.Cms.Core.Constants.Security.BackOfficeExternalAuthenticationTypePrefix + EntraIdLoginOptions.SchemeName,
+                    meta = new { label = "Microsoft" }
+                }
+            ]
+        };
+
+        return Task.FromResult<IEnumerable<PackageManifest>>([manifest]);
+    }
+}

--- a/src/Asm.Umbraco.Authentication/EntraId/EntraIdOptions.cs
+++ b/src/Asm.Umbraco.Authentication/EntraId/EntraIdOptions.cs
@@ -1,0 +1,22 @@
+namespace Asm.Umbraco.Authentication.EntraId;
+
+/// <summary>
+/// Microsoft Entra ID application settings used when configuring Umbraco back-office login.
+/// </summary>
+public record EntraIdOptions
+{
+    /// <summary>
+    /// The Entra ID tenant identifier (GUID) the application is registered against.
+    /// </summary>
+    public required string TenantId { get; set; }
+
+    /// <summary>
+    /// The Entra ID application (client) identifier.
+    /// </summary>
+    public required string ClientId { get; set; }
+
+    /// <summary>
+    /// The Entra ID application client secret.
+    /// </summary>
+    public required string ClientSecret { get; set; }
+}

--- a/src/Asm.Umbraco.Authentication/EntraId/IUmbracoBuilderExtensions.cs
+++ b/src/Asm.Umbraco.Authentication/EntraId/IUmbracoBuilderExtensions.cs
@@ -1,0 +1,73 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Api.Management.Security;
+using Umbraco.Cms.Infrastructure.Manifest;
+using Umbraco.Extensions;
+using Asm.Umbraco.Authentication.EntraId;
+
+namespace Umbraco.Cms.Core.DependencyInjection;
+
+/// <summary>
+/// Extensions on <see cref="IUmbracoBuilder"/> for registering
+/// Microsoft Entra ID back-office authentication.
+/// </summary>
+public static class IUmbracoBuilderExtensions
+{
+    /// <summary>
+    /// Registers Microsoft Entra ID as an Umbraco back-office external login provider
+    /// using the supplied configuration action.
+    /// </summary>
+    /// <param name="builder">The Umbraco builder.</param>
+    /// <param name="configure">Callback to configure the Entra ID options.</param>
+    /// <returns>The Umbraco builder.</returns>
+    public static IUmbracoBuilder AddEntraIdAuthentication(
+        this IUmbracoBuilder builder,
+        Action<EntraIdOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        builder.Services.Configure(configure);
+        return AddEntraIdCore(builder);
+    }
+
+    /// <summary>
+    /// Registers Microsoft Entra ID as an Umbraco back-office external login provider,
+    /// binding options from the supplied configuration section.
+    /// </summary>
+    /// <param name="builder">The Umbraco builder.</param>
+    /// <param name="configuration">The configuration section to bind options from.</param>
+    /// <returns>The Umbraco builder.</returns>
+    public static IUmbracoBuilder AddEntraIdAuthentication(
+        this IUmbracoBuilder builder,
+        IConfigurationSection configuration)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        builder.Services.Configure<EntraIdOptions>(configuration);
+        return AddEntraIdCore(builder);
+    }
+
+    private static IUmbracoBuilder AddEntraIdCore(IUmbracoBuilder builder)
+    {
+        builder.Services.ConfigureOptions<EntraIdLoginOptions>();
+        builder.Services.ConfigureOptions<EntraIdBackOfficeOptions>();
+        builder.Services.AddSingleton<IPackageManifestReader, EntraIdManifestReader>();
+
+        builder.AddBackOfficeExternalLogins(logins =>
+        {
+            logins.AddBackOfficeLogin(backOfficeAuthenticationBuilder =>
+            {
+                var schemeName = BackOfficeAuthenticationBuilder.SchemeForBackOffice(EntraIdLoginOptions.SchemeName);
+                ArgumentNullException.ThrowIfNull(schemeName, nameof(schemeName));
+
+                backOfficeAuthenticationBuilder.AddMicrosoftAccount(
+                    schemeName,
+                    options => { /* configured via EntraIdBackOfficeOptions */ });
+            });
+        });
+
+        return builder;
+    }
+}

--- a/src/Asm.Umbraco.Authentication/README.md
+++ b/src/Asm.Umbraco.Authentication/README.md
@@ -1,0 +1,38 @@
+# Asm.Umbraco.Authentication
+
+Back-office authentication helpers for Umbraco CMS.
+
+## Microsoft Entra ID
+
+Adds a Microsoft Entra ID external login provider to the Umbraco back office. Registers an `IPackageManifestReader` so the login button appears in the back-office SPA without any `App_Plugins` folder in the consuming application.
+
+### Usage
+
+```csharp
+// Bind options from configuration:
+umbracoBuilder.AddEntraIdAuthentication(builder.Configuration.GetSection("EntraId"));
+
+// Or configure inline:
+umbracoBuilder.AddEntraIdAuthentication(opts =>
+{
+    opts.TenantId = "...";
+    opts.ClientId = "...";
+    opts.ClientSecret = "...";
+});
+```
+
+### Configuration shape
+
+```json
+{
+  "EntraId": {
+    "TenantId": "...",
+    "ClientId": "...",
+    "ClientSecret": "..."
+  }
+}
+```
+
+### App registration
+
+Register the app in Entra ID with redirect URI `https://<your-host>/signin-oidc`. Grant `openid`, `profile`, and `email` delegated permissions.

--- a/src/Asm.Umbraco/Asm.Umbraco.csproj
+++ b/src/Asm.Umbraco/Asm.Umbraco.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>Asm core library for Umbraco CMS.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="SixLabors.ImageSharp" />
+    <PackageReference Include="Umbraco.Cms.Core" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Asm\Asm.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Asm.Umbraco/Asm.Umbraco.csproj
+++ b/src/Asm.Umbraco/Asm.Umbraco.csproj
@@ -8,6 +8,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="SixLabors.ImageSharp" />
     <PackageReference Include="Umbraco.Cms.Core" />
+    <PackageReference Include="Umbraco.Cms.Web.Common" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Asm.Umbraco/Extensions/IPublishedContentExtensions.cs
+++ b/src/Asm.Umbraco/Extensions/IPublishedContentExtensions.cs
@@ -1,0 +1,39 @@
+using Umbraco.Cms.Core.Models.PublishedContent;
+
+namespace Umbraco.Extensions;
+
+/// <summary>
+/// Extension helpers for <see cref="IPublishedContent"/>.
+/// </summary>
+public static class IPublishedContentExtensions
+{
+    /// <summary>
+    /// Returns the content item's <c>Name</c> as a lowercase, hyphen-separated CSS class name.
+    /// </summary>
+    /// <param name="model">The content item.</param>
+    /// <returns>The CSS-safe class name, or <c>null</c> if the model is null.</returns>
+    public static string? NameAsCssClass(this IPublishedContent model) =>
+        model?.Name.ToLower().Replace(' ', '-');
+
+    /// <summary>
+    /// Returns the value of the named property if it has a value, otherwise the supplied default.
+    /// </summary>
+    /// <typeparam name="T">The value type.</typeparam>
+    /// <param name="model">The content item.</param>
+    /// <param name="alias">The property alias.</param>
+    /// <param name="other">The fallback value if the property has no value.</param>
+    /// <returns>The property value or the fallback.</returns>
+    public static T? ValueOr<T>(this IPublishedContent model, string alias, T other) =>
+        model.HasValue(alias) ? model.Value<T>(alias) : other;
+
+    /// <summary>
+    /// Returns the supplied format string with the named property's value substituted in,
+    /// or an empty string if the property has no value.
+    /// </summary>
+    /// <param name="model">The content item.</param>
+    /// <param name="alias">The property alias.</param>
+    /// <param name="format">A composite format string with a single placeholder.</param>
+    /// <returns>The formatted string, or <see cref="String.Empty"/>.</returns>
+    public static string ValueAnd(this IPublishedContent model, string alias, string format) =>
+        model.HasValue(alias) ? String.Format(format, model.Value<string>(alias)) : String.Empty;
+}

--- a/src/Asm.Umbraco/MachineInfo/FixedMachineInfoFactory.cs
+++ b/src/Asm.Umbraco/MachineInfo/FixedMachineInfoFactory.cs
@@ -1,0 +1,46 @@
+using System.Diagnostics;
+using Microsoft.AspNetCore.DataProtection.Infrastructure;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Factories;
+
+namespace Asm.Umbraco.MachineInfo;
+
+/// <summary>
+/// Returns a fixed machine identifier so that container restarts
+/// don't create new server registrations in the database.
+/// </summary>
+public class FixedMachineInfoFactory : IMachineInfoFactory
+{
+    private readonly string _machineName;
+    private readonly Lazy<string> _localIdentity;
+
+    /// <summary>
+    /// Creates a new <see cref="FixedMachineInfoFactory"/>.
+    /// </summary>
+    /// <param name="applicationDiscriminator">The Data Protection application discriminator.</param>
+    /// <param name="options">The factory options.</param>
+    public FixedMachineInfoFactory(
+        IApplicationDiscriminator applicationDiscriminator,
+        IOptions<FixedMachineInfoFactoryOptions> options)
+    {
+        var opts = options.Value;
+        _machineName = Environment.GetEnvironmentVariable(opts.EnvironmentVariableName) ?? opts.MachineName;
+        _localIdentity = new Lazy<string>(() => BuildLocalIdentity(applicationDiscriminator));
+    }
+
+    /// <inheritdoc />
+    public string GetMachineIdentifier() => _machineName;
+
+    /// <inheritdoc />
+    public string GetLocalIdentity() => _localIdentity.Value;
+
+    private static string BuildLocalIdentity(IApplicationDiscriminator applicationDiscriminator)
+    {
+        using var process = Process.GetCurrentProcess();
+        return Environment.MachineName
+             + "/" + applicationDiscriminator.Discriminator
+             + " [P" + process.Id
+             + "/D" + AppDomain.CurrentDomain.Id
+             + "] " + Guid.NewGuid().ToString("N").ToUpper();
+    }
+}

--- a/src/Asm.Umbraco/MachineInfo/FixedMachineInfoFactoryOptions.cs
+++ b/src/Asm.Umbraco/MachineInfo/FixedMachineInfoFactoryOptions.cs
@@ -1,0 +1,18 @@
+namespace Asm.Umbraco.MachineInfo;
+
+/// <summary>
+/// Options for <see cref="FixedMachineInfoFactory"/>.
+/// </summary>
+public record FixedMachineInfoFactoryOptions
+{
+    /// <summary>
+    /// The fallback machine name used when no environment variable override is set.
+    /// </summary>
+    public required string MachineName { get; set; }
+
+    /// <summary>
+    /// The name of the environment variable whose value, when set, overrides <see cref="MachineName"/>.
+    /// Defaults to <c>MACHINE_NAME</c>.
+    /// </summary>
+    public string EnvironmentVariableName { get; set; } = "MACHINE_NAME";
+}

--- a/src/Asm.Umbraco/MachineInfo/IUmbracoBuilderExtensions.cs
+++ b/src/Asm.Umbraco/MachineInfo/IUmbracoBuilderExtensions.cs
@@ -1,0 +1,52 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.Factories;
+using Umbraco.Extensions;
+using Asm.Umbraco.MachineInfo;
+
+namespace Umbraco.Cms.Core.DependencyInjection;
+
+/// <summary>
+/// Extensions on <see cref="IUmbracoBuilder"/> for registering
+/// <see cref="FixedMachineInfoFactory"/>.
+/// </summary>
+public static class IUmbracoBuilderExtensions
+{
+    /// <summary>
+    /// Registers <see cref="FixedMachineInfoFactory"/> as the Umbraco
+    /// <see cref="IMachineInfoFactory"/> with the supplied options.
+    /// </summary>
+    /// <param name="builder">The Umbraco builder.</param>
+    /// <param name="configure">Callback to configure the factory options.</param>
+    /// <returns>The Umbraco builder.</returns>
+    public static IUmbracoBuilder AddFixedMachineInfoFactory(
+        this IUmbracoBuilder builder,
+        Action<FixedMachineInfoFactoryOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        builder.Services.Configure(configure);
+        builder.Services.AddUnique<IMachineInfoFactory, FixedMachineInfoFactory>();
+        return builder;
+    }
+
+    /// <summary>
+    /// Registers <see cref="FixedMachineInfoFactory"/> as the Umbraco
+    /// <see cref="IMachineInfoFactory"/>, binding options from the supplied configuration section.
+    /// </summary>
+    /// <param name="builder">The Umbraco builder.</param>
+    /// <param name="configuration">The configuration section to bind options from.</param>
+    /// <returns>The Umbraco builder.</returns>
+    public static IUmbracoBuilder AddFixedMachineInfoFactory(
+        this IUmbracoBuilder builder,
+        IConfigurationSection configuration)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        builder.Services.Configure<FixedMachineInfoFactoryOptions>(configuration);
+        builder.Services.AddUnique<IMachineInfoFactory, FixedMachineInfoFactory>();
+        return builder;
+    }
+}

--- a/src/Asm.Umbraco/README.md
+++ b/src/Asm.Umbraco/README.md
@@ -1,0 +1,25 @@
+# Asm.Umbraco
+
+Core helpers for Umbraco CMS applications:
+
+- `FixedMachineInfoFactory` — an `IMachineInfoFactory` that returns a stable machine identifier, suitable for container deployments where a random name would cause duplicate server registrations on restart.
+- `ImgSetTagHelper` — a Razor tag helper that renders an `<img>` with a `srcset` built from a collection of Umbraco media items.
+- `IPublishedContent` extensions — `NameAsCssClass()`, `ValueOr<T>()`, `ValueAnd()`.
+
+## Usage
+
+```csharp
+umbracoBuilder.AddFixedMachineInfoFactory(opts => opts.MachineName = "myapp");
+```
+
+Or, bind from configuration:
+
+```csharp
+umbracoBuilder.AddFixedMachineInfoFactory(builder.Configuration.GetSection("MachineInfo"));
+```
+
+Register the tag helpers in `_ViewImports.cshtml`:
+
+```razor
+@addTagHelper *, Asm.Umbraco
+```

--- a/src/Asm.Umbraco/TagHelpers/ImgSetTagHelper.cs
+++ b/src/Asm.Umbraco/TagHelpers/ImgSetTagHelper.cs
@@ -1,0 +1,119 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Hosting;
+using SixLabors.ImageSharp;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Extensions;
+
+namespace Asm.Umbraco.TagHelpers;
+
+/// <summary>
+/// Renders an <c>&lt;img&gt;</c> element with a <c>srcset</c> attribute built from a
+/// collection of Umbraco <see cref="IPublishedContent"/> media items, using the first item
+/// as the base image and subsequent items (with a <c>scaling</c> property) as additional
+/// srcset entries. Caches the image dimensions in memory when they aren't supplied by Umbraco.
+/// </summary>
+[HtmlTargetElement("imgset", Attributes = "images")]
+public class ImgSetTagHelper(IWebHostEnvironment webHostEnvironment, IMemoryCache memoryCache) : TagHelper
+{
+    /// <summary>
+    /// The current view context.
+    /// </summary>
+    [ViewContext]
+    public required ViewContext ViewContext { get; set; }
+
+    /// <summary>
+    /// The collection of images. The first is the base image; each subsequent image
+    /// contributes a <c>srcset</c> entry using its <c>scaling</c> property.
+    /// </summary>
+    [HtmlAttributeName("images")]
+    public IEnumerable<IPublishedContent> Images { get; set; } = [];
+
+    /// <summary>
+    /// The web host environment.
+    /// </summary>
+    protected IWebHostEnvironment WebHostEnvironment { get; } = webHostEnvironment;
+
+    /// <summary>
+    /// Memory cache used to store resolved image dimensions.
+    /// </summary>
+    protected IMemoryCache MemoryCache { get; } = memoryCache;
+
+    /// <inheritdoc />
+    public override void Process(TagHelperContext context, TagHelperOutput output)
+    {
+        if (Images == null)
+        {
+            output.SuppressOutput();
+            return;
+        }
+
+        var image = Images.FirstOrDefault();
+
+        if (image == null)
+        {
+            output.SuppressOutput();
+            return;
+        }
+
+        var altText = image.Value<string>("umbracoAltText");
+        altText = String.IsNullOrWhiteSpace(altText) ? String.Empty : altText;
+
+        string srcset = String.Empty;
+        foreach (var img in Images.Skip(1))
+        {
+            var scaling = img.Value<float?>("scaling");
+
+            if (scaling == null) continue;
+
+            srcset += $", {img.Url()} {scaling}x";
+        }
+        srcset = srcset.TrimStart(", ");
+
+        output.TagName = "img";
+
+        output.Attributes.Add("src", image.Url());
+        output.Attributes.Add("srcset", srcset);
+        output.Attributes.Add("alt", altText);
+
+        var height = image.Value<int>("umbracoHeight");
+        var width = image.Value<int>("umbracoWidth");
+
+        if (height == 0 || width == 0)
+        {
+            if (!WebHostEnvironment.IsDevelopment() && MemoryCache.TryGetValue(image.Url(), out (int Width, int Height) data))
+            {
+                width = data.Width;
+                height = data.Height;
+            }
+            else
+            {
+                string cleanPath = image.Url().Replace('~', '.');
+                cleanPath = cleanPath[..(cleanPath.IndexOf('?') > 0 ? cleanPath.IndexOf('?') : cleanPath.Length)];
+                cleanPath = cleanPath.Replace('/', Path.DirectorySeparatorChar);
+
+                string path = Path.Combine(WebHostEnvironment.WebRootPath, cleanPath.TrimStart('\\'));
+
+                if (!File.Exists(path)) return;
+
+                try
+                {
+                    using var imageFile = Image.Load(path);
+                    width = imageFile.Width;
+                    height = imageFile.Height;
+                    MemoryCache.Set(image.Url(), (width, height));
+                }
+                catch
+                {
+                    // Do nothing
+                }
+            }
+        }
+
+        output.Attributes.Add("width", width);
+        output.Attributes.Add("height", height);
+    }
+}

--- a/tests/Asm.AspNetCore.Tests/Extensions/IApplicationBuilderExtensionsSecurityTests.cs
+++ b/tests/Asm.AspNetCore.Tests/Extensions/IApplicationBuilderExtensionsSecurityTests.cs
@@ -1,0 +1,154 @@
+using System.Net;
+using System.Net.Http;
+using Asm.AspNetCore.Middleware;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Hosting;
+
+namespace Asm.AspNetCore.Tests.Extensions;
+
+/// <summary>
+/// Tests for the new overloads added to <see cref="IApplicationBuilderExtensions"/>:
+/// <c>UseSecurityHeaders(Action&lt;SecurityHeadersOptions&gt;)</c> and
+/// <c>UseCanonicalUrls(Action&lt;CanonicalUrlOptions&gt;?)</c>.
+/// Isolated from the existing Reqnroll feature tests.
+/// </summary>
+public class IApplicationBuilderExtensionsSecurityTests
+{
+    // ──────────────────────────────────────────────────────────────────────────
+    // UseSecurityHeaders(configure) — smoke test: pipeline runs end-to-end
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UseSecurityHeaders_WithConfigure_PipelineRunsAndHeadersAreAdded()
+    {
+        using var host = await new HostBuilder()
+            .ConfigureWebHost(webHost =>
+            {
+                webHost.UseTestServer();
+                webHost.Configure(app =>
+                {
+                    app.UseSecurityHeaders(opts =>
+                    {
+                        opts.Headers["X-Smoke-Test"] = "ok";
+                    });
+                    app.Run(async ctx =>
+                    {
+                        ctx.Response.ContentType = "text/html";
+                        await ctx.Response.WriteAsync("smoke");
+                    });
+                });
+            })
+            .StartAsync();
+
+        var client = host.GetTestClient();
+        var response = await client.GetAsync("/");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.True(response.Headers.Contains("X-Smoke-Test"),
+            "Configured static header should be present");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // UseCanonicalUrls() — smoke test: pipeline runs end-to-end
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UseCanonicalUrls_NoConfigure_PipelineRunsAndRedirectsUppercase()
+    {
+        using var host = await new HostBuilder()
+            .ConfigureWebHost(webHost =>
+            {
+                webHost.UseTestServer();
+                webHost.Configure(app =>
+                {
+                    app.UseCanonicalUrls();
+                    app.Run(async ctx =>
+                    {
+                        ctx.Response.ContentType = "text/html";
+                        await ctx.Response.WriteAsync("canonical");
+                    });
+                });
+            })
+            .StartAsync();
+
+        var client = host.GetTestClient();
+        var response = await client.GetAsync("/Hello");
+
+        // Default ForceLowercase=true should 301 to /hello
+        Assert.Equal(HttpStatusCode.MovedPermanently, response.StatusCode);
+        Assert.Equal("/hello", response.Headers.Location?.ToString());
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // UseCanonicalUrls with configure — smoke test
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UseCanonicalUrls_WithConfigure_PipelineRunsAndOptionsApplied()
+    {
+        using var host = await new HostBuilder()
+            .ConfigureWebHost(webHost =>
+            {
+                webHost.UseTestServer();
+                webHost.Configure(app =>
+                {
+                    app.UseCanonicalUrls(opts => opts.ForceLowercase = false);
+                    app.Run(async ctx =>
+                    {
+                        ctx.Response.ContentType = "text/html";
+                        await ctx.Response.WriteAsync("ok");
+                    });
+                });
+            })
+            .StartAsync();
+
+        var client = host.GetTestClient();
+        // With ForceLowercase=false, /Hello should pass through (200)
+        var response = await client.GetAsync("/Hello");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Argument null checks
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void UseSecurityHeaders_NullApp_ThrowsArgumentNullException()
+    {
+        IApplicationBuilder app = null!;
+        Assert.Throws<ArgumentNullException>(() => app.UseSecurityHeaders(_ => { }));
+    }
+
+    [Fact]
+    public void UseSecurityHeaders_NullConfigure_ThrowsArgumentNullException()
+    {
+        // We need a real (or minimal) IApplicationBuilder — use a basic test double
+        var app = new FakeApplicationBuilder();
+        Assert.Throws<ArgumentNullException>(() =>
+            app.UseSecurityHeaders(configure: null!));
+    }
+
+    [Fact]
+    public void UseCanonicalUrls_NullApp_ThrowsArgumentNullException()
+    {
+        IApplicationBuilder app = null!;
+        Assert.Throws<ArgumentNullException>(() => app.UseCanonicalUrls());
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Minimal IApplicationBuilder stub for null-check tests that don't need TestServer
+    // ──────────────────────────────────────────────────────────────────────────
+
+    private sealed class FakeApplicationBuilder : IApplicationBuilder
+    {
+        public IServiceProvider ApplicationServices { get; set; } = null!;
+        public Microsoft.AspNetCore.Http.Features.IFeatureCollection ServerFeatures { get; } = new Microsoft.AspNetCore.Http.Features.FeatureCollection();
+        public IDictionary<string, object?> Properties { get; } = new Dictionary<string, object?>();
+        public RequestDelegate Build() => _ => Task.CompletedTask;
+        public IApplicationBuilder New() => new FakeApplicationBuilder();
+        public IApplicationBuilder Use(Func<RequestDelegate, RequestDelegate> middleware) => this;
+    }
+}

--- a/tests/Asm.AspNetCore.Tests/Extensions/IServiceCollectionExtensionsReportingTests.cs
+++ b/tests/Asm.AspNetCore.Tests/Extensions/IServiceCollectionExtensionsReportingTests.cs
@@ -1,0 +1,79 @@
+using Asm.AspNetCore.Reporting;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Asm.AspNetCore.Tests.Extensions;
+
+/// <summary>
+/// Tests for <see cref="IServiceCollectionExtensions.AddSecurityReporting"/> —
+/// isolated from the existing Reqnroll-based IServiceCollectionExtensions feature tests.
+/// </summary>
+public class IServiceCollectionExtensionsReportingTests
+{
+    // ──────────────────────────────────────────────────────────────────────────
+    // AddSecurityReporting with no configure → defaults
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void AddSecurityReporting_NoConfiguration_RegistersDefaultOptions()
+    {
+        var services = new ServiceCollection();
+        services.AddSecurityReporting();
+
+        var provider = services.BuildServiceProvider();
+        var options = provider.GetService<SecurityReportingOptions>();
+
+        Assert.NotNull(options);
+        Assert.Equal("reporting", options.RoutePrefix);
+        Assert.Equal("integrity", options.IntegrityRoute);
+        Assert.Equal("csp", options.CspRoute);
+        Assert.Equal("integrity-endpoint", options.IntegrityGroupName);
+        Assert.Equal("csp-endpoint", options.CspGroupName);
+        Assert.Equal(86400, options.MaxAgeSeconds);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // AddSecurityReporting with configure → custom options reflected
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void AddSecurityReporting_WithConfigure_RegistersCustomisedOptions()
+    {
+        var services = new ServiceCollection();
+        services.AddSecurityReporting(opts => opts.RoutePrefix = "x");
+
+        var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<SecurityReportingOptions>();
+
+        Assert.Equal("x", options.RoutePrefix);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Singleton — same instance returned on multiple resolutions
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void AddSecurityReporting_ReturnsSameSingletonInstance()
+    {
+        var services = new ServiceCollection();
+        services.AddSecurityReporting();
+
+        var provider = services.BuildServiceProvider();
+        var first = provider.GetRequiredService<SecurityReportingOptions>();
+        var second = provider.GetRequiredService<SecurityReportingOptions>();
+
+        Assert.Same(first, second);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Method returns the same IServiceCollection for chaining
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void AddSecurityReporting_ReturnsTheSameServiceCollection()
+    {
+        var services = new ServiceCollection();
+        var returned = services.AddSecurityReporting();
+
+        Assert.Same(services, returned);
+    }
+}

--- a/tests/Asm.AspNetCore.Tests/Middleware/CanonicalUrlMiddlewareTests.cs
+++ b/tests/Asm.AspNetCore.Tests/Middleware/CanonicalUrlMiddlewareTests.cs
@@ -1,0 +1,180 @@
+using System.Net;
+using System.Net.Http;
+using Asm.AspNetCore.Middleware;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Hosting;
+
+namespace Asm.AspNetCore.Tests.Middleware;
+
+public class CanonicalUrlMiddlewareTests
+{
+    // ──────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Builds a test host with <see cref="CanonicalUrlMiddleware"/> and a terminal
+    /// 200 handler. The HttpClient is configured to NOT follow redirects so we can
+    /// assert on the 301 location header directly.
+    /// </summary>
+    private static async Task<(IHost host, HttpClient client)> BuildAsync(
+        Action<CanonicalUrlOptions>? configure = null)
+    {
+        var host = await new HostBuilder()
+            .ConfigureWebHost(webHost =>
+            {
+                webHost.UseTestServer();
+                webHost.Configure(app =>
+                {
+                    app.UseCanonicalUrls(configure);
+                    app.Run(async ctx =>
+                    {
+                        ctx.Response.StatusCode = 200;
+                        ctx.Response.ContentType = "text/html";
+                        await ctx.Response.WriteAsync("ok");
+                    });
+                });
+            })
+            .StartAsync();
+
+        // Don't follow redirects — we need to inspect the 301 Location header
+        var client = host.GetTestServer().CreateClient();
+        client.DefaultRequestHeaders.Clear();
+
+        return (host, client);
+    }
+
+    private static string? Location(HttpResponseMessage r) =>
+        r.Headers.Location?.ToString();
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // ForceLowercase — uppercase path → 301 to lowercase
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UppercasePath_Redirects_ToLowercase()
+    {
+        var (host, client) = await BuildAsync();
+        using (host)
+        {
+            var response = await client.GetAsync("/About");
+
+            Assert.Equal(HttpStatusCode.MovedPermanently, response.StatusCode);
+            Assert.Equal("/about", Location(response));
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // RemoveTrailingSlash — path ending in / → 301 without slash
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task TrailingSlash_Redirects_WithoutSlash()
+    {
+        var (host, client) = await BuildAsync();
+        using (host)
+        {
+            var response = await client.GetAsync("/about/");
+
+            Assert.Equal(HttpStatusCode.MovedPermanently, response.StatusCode);
+            Assert.Equal("/about", Location(response));
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Canonical path passes through (200)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CanonicalPath_PassesThrough_With200()
+    {
+        var (host, client) = await BuildAsync();
+        using (host)
+        {
+            var response = await client.GetAsync("/about");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // LowercaseExcludedExtensions — .pdf is exempt by default
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task PdfExtension_UpperCase_PassesThrough()
+    {
+        var (host, client) = await BuildAsync();
+        using (host)
+        {
+            // The default excluded extension is .pdf (case-insensitive)
+            var response = await client.GetAsync("/something.PDF");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // ExemptPathPrefixes — /umbraco prefix bypasses canonicalisation
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ExemptPrefix_UppercasePath_PassesThrough()
+    {
+        var (host, client) = await BuildAsync(opts =>
+            opts.ExemptPathPrefixes = ["/umbraco"]);
+        using (host)
+        {
+            var response = await client.GetAsync("/Umbraco/Foo");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // ForceLowercase = false — uppercase path passes through
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ForceLowercaseFalse_UppercasePath_PassesThrough()
+    {
+        var (host, client) = await BuildAsync(opts => opts.ForceLowercase = false);
+        using (host)
+        {
+            var response = await client.GetAsync("/About");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // RemoveTrailingSlash = false — trailing slash passes through
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RemoveTrailingSlashFalse_TrailingSlash_PassesThrough()
+    {
+        var (host, client) = await BuildAsync(opts => opts.RemoveTrailingSlash = false);
+        using (host)
+        {
+            var response = await client.GetAsync("/about/");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Query string is preserved on redirect
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UppercasePath_WithQueryString_RedirectPreservesQueryString()
+    {
+        var (host, client) = await BuildAsync();
+        using (host)
+        {
+            var response = await client.GetAsync("/About?x=1");
+
+            Assert.Equal(HttpStatusCode.MovedPermanently, response.StatusCode);
+            Assert.Equal("/about?x=1", Location(response));
+        }
+    }
+}

--- a/tests/Asm.AspNetCore.Tests/Middleware/CanonicalUrlOptionsTests.cs
+++ b/tests/Asm.AspNetCore.Tests/Middleware/CanonicalUrlOptionsTests.cs
@@ -1,0 +1,53 @@
+using Asm.AspNetCore.Middleware;
+
+namespace Asm.AspNetCore.Tests.Middleware;
+
+public class CanonicalUrlOptionsTests
+{
+    [Fact]
+    public void DefaultValues_AreCorrect()
+    {
+        var options = new CanonicalUrlOptions();
+
+        Assert.True(options.ForceLowercase);
+        Assert.True(options.RemoveTrailingSlash);
+        Assert.Empty(options.ExemptPathPrefixes);
+        Assert.Single(options.LowercaseExcludedExtensions);
+        Assert.Contains(".pdf", options.LowercaseExcludedExtensions);
+    }
+
+    [Fact]
+    public void ForceLowercase_CanBeSetToFalse()
+    {
+        var options = new CanonicalUrlOptions { ForceLowercase = false };
+        Assert.False(options.ForceLowercase);
+    }
+
+    [Fact]
+    public void RemoveTrailingSlash_CanBeSetToFalse()
+    {
+        var options = new CanonicalUrlOptions { RemoveTrailingSlash = false };
+        Assert.False(options.RemoveTrailingSlash);
+    }
+
+    [Fact]
+    public void LowercaseExcludedExtensions_CanBeReplaced()
+    {
+        var options = new CanonicalUrlOptions
+        {
+            LowercaseExcludedExtensions = [".pdf", ".jpg"]
+        };
+        Assert.Equal(2, options.LowercaseExcludedExtensions.Count);
+    }
+
+    [Fact]
+    public void ExemptPathPrefixes_CanBeConfigured()
+    {
+        var options = new CanonicalUrlOptions
+        {
+            ExemptPathPrefixes = ["/umbraco"]
+        };
+        Assert.Single(options.ExemptPathPrefixes);
+        Assert.Equal("/umbraco", options.ExemptPathPrefixes[0]);
+    }
+}

--- a/tests/Asm.AspNetCore.Tests/Middleware/SecurityHeadersMiddlewareTests.cs
+++ b/tests/Asm.AspNetCore.Tests/Middleware/SecurityHeadersMiddlewareTests.cs
@@ -1,0 +1,243 @@
+using System.Net;
+using System.Net.Http;
+using Asm.AspNetCore.Middleware;
+using Asm.AspNetCore.Reporting;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Asm.AspNetCore.Tests.Middleware;
+
+public class SecurityHeadersMiddlewareTests
+{
+    // ──────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────────────────
+
+    private static Task<IHost> BuildHostAsync(
+        Action<SecurityHeadersOptions> configure,
+        Action<IApplicationBuilder>? extraMiddleware = null,
+        Action<IServiceCollection>? configureServices = null,
+        string responseContentType = "text/html",
+        string? path = null)
+    {
+        return new HostBuilder()
+            .ConfigureWebHost(webHost =>
+            {
+                webHost.UseTestServer();
+                if (configureServices != null)
+                    webHost.ConfigureServices(configureServices);
+                webHost.Configure(app =>
+                {
+                    // Allow caller to inject upstream middleware (e.g. to set spurious headers)
+                    extraMiddleware?.Invoke(app);
+                    app.UseSecurityHeaders(configure);
+                    app.Run(async ctx =>
+                    {
+                        ctx.Response.ContentType = responseContentType;
+                        await ctx.Response.WriteAsync("ok");
+                    });
+                });
+            })
+            .StartAsync();
+    }
+
+    private static HttpClient GetClient(IHost host, string? path = null) =>
+        host.GetTestClient();
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Static headers on HTML responses
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task HtmlResponse_StaticHeaders_ArePresent()
+    {
+        using var host = await BuildHostAsync(opts =>
+        {
+            opts.Headers["X-Test-Header"] = "test-value";
+            opts.Headers["X-Another"] = "another-value";
+        });
+
+        var client = GetClient(host);
+        var response = await client.GetAsync("/");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.True(response.Headers.Contains("X-Test-Header"), "X-Test-Header missing");
+        Assert.Equal("test-value", response.Headers.GetValues("X-Test-Header").First());
+        Assert.True(response.Headers.Contains("X-Another"), "X-Another missing");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Non-HTML responses do NOT get static headers
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task NonHtmlResponse_StaticHeaders_AreNotAdded()
+    {
+        using var host = await BuildHostAsync(
+            opts => opts.Headers["X-Test-Header"] = "test-value",
+            responseContentType: "application/json");
+
+        var client = GetClient(host);
+        var response = await client.GetAsync("/");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.False(response.Headers.Contains("X-Test-Header"),
+            "Static security headers should not be added to non-HTML responses");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // RemoveServerHeaders strips fingerprint headers
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RemoveServerHeaders_True_RemovesFingerprintHeaders()
+    {
+        // Set fake fingerprint headers directly on the response (before writing),
+        // so they are present when the middleware's OnStarting callback fires and removes them.
+        using var host = await new HostBuilder()
+            .ConfigureWebHost(webHost =>
+            {
+                webHost.UseTestServer();
+                webHost.Configure(app =>
+                {
+                    app.UseSecurityHeaders(opts => opts.RemoveServerHeaders = true);
+                    app.Run(async ctx =>
+                    {
+                        // Set fake server-fingerprint headers directly (not in OnStarting)
+                        ctx.Response.Headers["Server"] = "FakeServer/1.0";
+                        ctx.Response.Headers["X-Powered-By"] = "ASP.NET";
+                        ctx.Response.Headers["X-AspNet-Version"] = "4.0";
+                        ctx.Response.Headers["X-AspNetMvc-Version"] = "5.0";
+                        ctx.Response.ContentType = "text/html";
+                        await ctx.Response.WriteAsync("ok");
+                    });
+                });
+            })
+            .StartAsync();
+
+        var client = GetClient(host);
+        var response = await client.GetAsync("/");
+
+        // Fingerprint headers should have been removed by the middleware's OnStarting callback
+        Assert.False(response.Headers.Contains("Server"), "Server header should be removed");
+        Assert.False(response.Headers.Contains("X-Powered-By"), "X-Powered-By should be removed");
+        Assert.False(response.Headers.Contains("X-AspNet-Version"), "X-AspNet-Version should be removed");
+        Assert.False(response.Headers.Contains("X-AspNetMvc-Version"), "X-AspNetMvc-Version should be removed");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // ExemptPathPrefixes — entire processing is skipped
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ExemptPathPrefix_SkipsHeaderProcessing()
+    {
+        // Inject fake Server header that would be removed if processing ran
+        using var host = await new HostBuilder()
+            .ConfigureWebHost(webHost =>
+            {
+                webHost.UseTestServer();
+                webHost.Configure(app =>
+                {
+                    // Upstream middleware sets a header that fingerprint-removal would strip
+                    app.Use(async (ctx, next) =>
+                    {
+                        ctx.Response.OnStarting(() =>
+                        {
+                            ctx.Response.Headers["Server"] = "ShouldSurvive";
+                            return Task.CompletedTask;
+                        });
+                        await next(ctx);
+                    });
+
+                    app.UseSecurityHeaders(opts =>
+                    {
+                        opts.RemoveServerHeaders = true;
+                        opts.ExemptPathPrefixes = ["/api"];
+                        opts.Headers["X-Static"] = "value";
+                    });
+
+                    app.Run(async ctx =>
+                    {
+                        ctx.Response.ContentType = "text/html";
+                        await ctx.Response.WriteAsync("ok");
+                    });
+                });
+            })
+            .StartAsync();
+
+        var client = GetClient(host);
+        var response = await client.GetAsync("/api/foo");
+
+        // Exempt path — no header removal, no static header added
+        Assert.True(response.Headers.Contains("Server"),
+            "Server header should survive on exempt path");
+        Assert.False(response.Headers.Contains("X-Static"),
+            "Static headers should not be added on exempt path");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // DynamicHeaders callback values are added
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DynamicHeaders_AreAppendedToHtmlResponse()
+    {
+        using var host = await BuildHostAsync(opts =>
+        {
+            opts.DynamicHeaders = ctx => new Dictionary<string, string>
+            {
+                ["X-Request-Scheme"] = ctx.Request.Scheme
+            };
+        });
+
+        var client = GetClient(host);
+        var response = await client.GetAsync("/");
+
+        Assert.True(response.Headers.Contains("X-Request-Scheme"),
+            "Dynamic header X-Request-Scheme missing");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // SecurityReportingOptions registered → Reporting-Endpoints + Report-To present
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task WithSecurityReporting_ReportingHeadersEmittedOnHtml()
+    {
+        using var host = await BuildHostAsync(
+            configure: opts => { /* defaults */ },
+            configureServices: svc => svc.AddSecurityReporting());
+
+        var client = GetClient(host);
+        var response = await client.GetAsync("/");
+
+        Assert.True(response.Headers.Contains("Reporting-Endpoints"),
+            "Reporting-Endpoints header missing");
+        Assert.True(response.Headers.Contains("Report-To"),
+            "Report-To header missing");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // SecurityReportingOptions NOT registered → headers absent
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task WithoutSecurityReporting_ReportingHeadersAbsent()
+    {
+        // No AddSecurityReporting() call
+        using var host = await BuildHostAsync(opts => { });
+
+        var client = GetClient(host);
+        var response = await client.GetAsync("/");
+
+        Assert.False(response.Headers.Contains("Reporting-Endpoints"),
+            "Reporting-Endpoints should be absent when reporting not registered");
+        Assert.False(response.Headers.Contains("Report-To"),
+            "Report-To should be absent when reporting not registered");
+    }
+}

--- a/tests/Asm.AspNetCore.Tests/Middleware/SecurityHeadersOptionsTests.cs
+++ b/tests/Asm.AspNetCore.Tests/Middleware/SecurityHeadersOptionsTests.cs
@@ -1,0 +1,54 @@
+using Asm.AspNetCore.Middleware;
+using Microsoft.AspNetCore.Http;
+
+namespace Asm.AspNetCore.Tests.Middleware;
+
+public class SecurityHeadersOptionsTests
+{
+    [Fact]
+    public void DefaultValues_AreCorrect()
+    {
+        var options = new SecurityHeadersOptions();
+
+        Assert.True(options.RemoveServerHeaders);
+        Assert.Empty(options.ExemptPathPrefixes);
+        Assert.Empty(options.Headers);
+        Assert.Null(options.DynamicHeaders);
+    }
+
+    [Fact]
+    public void RemoveServerHeaders_CanBeSetToFalse()
+    {
+        var options = new SecurityHeadersOptions { RemoveServerHeaders = false };
+        Assert.False(options.RemoveServerHeaders);
+    }
+
+    [Fact]
+    public void ExemptPathPrefixes_CanBeConfigured()
+    {
+        var options = new SecurityHeadersOptions
+        {
+            ExemptPathPrefixes = ["/api", "/health"]
+        };
+        Assert.Equal(2, options.ExemptPathPrefixes.Count);
+        Assert.Contains("/api", options.ExemptPathPrefixes);
+    }
+
+    [Fact]
+    public void Headers_CanBePopulated()
+    {
+        var options = new SecurityHeadersOptions();
+        options.Headers["X-Custom"] = "value";
+        Assert.Equal("value", options.Headers["X-Custom"]);
+    }
+
+    [Fact]
+    public void DynamicHeaders_CanBeAssigned()
+    {
+        Func<HttpContext, IDictionary<string, string>> cb =
+            _ => new Dictionary<string, string> { ["X-Dyn"] = "yes" };
+
+        var options = new SecurityHeadersOptions { DynamicHeaders = cb };
+        Assert.NotNull(options.DynamicHeaders);
+    }
+}

--- a/tests/Asm.AspNetCore.Tests/Reporting/IEndpointRouteBuilderExtensionsTests.cs
+++ b/tests/Asm.AspNetCore.Tests/Reporting/IEndpointRouteBuilderExtensionsTests.cs
@@ -1,0 +1,232 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using Asm.AspNetCore.Reporting;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Asm.AspNetCore.Tests.Reporting;
+
+public class IEndpointRouteBuilderExtensionsTests
+{
+    // ──────────────────────────────────────────────────────────────────────────
+    // Logger capture helper
+    // ──────────────────────────────────────────────────────────────────────────
+
+    private sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        public readonly List<(string Category, LogLevel Level, string Message)> Entries = [];
+
+        public ILogger CreateLogger(string categoryName) =>
+            new CapturingLogger(categoryName, Entries);
+
+        public void Dispose() { }
+
+        private sealed class CapturingLogger(
+            string category,
+            List<(string, LogLevel, string)> entries) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                entries.Add((category, logLevel, formatter(state, exception)));
+            }
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Build helper
+    // ──────────────────────────────────────────────────────────────────────────
+
+    private static async Task<(IHost host, HttpClient client, CapturingLoggerProvider logProvider)>
+        BuildHostAsync(Action<SecurityReportingOptions>? configureReporting = null)
+    {
+        var logProvider = new CapturingLoggerProvider();
+
+        var host = await new HostBuilder()
+            .ConfigureLogging(logging =>
+            {
+                logging.ClearProviders();
+                logging.AddProvider(logProvider);
+                logging.SetMinimumLevel(LogLevel.Warning);
+            })
+            .ConfigureWebHost(webHost =>
+            {
+                webHost.UseTestServer();
+                webHost.ConfigureServices(services =>
+                {
+                    services.AddRouting();
+                    services.AddSecurityReporting(configureReporting);
+                });
+                webHost.Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(endpoints =>
+                    {
+                        endpoints.MapSecurityReporting();
+                        endpoints.MapGet("/", () => "ok");
+                    });
+                });
+            })
+            .StartAsync();
+
+        return (host, host.GetTestClient(), logProvider);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // POST to integrity endpoint returns 204
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task PostIntegrity_Returns204()
+    {
+        var (host, client, _) = await BuildHostAsync();
+        using (host)
+        {
+            var content = new StringContent("{\"blocked-uri\":\"https://evil.com\"}", Encoding.UTF8, "application/json");
+            var response = await client.PostAsync("/reporting/integrity", content);
+
+            Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // POST to csp endpoint returns 204
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task PostCsp_Returns204()
+    {
+        var (host, client, _) = await BuildHostAsync();
+        using (host)
+        {
+            var content = new StringContent("{\"csp-report\":{\"violated-directive\":\"script-src\"}}", Encoding.UTF8, "application/csp-report");
+            var response = await client.PostAsync("/reporting/csp", content);
+
+            Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Body is logged at Warning under documented category names
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task PostIntegrity_LogsAtWarning_UnderIntegrityCategory()
+    {
+        var (host, client, logProvider) = await BuildHostAsync();
+        using (host)
+        {
+            var reportBody = "{\"integrity-report\":\"test\"}";
+            var content = new StringContent(reportBody, Encoding.UTF8, "application/json");
+            await client.PostAsync("/reporting/integrity", content);
+
+            var matchingEntries = logProvider.Entries
+                .Where(e => e.Category == IEndpointRouteBuilderExtensions.IntegrityLoggerCategory &&
+                            e.Level == LogLevel.Warning)
+                .ToList();
+
+            Assert.True(matchingEntries.Count > 0,
+                $"Expected a Warning log entry under category '{IEndpointRouteBuilderExtensions.IntegrityLoggerCategory}'");
+            Assert.Contains(reportBody, matchingEntries[0].Message);
+        }
+    }
+
+    [Fact]
+    public async Task PostCsp_LogsAtWarning_UnderCspCategory()
+    {
+        var (host, client, logProvider) = await BuildHostAsync();
+        using (host)
+        {
+            var reportBody = "{\"csp-report\":{\"violated-directive\":\"script-src\"}}";
+            var content = new StringContent(reportBody, Encoding.UTF8, "application/csp-report");
+            await client.PostAsync("/reporting/csp", content);
+
+            var matchingEntries = logProvider.Entries
+                .Where(e => e.Category == IEndpointRouteBuilderExtensions.CspLoggerCategory &&
+                            e.Level == LogLevel.Warning)
+                .ToList();
+
+            Assert.True(matchingEntries.Count > 0,
+                $"Expected a Warning log entry under category '{IEndpointRouteBuilderExtensions.CspLoggerCategory}'");
+            Assert.Contains(reportBody, matchingEntries[0].Message);
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Custom RoutePrefix shifts endpoints accordingly
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CustomRoutePrefix_ShiftsEndpoints()
+    {
+        var (host, client, _) = await BuildHostAsync(opts =>
+            opts.RoutePrefix = "api/reporting");
+        using (host)
+        {
+            // Default endpoint should not be present
+            var defaultResponse = await client.PostAsync("/reporting/integrity",
+                new StringContent("test", Encoding.UTF8, "application/json"));
+            Assert.Equal(HttpStatusCode.NotFound, defaultResponse.StatusCode);
+
+            // Custom prefix endpoint should respond
+            var customResponse = await client.PostAsync("/api/reporting/integrity",
+                new StringContent("test", Encoding.UTF8, "application/json"));
+            Assert.Equal(HttpStatusCode.NoContent, customResponse.StatusCode);
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // MapSecurityReporting without AddSecurityReporting → InvalidOperationException
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task MapSecurityReporting_WithoutAddSecurityReporting_ThrowsInvalidOperationException()
+    {
+        // Build host WITHOUT calling AddSecurityReporting
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            var host = await new HostBuilder()
+                .ConfigureWebHost(webHost =>
+                {
+                    webHost.UseTestServer();
+                    webHost.ConfigureServices(services =>
+                    {
+                        services.AddRouting();
+                        // deliberately omit AddSecurityReporting
+                    });
+                    webHost.Configure(app =>
+                    {
+                        app.UseRouting();
+                        app.UseEndpoints(endpoints =>
+                        {
+                            // This should throw because SecurityReportingOptions is not registered
+                            endpoints.MapSecurityReporting();
+                        });
+                    });
+                })
+                .StartAsync();
+
+            // We may need to make a request to trigger the endpoint resolution
+            var client = host.GetTestClient();
+            await client.PostAsync("/reporting/integrity",
+                new StringContent("test", Encoding.UTF8, "application/json"));
+
+            host.Dispose();
+        });
+
+        Assert.NotNull(ex);
+    }
+}

--- a/tests/Asm.AspNetCore.Tests/Reporting/IEndpointRouteBuilderExtensionsTests.cs
+++ b/tests/Asm.AspNetCore.Tests/Reporting/IEndpointRouteBuilderExtensionsTests.cs
@@ -229,4 +229,170 @@ public class IEndpointRouteBuilderExtensionsTests
 
         Assert.NotNull(ex);
     }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Body under cap: 204 + log captured
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task PostCsp_BodyUnderCap_Returns204AndLogsBody()
+    {
+        var (host, client, logProvider) = await BuildHostAsync(opts => opts.MaxBodyBytes = 1024);
+        using (host)
+        {
+            var reportBody = "{\"csp-report\":{\"violated-directive\":\"default-src\"}}";
+            var content = new StringContent(reportBody, Encoding.UTF8, "application/csp-report");
+            var response = await client.PostAsync("/reporting/csp", content);
+
+            Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+
+            var matchingEntries = logProvider.Entries
+                .Where(e => e.Category == IEndpointRouteBuilderExtensions.CspLoggerCategory &&
+                            e.Level == LogLevel.Warning)
+                .ToList();
+
+            Assert.True(matchingEntries.Count > 0, "Expected at least one Warning log entry under the CSP category.");
+            Assert.Contains(reportBody, matchingEntries[0].Message);
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Body exceeding declared Content-Length: 413
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task PostCsp_DeclaredContentLengthExceedsCap_Returns413()
+    {
+        var (host, client, logProvider) = await BuildHostAsync(opts => opts.MaxBodyBytes = 10);
+        using (host)
+        {
+            // Body itself is 20 bytes; Content-Length is set accurately by StringContent.
+            var content = new StringContent("12345678901234567890", Encoding.UTF8, "application/csp-report");
+            var response = await client.PostAsync("/reporting/csp", content);
+
+            Assert.Equal(HttpStatusCode.RequestEntityTooLarge, response.StatusCode);
+
+            // Nothing should have been logged
+            Assert.DoesNotContain(logProvider.Entries,
+                e => e.Category == IEndpointRouteBuilderExtensions.CspLoggerCategory);
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Body exceeds cap via streaming (no Content-Length): 413
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task PostCsp_StreamingBodyExceedsCap_Returns413()
+    {
+        var (host, client, logProvider) = await BuildHostAsync(opts => opts.MaxBodyBytes = 10);
+        using (host)
+        {
+            // Use a StreamContent without a known length so Content-Length is not sent.
+            var bodyBytes = Encoding.UTF8.GetBytes("12345678901234567890");
+            var stream = new MemoryStream(bodyBytes);
+            var content = new StreamContent(stream);
+            content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/csp-report");
+            // Deliberately omit Content-Length so only the bounded read enforces the cap.
+
+            var response = await client.PostAsync("/reporting/csp", content);
+
+            Assert.Equal(HttpStatusCode.RequestEntityTooLarge, response.StatusCode);
+
+            // Nothing should have been logged
+            Assert.DoesNotContain(logProvider.Entries,
+                e => e.Category == IEndpointRouteBuilderExtensions.CspLoggerCategory);
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Body containing \r\n control chars: log contains sanitised text
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task PostCsp_BodyWithControlChars_LogsSanitisedBody()
+    {
+        var (host, client, logProvider) = await BuildHostAsync();
+        using (host)
+        {
+            // Embed \r\n and a form-feed into the body to simulate log-injection attempt.
+            var maliciousBody = "{\"injected\": \"value\r\nFAKE LOG ENTRY\fmore-fake\"}";
+            var content = new StringContent(maliciousBody, Encoding.UTF8, "application/csp-report");
+            await client.PostAsync("/reporting/csp", content);
+
+            var matchingEntries = logProvider.Entries
+                .Where(e => e.Category == IEndpointRouteBuilderExtensions.CspLoggerCategory &&
+                            e.Level == LogLevel.Warning)
+                .ToList();
+
+            Assert.True(matchingEntries.Count > 0, "Expected at least one Warning log entry under the CSP category.");
+            var message = matchingEntries[0].Message;
+            // CR, LF and form-feed must not appear in the logged message.
+            Assert.DoesNotContain('\r', message);
+            Assert.DoesNotContain('\n', message);
+            Assert.DoesNotContain('\f', message);
+            // The non-control content should still be present.
+            Assert.Contains("FAKE LOG ENTRY", message);
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // ContentType header containing \r\n: sanitised in log
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task PostCsp_ContentTypeWithControlChars_LogsSanitisedContentType()
+    {
+        var (host, client, logProvider) = await BuildHostAsync();
+        using (host)
+        {
+            var content = new StringContent("{\"csp-report\":{}}", Encoding.UTF8, "application/csp-report");
+
+            // ASP.NET Core / TestServer won't let us inject \r\n into a header value directly
+            // (it would throw in the HTTP client), so we test the sanitiser at the unit level by
+            // verifying a clean ContentType passes through correctly and that the log entry
+            // contains the content type string without control characters.
+            var response = await client.PostAsync("/reporting/csp", content);
+
+            Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+
+            var matchingEntries = logProvider.Entries
+                .Where(e => e.Category == IEndpointRouteBuilderExtensions.CspLoggerCategory &&
+                            e.Level == LogLevel.Warning)
+                .ToList();
+
+            Assert.True(matchingEntries.Count > 0, "Expected at least one Warning log entry under the CSP category.");
+            var message = matchingEntries[0].Message;
+            // The logged message must not contain raw control characters.
+            Assert.DoesNotContain('\r', message);
+            Assert.DoesNotContain('\n', message);
+            // The content type value should appear.
+            Assert.Contains("application/csp-report", message);
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Custom MaxBodyBytes = 1024: boundary is respected
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task PostCsp_CustomMaxBodyBytes_BoundaryRespected()
+    {
+        const int cap = 1024;
+        var (host, client, logProvider) = await BuildHostAsync(opts => opts.MaxBodyBytes = cap);
+        using (host)
+        {
+            // Exactly at the cap (1024 bytes): should succeed.
+            var atCapBody = new string('x', cap);
+            var atCapContent = new StringContent(atCapBody, Encoding.UTF8, "application/csp-report");
+            var atCapResponse = await client.PostAsync("/reporting/csp", atCapContent);
+            Assert.Equal(HttpStatusCode.NoContent, atCapResponse.StatusCode);
+
+            // One byte over the cap: should be rejected.
+            var overCapBody = new string('x', cap + 1);
+            var overCapContent = new StringContent(overCapBody, Encoding.UTF8, "application/csp-report");
+            var overCapResponse = await client.PostAsync("/reporting/csp", overCapContent);
+            Assert.Equal(HttpStatusCode.RequestEntityTooLarge, overCapResponse.StatusCode);
+        }
+    }
 }

--- a/tests/Asm.AspNetCore.Tests/Reporting/SecurityReportingHeaderBuilderTests.cs
+++ b/tests/Asm.AspNetCore.Tests/Reporting/SecurityReportingHeaderBuilderTests.cs
@@ -1,0 +1,113 @@
+using Asm.AspNetCore.Reporting;
+using Microsoft.AspNetCore.Http;
+
+namespace Asm.AspNetCore.Tests.Reporting;
+
+public class SecurityReportingHeaderBuilderTests
+{
+    // Build a minimal HttpContext with a known scheme and host
+    private static HttpContext BuildContext(string scheme = "https", string host = "example.com")
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Request.Scheme = scheme;
+        ctx.Request.Host = new HostString(host);
+        return ctx;
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // BuildReportingEndpoints
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void BuildReportingEndpoints_ContainsBothGroupNamesAndUrls()
+    {
+        var ctx = BuildContext();
+        var options = new SecurityReportingOptions();
+
+        var result = SecurityReportingHeaderBuilder.BuildReportingEndpoints(ctx, options);
+
+        Assert.Contains(options.IntegrityGroupName, result);
+        Assert.Contains(options.CspGroupName, result);
+        Assert.Contains("https://example.com/reporting/integrity", result);
+        Assert.Contains("https://example.com/reporting/csp", result);
+    }
+
+    [Fact]
+    public void BuildReportingEndpoints_CustomRoutePrefix_ReflectedInUrls()
+    {
+        var ctx = BuildContext();
+        var options = new SecurityReportingOptions { RoutePrefix = "api/reporting" };
+
+        var result = SecurityReportingHeaderBuilder.BuildReportingEndpoints(ctx, options);
+
+        Assert.Contains("https://example.com/api/reporting/integrity", result);
+        Assert.Contains("https://example.com/api/reporting/csp", result);
+    }
+
+    [Fact]
+    public void BuildReportingEndpoints_RoutePrefixWithLeadingSlash_WorksCorrectly()
+    {
+        var ctx = BuildContext();
+        var options = new SecurityReportingOptions { RoutePrefix = "/reporting/" };
+
+        var result = SecurityReportingHeaderBuilder.BuildReportingEndpoints(ctx, options);
+
+        // Leading/trailing slashes in RoutePrefix should be handled gracefully
+        Assert.Contains("https://example.com/reporting/integrity", result);
+        Assert.Contains("https://example.com/reporting/csp", result);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // BuildReportTo
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void BuildReportTo_ContainsBothGroups_MaxAge_AndUrls()
+    {
+        var ctx = BuildContext();
+        var options = new SecurityReportingOptions();
+
+        var result = SecurityReportingHeaderBuilder.BuildReportTo(ctx, options);
+
+        Assert.Contains(options.IntegrityGroupName, result);
+        Assert.Contains(options.CspGroupName, result);
+        Assert.Contains(options.MaxAgeSeconds.ToString(), result);
+        Assert.Contains("https://example.com/reporting/integrity", result);
+        Assert.Contains("https://example.com/reporting/csp", result);
+    }
+
+    [Fact]
+    public void BuildReportTo_CustomMaxAge_ReflectedInOutput()
+    {
+        var ctx = BuildContext();
+        var options = new SecurityReportingOptions { MaxAgeSeconds = 3600 };
+
+        var result = SecurityReportingHeaderBuilder.BuildReportTo(ctx, options);
+
+        Assert.Contains("3600", result);
+    }
+
+    [Fact]
+    public void BuildReportTo_CustomRoutePrefix_ReflectedInUrls()
+    {
+        var ctx = BuildContext();
+        var options = new SecurityReportingOptions { RoutePrefix = "api/reporting" };
+
+        var result = SecurityReportingHeaderBuilder.BuildReportTo(ctx, options);
+
+        Assert.Contains("https://example.com/api/reporting/integrity", result);
+        Assert.Contains("https://example.com/api/reporting/csp", result);
+    }
+
+    [Fact]
+    public void BuildReportTo_ContainsGroupKeyword()
+    {
+        var ctx = BuildContext();
+        var options = new SecurityReportingOptions();
+
+        var result = SecurityReportingHeaderBuilder.BuildReportTo(ctx, options);
+
+        // Should be JSON-like objects with "group" key
+        Assert.Contains("\"group\"", result);
+    }
+}

--- a/tests/Asm.AspNetCore.Tests/Reporting/SecurityReportingOptionsTests.cs
+++ b/tests/Asm.AspNetCore.Tests/Reporting/SecurityReportingOptionsTests.cs
@@ -15,6 +15,7 @@ public class SecurityReportingOptionsTests
         Assert.Equal("integrity-endpoint", options.IntegrityGroupName);
         Assert.Equal("csp-endpoint", options.CspGroupName);
         Assert.Equal(86400, options.MaxAgeSeconds);
+        Assert.Equal(65536, options.MaxBodyBytes);
     }
 
     [Fact]
@@ -53,5 +54,19 @@ public class SecurityReportingOptionsTests
         };
         Assert.Equal("sri", options.IntegrityRoute);
         Assert.Equal("content-security-policy", options.CspRoute);
+    }
+
+    [Fact]
+    public void MaxBodyBytes_DefaultsTo65536()
+    {
+        var options = new SecurityReportingOptions();
+        Assert.Equal(65536, options.MaxBodyBytes);
+    }
+
+    [Fact]
+    public void MaxBodyBytes_CanBeChanged()
+    {
+        var options = new SecurityReportingOptions { MaxBodyBytes = 1024 };
+        Assert.Equal(1024, options.MaxBodyBytes);
     }
 }

--- a/tests/Asm.AspNetCore.Tests/Reporting/SecurityReportingOptionsTests.cs
+++ b/tests/Asm.AspNetCore.Tests/Reporting/SecurityReportingOptionsTests.cs
@@ -1,0 +1,57 @@
+using Asm.AspNetCore.Reporting;
+
+namespace Asm.AspNetCore.Tests.Reporting;
+
+public class SecurityReportingOptionsTests
+{
+    [Fact]
+    public void DefaultValues_AreCorrect()
+    {
+        var options = new SecurityReportingOptions();
+
+        Assert.Equal("reporting", options.RoutePrefix);
+        Assert.Equal("integrity", options.IntegrityRoute);
+        Assert.Equal("csp", options.CspRoute);
+        Assert.Equal("integrity-endpoint", options.IntegrityGroupName);
+        Assert.Equal("csp-endpoint", options.CspGroupName);
+        Assert.Equal(86400, options.MaxAgeSeconds);
+    }
+
+    [Fact]
+    public void RoutePrefix_CanBeChanged()
+    {
+        var options = new SecurityReportingOptions { RoutePrefix = "api/reporting" };
+        Assert.Equal("api/reporting", options.RoutePrefix);
+    }
+
+    [Fact]
+    public void MaxAgeSeconds_CanBeChanged()
+    {
+        var options = new SecurityReportingOptions { MaxAgeSeconds = 3600 };
+        Assert.Equal(3600, options.MaxAgeSeconds);
+    }
+
+    [Fact]
+    public void GroupNames_CanBeChanged()
+    {
+        var options = new SecurityReportingOptions
+        {
+            IntegrityGroupName = "my-integrity",
+            CspGroupName = "my-csp"
+        };
+        Assert.Equal("my-integrity", options.IntegrityGroupName);
+        Assert.Equal("my-csp", options.CspGroupName);
+    }
+
+    [Fact]
+    public void RouteSegments_CanBeChanged()
+    {
+        var options = new SecurityReportingOptions
+        {
+            IntegrityRoute = "sri",
+            CspRoute = "content-security-policy"
+        };
+        Assert.Equal("sri", options.IntegrityRoute);
+        Assert.Equal("content-security-policy", options.CspRoute);
+    }
+}

--- a/tests/Asm.Umbraco.Authentication.Tests/Asm.Umbraco.Authentication.Tests.csproj
+++ b/tests/Asm.Umbraco.Authentication.Tests/Asm.Umbraco.Authentication.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <CoverletInclude>[Asm.Umbraco.Authentication]*</CoverletInclude>
+    <CoverletExcludeByFile>**/*</CoverletExcludeByFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Asm.Umbraco.Authentication\Asm.Umbraco.Authentication.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Moq" />
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Asm.Umbraco.Authentication.Tests/EntraId/EntraIdBackOfficeOptionsTests.cs
+++ b/tests/Asm.Umbraco.Authentication.Tests/EntraId/EntraIdBackOfficeOptionsTests.cs
@@ -1,0 +1,186 @@
+using Asm.Umbraco.Authentication.EntraId;
+using Microsoft.AspNetCore.Authentication.MicrosoftAccount;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core;
+
+namespace Asm.Umbraco.Authentication.Tests.EntraId;
+
+public class EntraIdBackOfficeOptionsTests
+{
+    private const string TenantId = "aaaabbbb-1111-2222-3333-ccccddddeeee";
+    private const string ClientId = "my-client-id";
+    private const string ClientSecret = "my-client-secret";
+
+    private const string MatchingName =
+        Constants.Security.BackOfficeExternalAuthenticationTypePrefix + EntraIdLoginOptions.SchemeName;
+
+    private static EntraIdBackOfficeOptions CreateSut() =>
+        new(Options.Create(new EntraIdOptions
+        {
+            TenantId = TenantId,
+            ClientId = ClientId,
+            ClientSecret = ClientSecret
+        }));
+
+    // -----------------------------------------------------------------------
+    // Configure(string?, MicrosoftAccountOptions)
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Configure_WithMatchingName_SetsClientId()
+    {
+        var sut = CreateSut();
+        var options = new MicrosoftAccountOptions();
+
+        sut.Configure(MatchingName, options);
+
+        Assert.Equal(ClientId, options.ClientId);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Configure_WithMatchingName_SetsClientSecret()
+    {
+        var sut = CreateSut();
+        var options = new MicrosoftAccountOptions();
+
+        sut.Configure(MatchingName, options);
+
+        Assert.Equal(ClientSecret, options.ClientSecret);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Configure_WithMatchingName_SetsCallbackPath()
+    {
+        var sut = CreateSut();
+        var options = new MicrosoftAccountOptions();
+
+        sut.Configure(MatchingName, options);
+
+        Assert.Equal("/signin-oidc", options.CallbackPath);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Configure_WithMatchingName_SetsTokenEndpoint()
+    {
+        var sut = CreateSut();
+        var options = new MicrosoftAccountOptions();
+
+        sut.Configure(MatchingName, options);
+
+        Assert.Equal(
+            $"https://login.microsoftonline.com/{TenantId}/oauth2/v2.0/token",
+            options.TokenEndpoint);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Configure_WithMatchingName_SetsAuthorizationEndpoint()
+    {
+        var sut = CreateSut();
+        var options = new MicrosoftAccountOptions();
+
+        sut.Configure(MatchingName, options);
+
+        Assert.Equal(
+            $"https://login.microsoftonline.com/{TenantId}/oauth2/v2.0/authorize",
+            options.AuthorizationEndpoint);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Configure_WithNonMatchingName_LeavesClientIdUnchanged()
+    {
+        var sut = CreateSut();
+        var options = new MicrosoftAccountOptions();
+        var originalClientId = options.ClientId;
+
+        sut.Configure("SomeDifferentScheme", options);
+
+        Assert.Equal(originalClientId, options.ClientId);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Configure_WithNonMatchingName_LeavesClientSecretUnchanged()
+    {
+        var sut = CreateSut();
+        var options = new MicrosoftAccountOptions();
+        var originalSecret = options.ClientSecret;
+
+        sut.Configure("SomeDifferentScheme", options);
+
+        Assert.Equal(originalSecret, options.ClientSecret);
+    }
+
+    // -----------------------------------------------------------------------
+    // Configure(MicrosoftAccountOptions) — no-name overload
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Configure_WithoutName_SetsClientId()
+    {
+        var sut = CreateSut();
+        var options = new MicrosoftAccountOptions();
+
+        sut.Configure(options);
+
+        Assert.Equal(ClientId, options.ClientId);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Configure_WithoutName_SetsClientSecret()
+    {
+        var sut = CreateSut();
+        var options = new MicrosoftAccountOptions();
+
+        sut.Configure(options);
+
+        Assert.Equal(ClientSecret, options.ClientSecret);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Configure_WithoutName_SetsCallbackPath()
+    {
+        var sut = CreateSut();
+        var options = new MicrosoftAccountOptions();
+
+        sut.Configure(options);
+
+        Assert.Equal("/signin-oidc", options.CallbackPath);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Configure_WithoutName_SetsTokenEndpoint()
+    {
+        var sut = CreateSut();
+        var options = new MicrosoftAccountOptions();
+
+        sut.Configure(options);
+
+        Assert.Equal(
+            $"https://login.microsoftonline.com/{TenantId}/oauth2/v2.0/token",
+            options.TokenEndpoint);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Configure_WithoutName_SetsAuthorizationEndpoint()
+    {
+        var sut = CreateSut();
+        var options = new MicrosoftAccountOptions();
+
+        sut.Configure(options);
+
+        Assert.Equal(
+            $"https://login.microsoftonline.com/{TenantId}/oauth2/v2.0/authorize",
+            options.AuthorizationEndpoint);
+    }
+}

--- a/tests/Asm.Umbraco.Authentication.Tests/EntraId/EntraIdLoginOptionsTests.cs
+++ b/tests/Asm.Umbraco.Authentication.Tests/EntraId/EntraIdLoginOptionsTests.cs
@@ -1,0 +1,163 @@
+using Asm.Umbraco.Authentication.EntraId;
+using Microsoft.AspNetCore.Identity;
+using Umbraco.Cms.Api.Management.Security;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Security;
+
+namespace Asm.Umbraco.Authentication.Tests.EntraId;
+
+public class EntraIdLoginOptionsTests
+{
+    private const string MatchingName =
+        Constants.Security.BackOfficeExternalAuthenticationTypePrefix + EntraIdLoginOptions.SchemeName;
+
+    // -----------------------------------------------------------------------
+    // Configure(string?, BackOfficeExternalLoginProviderOptions)
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Configure_WithMatchingName_SetsAutoLinkOptionsNotNull()
+    {
+        var sut = new EntraIdLoginOptions();
+        var options = new BackOfficeExternalLoginProviderOptions();
+
+        sut.Configure(MatchingName, options);
+
+        Assert.NotNull(options.AutoLinkOptions);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Configure_WithMatchingName_AutoLinksExternalAccount()
+    {
+        var sut = new EntraIdLoginOptions();
+        var options = new BackOfficeExternalLoginProviderOptions();
+
+        sut.Configure(MatchingName, options);
+
+        Assert.True(options.AutoLinkOptions.AutoLinkExternalAccount);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Configure_WithMatchingName_SetsDenyLocalLoginFalse()
+    {
+        var sut = new EntraIdLoginOptions();
+        var options = new BackOfficeExternalLoginProviderOptions();
+
+        sut.Configure(MatchingName, options);
+
+        Assert.False(options.DenyLocalLogin);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Configure_WithNonMatchingName_LeavesAutoLinkOptionsUnchanged()
+    {
+        var sut = new EntraIdLoginOptions();
+        var options = new BackOfficeExternalLoginProviderOptions();
+
+        // Capture the default state before calling Configure with a non-matching name
+        var defaultAutoLinkExternalAccount = options.AutoLinkOptions.AutoLinkExternalAccount;
+
+        sut.Configure("SomeDifferentScheme", options);
+
+        // The Configure call should have been a no-op — auto-link state must be unchanged
+        Assert.Equal(defaultAutoLinkExternalAccount, options.AutoLinkOptions.AutoLinkExternalAccount);
+        Assert.False(options.AutoLinkOptions.AutoLinkExternalAccount,
+            "Non-matching name must not enable auto-linking.");
+    }
+
+    // -----------------------------------------------------------------------
+    // Configure(BackOfficeExternalLoginProviderOptions) — no-name overload
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Configure_WithoutName_SetsAutoLinkOptionsNotNull()
+    {
+        var sut = new EntraIdLoginOptions();
+        var options = new BackOfficeExternalLoginProviderOptions();
+
+        sut.Configure(options);
+
+        Assert.NotNull(options.AutoLinkOptions);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Configure_WithoutName_AutoLinksExternalAccount()
+    {
+        var sut = new EntraIdLoginOptions();
+        var options = new BackOfficeExternalLoginProviderOptions();
+
+        sut.Configure(options);
+
+        Assert.True(options.AutoLinkOptions.AutoLinkExternalAccount);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Configure_WithoutName_SetsDenyLocalLoginFalse()
+    {
+        var sut = new EntraIdLoginOptions();
+        var options = new BackOfficeExternalLoginProviderOptions();
+
+        sut.Configure(options);
+
+        Assert.False(options.DenyLocalLogin);
+    }
+
+    // -----------------------------------------------------------------------
+    // OnAutoLinking callback
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void OnAutoLinking_SetsIsApprovedTrue()
+    {
+        var sut = new EntraIdLoginOptions();
+        var options = new BackOfficeExternalLoginProviderOptions();
+        sut.Configure(options);
+
+        var user = new BackOfficeIdentityUser(new GlobalSettings(), 1, []);
+        var loginInfo = CreateExternalLoginInfo();
+
+        options.AutoLinkOptions.OnAutoLinking?.Invoke(user, loginInfo);
+
+        Assert.True(user.IsApproved);
+    }
+
+    // -----------------------------------------------------------------------
+    // OnExternalLogin callback
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void OnExternalLogin_ReturnsTrue()
+    {
+        var sut = new EntraIdLoginOptions();
+        var options = new BackOfficeExternalLoginProviderOptions();
+        sut.Configure(options);
+
+        var user = new BackOfficeIdentityUser(new GlobalSettings(), 1, []);
+        var loginInfo = CreateExternalLoginInfo();
+
+        var result = options.AutoLinkOptions.OnExternalLogin?.Invoke(user, loginInfo);
+
+        Assert.True(result);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static ExternalLoginInfo CreateExternalLoginInfo() =>
+        new(
+            new System.Security.Claims.ClaimsPrincipal(),
+            "test-provider",
+            "test-key",
+            "Test Provider");
+}

--- a/tests/Asm.Umbraco.Authentication.Tests/EntraId/EntraIdManifestReaderTests.cs
+++ b/tests/Asm.Umbraco.Authentication.Tests/EntraId/EntraIdManifestReaderTests.cs
@@ -1,0 +1,98 @@
+using Asm.Umbraco.Authentication.EntraId;
+using Umbraco.Cms.Core;
+
+namespace Asm.Umbraco.Authentication.Tests.EntraId;
+
+public class EntraIdManifestReaderTests
+{
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task ReadPackageManifestsAsync_ReturnsSingleManifest()
+    {
+        var sut = new EntraIdManifestReader();
+
+        var manifests = await sut.ReadPackageManifestsAsync();
+
+        Assert.Single(manifests);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task ReadPackageManifestsAsync_ManifestNameIsCorrect()
+    {
+        var sut = new EntraIdManifestReader();
+
+        var manifests = await sut.ReadPackageManifestsAsync();
+        var manifest = manifests.Single();
+
+        Assert.Equal("Asm.Umbraco.Authentication.EntraId", manifest.Name);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task ReadPackageManifestsAsync_ManifestAllowsPublicAccess()
+    {
+        var sut = new EntraIdManifestReader();
+
+        var manifests = await sut.ReadPackageManifestsAsync();
+        var manifest = manifests.Single();
+
+        Assert.True(manifest.AllowPublicAccess);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task ReadPackageManifestsAsync_ManifestHasExactlyOneExtension()
+    {
+        var sut = new EntraIdManifestReader();
+
+        var manifests = await sut.ReadPackageManifestsAsync();
+        var manifest = manifests.Single();
+
+        Assert.NotNull(manifest.Extensions);
+        Assert.Single(manifest.Extensions);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task ReadPackageManifestsAsync_ExtensionTypeIsAuthProvider()
+    {
+        var sut = new EntraIdManifestReader();
+
+        var manifests = await sut.ReadPackageManifestsAsync();
+        var extension = manifests.Single().Extensions!.Single();
+
+        // Extensions are anonymous objects — use dynamic to read properties
+        dynamic ext = extension;
+        Assert.Equal("authProvider", (string)ext.type);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task ReadPackageManifestsAsync_ExtensionForProviderNameContainsOpenIdConnect()
+    {
+        var expectedProviderName =
+            Constants.Security.BackOfficeExternalAuthenticationTypePrefix + EntraIdLoginOptions.SchemeName;
+
+        var sut = new EntraIdManifestReader();
+
+        var manifests = await sut.ReadPackageManifestsAsync();
+        var extension = manifests.Single().Extensions!.Single();
+
+        dynamic ext = extension;
+        Assert.Equal(expectedProviderName, (string)ext.forProviderName);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task ReadPackageManifestsAsync_ExtensionMetaLabelIsMicrosoft()
+    {
+        var sut = new EntraIdManifestReader();
+
+        var manifests = await sut.ReadPackageManifestsAsync();
+        var extension = manifests.Single().Extensions!.Single();
+
+        dynamic ext = extension;
+        Assert.Equal("Microsoft", (string)ext.meta.label);
+    }
+}

--- a/tests/Asm.Umbraco.Authentication.Tests/EntraId/EntraIdOptionsTests.cs
+++ b/tests/Asm.Umbraco.Authentication.Tests/EntraId/EntraIdOptionsTests.cs
@@ -1,0 +1,88 @@
+using Asm.Umbraco.Authentication.EntraId;
+
+namespace Asm.Umbraco.Authentication.Tests.EntraId;
+
+public class EntraIdOptionsTests
+{
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void TenantId_CanBeSetAndRead()
+    {
+        var options = new EntraIdOptions
+        {
+            TenantId = "test-tenant-id",
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret"
+        };
+
+        Assert.Equal("test-tenant-id", options.TenantId);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ClientId_CanBeSetAndRead()
+    {
+        var options = new EntraIdOptions
+        {
+            TenantId = "test-tenant-id",
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret"
+        };
+
+        Assert.Equal("test-client-id", options.ClientId);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ClientSecret_CanBeSetAndRead()
+    {
+        var options = new EntraIdOptions
+        {
+            TenantId = "test-tenant-id",
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret"
+        };
+
+        Assert.Equal("test-client-secret", options.ClientSecret);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Records_WithSameValues_AreEqual()
+    {
+        var a = new EntraIdOptions
+        {
+            TenantId = "tenant",
+            ClientId = "client",
+            ClientSecret = "secret"
+        };
+        var b = new EntraIdOptions
+        {
+            TenantId = "tenant",
+            ClientId = "client",
+            ClientSecret = "secret"
+        };
+
+        Assert.Equal(a, b);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Records_WithDifferentValues_AreNotEqual()
+    {
+        var a = new EntraIdOptions
+        {
+            TenantId = "tenant-a",
+            ClientId = "client",
+            ClientSecret = "secret"
+        };
+        var b = new EntraIdOptions
+        {
+            TenantId = "tenant-b",
+            ClientId = "client",
+            ClientSecret = "secret"
+        };
+
+        Assert.NotEqual(a, b);
+    }
+}

--- a/tests/Asm.Umbraco.Authentication.Tests/EntraId/IUmbracoBuilderExtensionsTests.cs
+++ b/tests/Asm.Umbraco.Authentication.Tests/EntraId/IUmbracoBuilderExtensionsTests.cs
@@ -1,0 +1,260 @@
+using Asm.Umbraco.Authentication.EntraId;
+using Microsoft.AspNetCore.Authentication.MicrosoftAccount;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Api.Management.Security;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Infrastructure.Manifest;
+
+namespace Asm.Umbraco.Authentication.Tests.EntraId;
+
+public class IUmbracoBuilderExtensionsTests
+{
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static (IUmbracoBuilder Builder, IServiceCollection Services) CreateBuilder()
+    {
+        var services = new ServiceCollection();
+        services.AddOptions();
+        var builderMock = new Mock<IUmbracoBuilder>();
+        builderMock.Setup(b => b.Services).Returns(services);
+        return (builderMock.Object, services);
+    }
+
+    // -----------------------------------------------------------------------
+    // AddEntraIdAuthentication(Action<EntraIdOptions>)
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AddEntraIdAuthentication_WithAction_RegistersEntraIdLoginOptions()
+    {
+        var (builder, services) = CreateBuilder();
+
+        builder.AddEntraIdAuthentication(o =>
+        {
+            o.TenantId = "t";
+            o.ClientId = "c";
+            o.ClientSecret = "s";
+        });
+
+        Assert.Contains(services, sd =>
+            sd.ServiceType == typeof(IConfigureOptions<BackOfficeExternalLoginProviderOptions>) &&
+            sd.ImplementationType == typeof(EntraIdLoginOptions));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AddEntraIdAuthentication_WithAction_RegistersEntraIdBackOfficeOptions()
+    {
+        var (builder, services) = CreateBuilder();
+
+        builder.AddEntraIdAuthentication(o =>
+        {
+            o.TenantId = "t";
+            o.ClientId = "c";
+            o.ClientSecret = "s";
+        });
+
+        Assert.Contains(services, sd =>
+            sd.ServiceType == typeof(IConfigureOptions<MicrosoftAccountOptions>) &&
+            sd.ImplementationType == typeof(EntraIdBackOfficeOptions));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AddEntraIdAuthentication_WithAction_RegistersPackageManifestReader()
+    {
+        var (builder, services) = CreateBuilder();
+
+        builder.AddEntraIdAuthentication(o =>
+        {
+            o.TenantId = "t";
+            o.ClientId = "c";
+            o.ClientSecret = "s";
+        });
+
+        Assert.Contains(services, sd =>
+            sd.ServiceType == typeof(IPackageManifestReader) &&
+            sd.ImplementationType == typeof(EntraIdManifestReader));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AddEntraIdAuthentication_WithAction_BindsEntraIdOptions()
+    {
+        var (builder, services) = CreateBuilder();
+
+        builder.AddEntraIdAuthentication(o =>
+        {
+            o.TenantId = "test-tenant";
+            o.ClientId = "test-client";
+            o.ClientSecret = "test-secret";
+        });
+
+        var sp = services.BuildServiceProvider();
+        var options = sp.GetRequiredService<IOptions<EntraIdOptions>>();
+
+        Assert.Equal("test-tenant", options.Value.TenantId);
+        Assert.Equal("test-client", options.Value.ClientId);
+        Assert.Equal("test-secret", options.Value.ClientSecret);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AddEntraIdAuthentication_WithAction_ReturnsBuilder()
+    {
+        var (builder, _) = CreateBuilder();
+
+        var returned = builder.AddEntraIdAuthentication(o =>
+        {
+            o.TenantId = "t";
+            o.ClientId = "c";
+            o.ClientSecret = "s";
+        });
+
+        Assert.Same(builder, returned);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AddEntraIdAuthentication_WithNullBuilder_ThrowsArgumentNullException()
+    {
+        IUmbracoBuilder nullBuilder = null;
+
+        Assert.Throws<ArgumentNullException>(() =>
+            nullBuilder.AddEntraIdAuthentication(o =>
+            {
+                o.TenantId = "t";
+                o.ClientId = "c";
+                o.ClientSecret = "s";
+            }));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AddEntraIdAuthentication_WithNullAction_ThrowsArgumentNullException()
+    {
+        var (builder, _) = CreateBuilder();
+
+        Assert.Throws<ArgumentNullException>(() =>
+            builder.AddEntraIdAuthentication((Action<EntraIdOptions>)null));
+    }
+
+    // -----------------------------------------------------------------------
+    // AddEntraIdAuthentication(IConfigurationSection)
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AddEntraIdAuthentication_WithConfigSection_RegistersEntraIdLoginOptions()
+    {
+        var (builder, services) = CreateBuilder();
+
+        builder.AddEntraIdAuthentication(BuildConfigSection());
+
+        Assert.Contains(services, sd =>
+            sd.ServiceType == typeof(IConfigureOptions<BackOfficeExternalLoginProviderOptions>) &&
+            sd.ImplementationType == typeof(EntraIdLoginOptions));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AddEntraIdAuthentication_WithConfigSection_RegistersEntraIdBackOfficeOptions()
+    {
+        var (builder, services) = CreateBuilder();
+
+        builder.AddEntraIdAuthentication(BuildConfigSection());
+
+        Assert.Contains(services, sd =>
+            sd.ServiceType == typeof(IConfigureOptions<MicrosoftAccountOptions>) &&
+            sd.ImplementationType == typeof(EntraIdBackOfficeOptions));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AddEntraIdAuthentication_WithConfigSection_RegistersPackageManifestReader()
+    {
+        var (builder, services) = CreateBuilder();
+
+        builder.AddEntraIdAuthentication(BuildConfigSection());
+
+        Assert.Contains(services, sd =>
+            sd.ServiceType == typeof(IPackageManifestReader) &&
+            sd.ImplementationType == typeof(EntraIdManifestReader));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AddEntraIdAuthentication_WithConfigSection_BindsEntraIdOptions()
+    {
+        var (builder, services) = CreateBuilder();
+
+        builder.AddEntraIdAuthentication(BuildConfigSection(
+            tenantId: "section-tenant",
+            clientId: "section-client",
+            clientSecret: "section-secret"));
+
+        var sp = services.BuildServiceProvider();
+        var options = sp.GetRequiredService<IOptions<EntraIdOptions>>();
+
+        Assert.Equal("section-tenant", options.Value.TenantId);
+        Assert.Equal("section-client", options.Value.ClientId);
+        Assert.Equal("section-secret", options.Value.ClientSecret);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AddEntraIdAuthentication_WithConfigSection_ReturnsBuilder()
+    {
+        var (builder, _) = CreateBuilder();
+
+        var returned = builder.AddEntraIdAuthentication(BuildConfigSection());
+
+        Assert.Same(builder, returned);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AddEntraIdAuthentication_WithNullConfigSection_ThrowsArgumentNullException()
+    {
+        var (builder, _) = CreateBuilder();
+
+        Assert.Throws<ArgumentNullException>(() =>
+            builder.AddEntraIdAuthentication((IConfigurationSection)null));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AddEntraIdAuthentication_WithConfigSection_NullBuilder_ThrowsArgumentNullException()
+    {
+        IUmbracoBuilder nullBuilder = null;
+
+        Assert.Throws<ArgumentNullException>(() =>
+            nullBuilder.AddEntraIdAuthentication(BuildConfigSection()));
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static IConfigurationSection BuildConfigSection(
+        string tenantId = "default-tenant",
+        string clientId = "default-client",
+        string clientSecret = "default-secret")
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["EntraId:TenantId"] = tenantId,
+                ["EntraId:ClientId"] = clientId,
+                ["EntraId:ClientSecret"] = clientSecret
+            })
+            .Build();
+
+        return config.GetSection("EntraId");
+    }
+}

--- a/tests/Asm.Umbraco.Tests/Asm.Umbraco.Tests.csproj
+++ b/tests/Asm.Umbraco.Tests/Asm.Umbraco.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <CoverletInclude>[Asm.Umbraco]*</CoverletInclude>
+    <CoverletExcludeByFile>**/*</CoverletExcludeByFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Asm.Umbraco\Asm.Umbraco.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Moq" />
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Asm.Umbraco.Tests/Extensions/IPublishedContentExtensionsTests.cs
+++ b/tests/Asm.Umbraco.Tests/Extensions/IPublishedContentExtensionsTests.cs
@@ -1,0 +1,76 @@
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Extensions;
+
+namespace Asm.Umbraco.Tests.Extensions;
+
+public class IPublishedContentExtensionsTests
+{
+    // -----------------------------------------------------------------------
+    // NameAsCssClass
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void NameAsCssClass_ReturnsLowercaseHyphenSeparatedName()
+    {
+        var contentMock = new Mock<IPublishedContent>();
+        contentMock.Setup(c => c.Name).Returns("Hello World");
+
+        var result = contentMock.Object.NameAsCssClass();
+
+        Assert.Equal("hello-world", result);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void NameAsCssClass_WhenNullContent_ReturnsNull()
+    {
+        IPublishedContent content = null;
+        var result = content.NameAsCssClass();
+        Assert.Null(result);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void NameAsCssClass_MultipleSpaces_ReplacesEachWithHyphen()
+    {
+        var contentMock = new Mock<IPublishedContent>();
+        contentMock.Setup(c => c.Name).Returns("One Two Three");
+
+        var result = contentMock.Object.NameAsCssClass();
+
+        Assert.Equal("one-two-three", result);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void NameAsCssClass_AlreadyLowercase_ReturnsUnchangedExceptSpaces()
+    {
+        var contentMock = new Mock<IPublishedContent>();
+        contentMock.Setup(c => c.Name).Returns("already lower");
+
+        var result = contentMock.Object.NameAsCssClass();
+
+        Assert.Equal("already-lower", result);
+    }
+
+    // -----------------------------------------------------------------------
+    // ValueOr<T> and ValueAnd — SKIPPED
+    //
+    // Both ValueOr<T> and ValueAnd call model.HasValue(alias) where model is
+    // IPublishedContent. This resolves to FriendlyPublishedContentExtensions.HasValue
+    // (from Umbraco.Cms.Web.Common), which initialises via a static type initialiser
+    // that calls GetRequiredService<IPublishedValueFallback>() against Umbraco's
+    // static service provider (Current). In a unit test environment Umbraco's
+    // composition is never set up, so the static constructor throws:
+    //   "Value cannot be null (Parameter 'provider')"
+    //
+    // This failure occurs even on the false-branch path (HasValue returns false →
+    // return fallback), because FriendlyPublishedContentExtensions initialises
+    // eagerly at first use of any member. There is no way to test these methods
+    // in isolation without bootstrapping the full Umbraco composition.
+    //
+    // Coverage for ValueOr and ValueAnd should be provided by integration or
+    // acceptance tests that run inside a fully composed Umbraco host.
+    // -----------------------------------------------------------------------
+}

--- a/tests/Asm.Umbraco.Tests/MachineInfo/FixedMachineInfoFactoryOptionsTests.cs
+++ b/tests/Asm.Umbraco.Tests/MachineInfo/FixedMachineInfoFactoryOptionsTests.cs
@@ -1,0 +1,34 @@
+using Asm.Umbraco.MachineInfo;
+
+namespace Asm.Umbraco.Tests.MachineInfo;
+
+public class FixedMachineInfoFactoryOptionsTests
+{
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void EnvironmentVariableName_DefaultsToMachineName()
+    {
+        var options = new FixedMachineInfoFactoryOptions { MachineName = "test-machine" };
+        Assert.Equal("MACHINE_NAME", options.EnvironmentVariableName);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void MachineName_RoundTrip()
+    {
+        var options = new FixedMachineInfoFactoryOptions { MachineName = "my-server" };
+        Assert.Equal("my-server", options.MachineName);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void EnvironmentVariableName_CanBeOverridden()
+    {
+        var options = new FixedMachineInfoFactoryOptions
+        {
+            MachineName = "test-machine",
+            EnvironmentVariableName = "CUSTOM_MACHINE_VAR"
+        };
+        Assert.Equal("CUSTOM_MACHINE_VAR", options.EnvironmentVariableName);
+    }
+}

--- a/tests/Asm.Umbraco.Tests/MachineInfo/FixedMachineInfoFactoryTests.cs
+++ b/tests/Asm.Umbraco.Tests/MachineInfo/FixedMachineInfoFactoryTests.cs
@@ -1,0 +1,98 @@
+using Asm.Umbraco.MachineInfo;
+using Microsoft.AspNetCore.DataProtection.Infrastructure;
+using Microsoft.Extensions.Options;
+
+namespace Asm.Umbraco.Tests.MachineInfo;
+
+public class FixedMachineInfoFactoryTests : IDisposable
+{
+    private const string TestEnvVar = "MACHINE_NAME";
+    private const string CustomEnvVar = "CUSTOM_MACHINE_VAR";
+
+    private readonly Mock<IApplicationDiscriminator> _discriminatorMock;
+
+    public FixedMachineInfoFactoryTests()
+    {
+        _discriminatorMock = new Mock<IApplicationDiscriminator>();
+        _discriminatorMock.Setup(d => d.Discriminator).Returns("test-app");
+
+        // Clean up env vars before each test
+        Environment.SetEnvironmentVariable(TestEnvVar, null);
+        Environment.SetEnvironmentVariable(CustomEnvVar, null);
+    }
+
+    public void Dispose()
+    {
+        // Clean up after each test
+        Environment.SetEnvironmentVariable(TestEnvVar, null);
+        Environment.SetEnvironmentVariable(CustomEnvVar, null);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void GetMachineIdentifier_WhenEnvVarSet_ReturnsEnvVarValue()
+    {
+        Environment.SetEnvironmentVariable(TestEnvVar, "env-machine-name");
+
+        var options = Options.Create(new FixedMachineInfoFactoryOptions { MachineName = "fallback-name" });
+        var factory = new FixedMachineInfoFactory(_discriminatorMock.Object, options);
+
+        Assert.Equal("env-machine-name", factory.GetMachineIdentifier());
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void GetMachineIdentifier_WhenEnvVarNotSet_ReturnsFallbackMachineName()
+    {
+        Environment.SetEnvironmentVariable(TestEnvVar, null);
+
+        var options = Options.Create(new FixedMachineInfoFactoryOptions { MachineName = "fallback-name" });
+        var factory = new FixedMachineInfoFactory(_discriminatorMock.Object, options);
+
+        Assert.Equal("fallback-name", factory.GetMachineIdentifier());
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void GetMachineIdentifier_WhenCustomEnvVarSet_ReturnsCustomEnvVarValue()
+    {
+        Environment.SetEnvironmentVariable(CustomEnvVar, "custom-env-machine");
+
+        var options = Options.Create(new FixedMachineInfoFactoryOptions
+        {
+            MachineName = "fallback-name",
+            EnvironmentVariableName = CustomEnvVar
+        });
+        var factory = new FixedMachineInfoFactory(_discriminatorMock.Object, options);
+
+        Assert.Equal("custom-env-machine", factory.GetMachineIdentifier());
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void GetLocalIdentity_ContainsMachineNameDiscriminatorProcessIdDomainIdAndGuid()
+    {
+        var options = Options.Create(new FixedMachineInfoFactoryOptions { MachineName = "test-machine" });
+        var factory = new FixedMachineInfoFactory(_discriminatorMock.Object, options);
+
+        var identity = factory.GetLocalIdentity();
+
+        Assert.Contains("test-app", identity);                  // discriminator
+        Assert.Contains("[P", identity);                        // process id prefix
+        Assert.Contains("/D", identity);                        // domain id prefix
+        Assert.Matches(@"[0-9A-F]{32}", identity);              // GUID segment (N format, uppercased)
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void GetLocalIdentity_ReturnsSameValueOnMultipleCalls()
+    {
+        var options = Options.Create(new FixedMachineInfoFactoryOptions { MachineName = "test-machine" });
+        var factory = new FixedMachineInfoFactory(_discriminatorMock.Object, options);
+
+        var first = factory.GetLocalIdentity();
+        var second = factory.GetLocalIdentity();
+
+        Assert.Equal(first, second);
+    }
+}

--- a/tests/Asm.Umbraco.Tests/MachineInfo/IUmbracoBuilderExtensionsTests.cs
+++ b/tests/Asm.Umbraco.Tests/MachineInfo/IUmbracoBuilderExtensionsTests.cs
@@ -1,0 +1,142 @@
+using Asm.Umbraco.MachineInfo;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Factories;
+
+namespace Asm.Umbraco.Tests.MachineInfo;
+
+public class IUmbracoBuilderExtensionsTests
+{
+    private static (IUmbracoBuilder Builder, IServiceCollection Services) CreateBuilder()
+    {
+        var services = new ServiceCollection();
+        var builderMock = new Mock<IUmbracoBuilder>();
+        builderMock.Setup(b => b.Services).Returns(services);
+        return (builderMock.Object, services);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AddFixedMachineInfoFactory_WithActionConfigure_RegistersIMachineInfoFactory()
+    {
+        var (builder, services) = CreateBuilder();
+
+        builder.AddFixedMachineInfoFactory(opts =>
+        {
+            opts.MachineName = "configured-machine";
+        });
+
+        // Verify that a service descriptor for IMachineInfoFactory → FixedMachineInfoFactory was registered.
+        // We check the descriptor rather than resolving the service to avoid needing IApplicationDiscriminator.
+        Assert.Contains(services, sd =>
+            sd.ServiceType == typeof(IMachineInfoFactory) &&
+            sd.ImplementationType == typeof(FixedMachineInfoFactory));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AddFixedMachineInfoFactory_WithActionConfigure_BindsOptions()
+    {
+        var (builder, services) = CreateBuilder();
+
+        builder.AddFixedMachineInfoFactory(opts =>
+        {
+            opts.MachineName = "configured-machine";
+            opts.EnvironmentVariableName = "CUSTOM_VAR";
+        });
+
+        var sp = services.BuildServiceProvider();
+        var options = sp.GetRequiredService<IOptions<FixedMachineInfoFactoryOptions>>();
+        Assert.Equal("configured-machine", options.Value.MachineName);
+        Assert.Equal("CUSTOM_VAR", options.Value.EnvironmentVariableName);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AddFixedMachineInfoFactory_WithActionConfigure_ReturnsBuilder()
+    {
+        var (builder, _) = CreateBuilder();
+
+        var returned = builder.AddFixedMachineInfoFactory(opts => opts.MachineName = "machine");
+
+        Assert.Same(builder, returned);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AddFixedMachineInfoFactory_WithConfigSection_RegistersIMachineInfoFactory()
+    {
+        var (builder, services) = CreateBuilder();
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["MachineInfo:MachineName"] = "section-machine",
+                ["MachineInfo:EnvironmentVariableName"] = "SECTION_VAR"
+            })
+            .Build();
+
+        builder.AddFixedMachineInfoFactory(config.GetSection("MachineInfo"));
+
+        Assert.Contains(services, sd =>
+            sd.ServiceType == typeof(IMachineInfoFactory) &&
+            sd.ImplementationType == typeof(FixedMachineInfoFactory));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AddFixedMachineInfoFactory_WithConfigSection_BindsOptions()
+    {
+        var (builder, services) = CreateBuilder();
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["MachineInfo:MachineName"] = "section-machine",
+                ["MachineInfo:EnvironmentVariableName"] = "SECTION_VAR"
+            })
+            .Build();
+
+        builder.AddFixedMachineInfoFactory(config.GetSection("MachineInfo"));
+
+        var sp = services.BuildServiceProvider();
+        var options = sp.GetRequiredService<IOptions<FixedMachineInfoFactoryOptions>>();
+        Assert.Equal("section-machine", options.Value.MachineName);
+        Assert.Equal("SECTION_VAR", options.Value.EnvironmentVariableName);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AddFixedMachineInfoFactory_WithConfigSection_ReturnsBuilder()
+    {
+        var (builder, _) = CreateBuilder();
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string> { ["MachineInfo:MachineName"] = "m" })
+            .Build();
+
+        var returned = builder.AddFixedMachineInfoFactory(config.GetSection("MachineInfo"));
+
+        Assert.Same(builder, returned);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AddFixedMachineInfoFactory_NullBuilder_ThrowsArgumentNullException()
+    {
+        IUmbracoBuilder nullBuilder = null;
+        Assert.Throws<ArgumentNullException>(() =>
+            nullBuilder.AddFixedMachineInfoFactory(opts => opts.MachineName = "x"));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AddFixedMachineInfoFactory_NullConfigure_ThrowsArgumentNullException()
+    {
+        var (builder, _) = CreateBuilder();
+        Assert.Throws<ArgumentNullException>(() =>
+            builder.AddFixedMachineInfoFactory((Action<FixedMachineInfoFactoryOptions>)null));
+    }
+}

--- a/tests/Asm.Umbraco.Tests/TagHelpers/ImgSetTagHelperTests.cs
+++ b/tests/Asm.Umbraco.Tests/TagHelpers/ImgSetTagHelperTests.cs
@@ -1,0 +1,77 @@
+using Asm.Umbraco.TagHelpers;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.Extensions.Caching.Memory;
+using Umbraco.Cms.Core.Models.PublishedContent;
+
+namespace Asm.Umbraco.Tests.TagHelpers;
+
+// NOTE: Tests that exercise the full Process() path (non-empty image list) are
+// not included here because image.Url() resolves via FriendlyPublishedContentExtensions
+// which requires IPublishedUrlProvider from Umbraco's composition/service locator.
+// Bootstrapping the full Umbraco composition in a unit test is disproportionate
+// effort for the value gained. Those paths are better covered by integration tests.
+//
+// What IS covered: the short-circuit paths (null/empty images) that suppress output
+// without touching the Umbraco extension method chain.
+
+public class ImgSetTagHelperTests
+{
+    private static TagHelperContext CreateContext() =>
+        new(
+            tagName: "imgset",
+            allAttributes: new TagHelperAttributeList(),
+            items: new Dictionary<object, object>(),
+            uniqueId: "test");
+
+    private static TagHelperOutput CreateOutput() =>
+        new(
+            tagName: "imgset",
+            attributes: new TagHelperAttributeList(),
+            getChildContentAsync: (_, _) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
+
+    private ImgSetTagHelper CreateTagHelper(IEnumerable<IPublishedContent> images = null)
+    {
+        var envMock = new Mock<IWebHostEnvironment>();
+        envMock.Setup(e => e.EnvironmentName).Returns("Production");
+        envMock.Setup(e => e.WebRootPath).Returns("/var/www");
+
+        var cacheMock = new Mock<IMemoryCache>();
+
+        var helper = new ImgSetTagHelper(envMock.Object, cacheMock.Object)
+        {
+            ViewContext = new ViewContext(),
+            Images = images ?? []
+        };
+
+        return helper;
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Process_WhenImagesIsNull_SuppressesOutput()
+    {
+        var helper = CreateTagHelper();
+        helper.Images = null;
+
+        var output = CreateOutput();
+        helper.Process(CreateContext(), output);
+
+        // SuppressOutput() sets TagName to null
+        Assert.Null(output.TagName);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Process_WhenImagesIsEmpty_SuppressesOutput()
+    {
+        var helper = CreateTagHelper(images: []);
+
+        var output = CreateOutput();
+        helper.Process(CreateContext(), output);
+
+        // An empty Images enumerable means FirstOrDefault() returns null, triggering SuppressOutput()
+        Assert.Null(output.TagName);
+    }
+}


### PR DESCRIPTION
## Summary

Adds two new NuGet packages and extends an existing one, extracting reusable code previously living in the AndrewMcLachlan.com (AmCom) consumer.

### New packages
- **Asm.Umbraco** — `FixedMachineInfoFactory` (stable machine identifier for container deployments), `ImgSetTagHelper` (renders `<img srcset>` from Umbraco media collections), and three `IPublishedContent` extension helpers.
- **Asm.Umbraco.Authentication** — Microsoft Entra ID back-office login provider with an `IPackageManifestReader` so the login button appears in the back-office SPA without any `App_Plugins` folder in the consumer.

### Additions to Asm.AspNetCore
- `SecurityHeadersMiddleware` — configurable response-header policy with server-fingerprint stripping and automatic emission of `Reporting-Endpoints` / `Report-To` headers when `AddSecurityReporting()` is registered.
- `CanonicalUrlMiddleware` — lowercase + trailing-slash canonicalisation via 301 redirects. Replaces the name `UrlRewrite` from the original to avoid confusion with `Microsoft.AspNetCore.Rewrite`.
- `SecurityReportingOptions` + endpoint helpers — `MapSecurityReporting()` maps `POST {prefix}/integrity` and `POST {prefix}/csp` endpoints that log to dedicated categories.

### Other changes
- Bumped Microsoft.Extensions.* and .NET 10 Microsoft packages from 10.0.3 → 10.0.4 to satisfy Umbraco 17.3.4's transitive requirements.

## Tests

**116 new tests across 3 test projects, all passing:**
- `tests/Asm.Umbraco.Tests/` — 22 tests (new project)
- `tests/Asm.Umbraco.Authentication.Tests/` — 47 tests (new project)
- `tests/Asm.AspNetCore.Tests/` — 47 new tests added to existing project (123 total now passing)

Some `IPublishedContent.Value<T>()` / `HasValue()` paths in `ImgSetTagHelper` and `IPublishedContentExtensions` are only partially covered because Umbraco's `FriendlyPublishedContentExtensions` depend on a static service locator (`Current`) that can't be set up cleanly in unit tests. Full coverage there would require integration-level Umbraco composition; flagged as a follow-up.

## Conventions applied

- Extension classes named after the type they extend (`IUmbracoBuilderExtensions`, `IApplicationBuilderExtensions`, `IServiceCollectionExtensions`, `IEndpointRouteBuilderExtensions`) in that type's namespace (`Umbraco.Cms.Core.DependencyInjection`, `Microsoft.AspNetCore.Builder`, `Microsoft.Extensions.DependencyInjection`, `Microsoft.AspNetCore.Routing`).
- Options records use `{ get; set; }` to work with the idiomatic `Action<TOptions>` callback pattern.
- XML documentation on all public surface (per `<GenerateDocumentationFile>true</GenerateDocumentationFile>`).

## Test plan

- [ ] Review public API shape — especially the `AddEntraIdAuthentication` / `AddFixedMachineInfoFactory` overload pairs
- [ ] Confirm the `Microsoft.Extensions.*` 10.0.3 → 10.0.4 bump doesn't break any other consumer
- [ ] `dotnet test Asm.slnx` — confirm all test projects pass locally
- [ ] Decide whether the existing parameterless `IApplicationBuilderExtensions.UseSecurityHeaders()` helper should stay, be deprecated, or be refactored to build on the new middleware (it's unchanged in this PR)

Companion spec + plan in the AmCom repo at `docs/specs/2026-04-23-asm-umbraco-library-extraction-design.md` and `docs/plans/2026-04-23-asm-umbraco-library-extraction-plan.md`. Those docs don't yet reflect the two mid-execution scope changes (extension-class naming convention, tests in scope) — I can push doc updates in a follow-up commit if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)