### PR TITLE
Refactor SecurityHeadersOptions: sensible defaults, first-class header properties

### DIFF
--- a/src/Asm.AspNetCore/Extensions/IApplicationBuilderExtensions.cs
+++ b/src/Asm.AspNetCore/Extensions/IApplicationBuilderExtensions.cs
@@ -28,7 +28,7 @@ public static class IApplicationBuilderExtensions
         });
 
     /// <summary>
-    /// Adds security headers to the middleware pipeline.
+    /// Adds a hardcoded default security-header set to the pipeline.
     /// </summary>
     /// <remarks>
     /// Adds:
@@ -42,6 +42,9 @@ public static class IApplicationBuilderExtensions
     /// </remarks>
     /// <param name="builder">The <see cref="IApplicationBuilder"/> instance that this method extends.</param>
     /// <returns>The <see cref="IApplicationBuilder"/> so that calls can be chained.</returns>
+    [Obsolete("Use UseSecurityHeaders(Action<SecurityHeadersOptions>) instead, which provides "
+            + "configurable defaults and integrates with AddSecurityReporting(). "
+            + "Pass _ => {} to get the new defaults without overrides.")]
     public static IApplicationBuilder UseSecurityHeaders(this IApplicationBuilder builder) =>
         builder.Use(async (context, next) =>
         {
@@ -62,9 +65,7 @@ public static class IApplicationBuilderExtensions
     /// <param name="app">The application builder.</param>
     /// <param name="configure">Callback to configure the security headers.</param>
     /// <returns>The application builder.</returns>
-    public static IApplicationBuilder UseSecurityHeaders(
-        this IApplicationBuilder app,
-        Action<SecurityHeadersOptions> configure)
+    public static IApplicationBuilder UseSecurityHeaders(this IApplicationBuilder app, Action<SecurityHeadersOptions> configure)
     {
         ArgumentNullException.ThrowIfNull(app);
         ArgumentNullException.ThrowIfNull(configure);
@@ -81,9 +82,7 @@ public static class IApplicationBuilderExtensions
     /// <param name="app">The application builder.</param>
     /// <param name="configure">Optional callback to configure canonicalisation options.</param>
     /// <returns>The application builder.</returns>
-    public static IApplicationBuilder UseCanonicalUrls(
-        this IApplicationBuilder app,
-        Action<CanonicalUrlOptions>? configure = null)
+    public static IApplicationBuilder UseCanonicalUrls(this IApplicationBuilder app, Action<CanonicalUrlOptions>? configure = null)
     {
         ArgumentNullException.ThrowIfNull(app);
 

--- a/src/Asm.AspNetCore/Extensions/IHeaderDictionaryExtensions.cs
+++ b/src/Asm.AspNetCore/Extensions/IHeaderDictionaryExtensions.cs
@@ -1,0 +1,21 @@
+namespace Microsoft.AspNetCore.Http;
+
+/// <summary>
+/// Extensions for the <see cref="IHeaderDictionary"/> interface.
+/// </summary>
+public static class IHeaderDictionaryExtensions
+{
+    /// <summary>
+    /// Appends the specified header only when <paramref name="value"/> is not null.
+    /// </summary>
+    /// <param name="headers">The header dictionary.</param>
+    /// <param name="name">The header name.</param>
+    /// <param name="value">The header value, or <see langword="null"/> to skip.</param>
+    public static void AppendIfNotNull(this IHeaderDictionary headers, string name, string? value)
+    {
+        if (value is not null)
+        {
+            headers.Append(name, value);
+        }
+    }
+}

--- a/src/Asm.AspNetCore/Middleware/SecurityHeadersMiddleware.cs
+++ b/src/Asm.AspNetCore/Middleware/SecurityHeadersMiddleware.cs
@@ -27,10 +27,7 @@ public class SecurityHeadersMiddleware
     /// <param name="reportingOptions">Optional reporting options. When present (i.e.
     /// <c>AddSecurityReporting()</c> was called), the middleware emits
     /// <c>Reporting-Endpoints</c> and <c>Report-To</c> headers.</param>
-    public SecurityHeadersMiddleware(
-        RequestDelegate next,
-        IOptions<SecurityHeadersOptions> options,
-        SecurityReportingOptions? reportingOptions = null)
+    public SecurityHeadersMiddleware(RequestDelegate next, IOptions<SecurityHeadersOptions> options, SecurityReportingOptions? reportingOptions = null)
     {
         _next = next;
         _options = options.Value;
@@ -64,7 +61,17 @@ public class SecurityHeadersMiddleware
                 return Task.CompletedTask;
             }
 
-            foreach (var (name, value) in _options.Headers)
+            context.Response.Headers.AppendIfNotNull("Content-Security-Policy", _options.ContentSecurityPolicy);
+            context.Response.Headers.AppendIfNotNull("Cross-Origin-Opener-Policy", _options.CrossOriginOpenerPolicy);
+            context.Response.Headers.AppendIfNotNull("Cross-Origin-Embedder-Policy", _options.CrossOriginEmbedderPolicy);
+            context.Response.Headers.AppendIfNotNull("Cross-Origin-Resource-Policy", _options.CrossOriginResourcePolicy);
+            context.Response.Headers.AppendIfNotNull("X-Frame-Options", _options.XFrameOptions);
+            context.Response.Headers.AppendIfNotNull("X-Content-Type-Options", _options.XContentTypeOptions);
+            context.Response.Headers.AppendIfNotNull("Referrer-Policy", _options.ReferrerPolicy);
+            context.Response.Headers.AppendIfNotNull("Permissions-Policy", _options.PermissionsPolicy);
+            context.Response.Headers.AppendIfNotNull("X-Permitted-Cross-Domain-Policies", _options.XPermittedCrossDomainPolicies);
+
+            foreach (var (name, value) in _options.CustomHeaders)
             {
                 context.Response.Headers.Append(name, value);
             }
@@ -79,12 +86,8 @@ public class SecurityHeadersMiddleware
 
             if (_reportingOptions is { } reporting)
             {
-                context.Response.Headers.Append(
-                    "Reporting-Endpoints",
-                    SecurityReportingHeaderBuilder.BuildReportingEndpoints(context, reporting));
-                context.Response.Headers.Append(
-                    "Report-To",
-                    SecurityReportingHeaderBuilder.BuildReportTo(context, reporting));
+                context.Response.Headers.Append("Reporting-Endpoints", SecurityReportingHeaderBuilder.BuildReportingEndpoints(context, reporting));
+                context.Response.Headers.Append("Report-To", SecurityReportingHeaderBuilder.BuildReportTo(context, reporting));
             }
 
             return Task.CompletedTask;
@@ -95,7 +98,7 @@ public class SecurityHeadersMiddleware
 
     private bool IsExempt(string? path)
     {
-        if (string.IsNullOrEmpty(path) || _options.ExemptPathPrefixes.Count == 0)
+        if (String.IsNullOrEmpty(path) || _options.ExemptPathPrefixes.Count == 0)
         {
             return false;
         }
@@ -109,4 +112,5 @@ public class SecurityHeadersMiddleware
         }
         return false;
     }
+
 }

--- a/src/Asm.AspNetCore/Middleware/SecurityHeadersOptions.cs
+++ b/src/Asm.AspNetCore/Middleware/SecurityHeadersOptions.cs
@@ -5,6 +5,12 @@ namespace Asm.AspNetCore.Middleware;
 /// <summary>
 /// Options for <see cref="SecurityHeadersMiddleware"/>.
 /// </summary>
+/// <remarks>
+/// The middleware ships sensible defaults for the commonly-required security
+/// headers. Consumers only need to override the properties that are site-specific
+/// (typically <see cref="ContentSecurityPolicy"/> and <see cref="PermissionsPolicy"/>).
+/// Set any property to <see langword="null"/> to suppress that header entirely.
+/// </remarks>
 public record SecurityHeadersOptions
 {
     /// <summary>
@@ -21,14 +27,72 @@ public record SecurityHeadersOptions
     public IReadOnlyList<string> ExemptPathPrefixes { get; set; } = [];
 
     /// <summary>
-    /// Static headers added to all HTML responses (after fingerprint stripping).
+    /// <c>Content-Security-Policy</c> header value. Defaults to <c>"default-src 'self'"</c>.
+    /// Set to <see langword="null"/> to suppress the header. Most apps should override this
+    /// with a policy tailored to their resource origins.
     /// </summary>
-    public IDictionary<string, string> Headers { get; set; }
+    public string? ContentSecurityPolicy { get; set; } = "default-src 'self'";
+
+    /// <summary>
+    /// <c>Cross-Origin-Opener-Policy</c> header value. Defaults to
+    /// <c>"same-origin-allow-popups"</c> to allow third-party OAuth popups.
+    /// Set to <see langword="null"/> to suppress the header.
+    /// </summary>
+    public string? CrossOriginOpenerPolicy { get; set; } = "same-origin-allow-popups";
+
+    /// <summary>
+    /// <c>Cross-Origin-Embedder-Policy</c> header value. Defaults to <c>"require-corp"</c>.
+    /// Set to <see langword="null"/> to suppress the header.
+    /// </summary>
+    public string? CrossOriginEmbedderPolicy { get; set; } = "require-corp";
+
+    /// <summary>
+    /// <c>Cross-Origin-Resource-Policy</c> header value. Defaults to <c>"same-origin"</c>.
+    /// Set to <see langword="null"/> to suppress the header.
+    /// </summary>
+    public string? CrossOriginResourcePolicy { get; set; } = "same-origin";
+
+    /// <summary>
+    /// <c>X-Frame-Options</c> header value. Defaults to <c>"SAMEORIGIN"</c>.
+    /// Set to <see langword="null"/> to suppress the header.
+    /// </summary>
+    public string? XFrameOptions { get; set; } = "SAMEORIGIN";
+
+    /// <summary>
+    /// <c>X-Content-Type-Options</c> header value. Defaults to <c>"nosniff"</c>.
+    /// Set to <see langword="null"/> to suppress the header.
+    /// </summary>
+    public string? XContentTypeOptions { get; set; } = "nosniff";
+
+    /// <summary>
+    /// <c>Referrer-Policy</c> header value. Defaults to <c>"strict-origin-when-cross-origin"</c>.
+    /// Set to <see langword="null"/> to suppress the header.
+    /// </summary>
+    public string? ReferrerPolicy { get; set; } = "strict-origin-when-cross-origin";
+
+    /// <summary>
+    /// <c>Permissions-Policy</c> header value. Defaults to <see langword="null"/>
+    /// (no universally-sensible default); consumers needing the header should set one.
+    /// </summary>
+    public string? PermissionsPolicy { get; set; }
+
+    /// <summary>
+    /// <c>X-Permitted-Cross-Domain-Policies</c> header value. Defaults to <c>"none"</c>,
+    /// instructing legacy Flash/Acrobat clients not to load cross-domain policy files.
+    /// Set to <see langword="null"/> to suppress the header.
+    /// </summary>
+    public string? XPermittedCrossDomainPolicies { get; set; } = "none";
+
+    /// <summary>
+    /// Additional headers beyond the standard set exposed as first-class properties.
+    /// Useful for non-standard or consumer-specific headers.
+    /// </summary>
+    public IDictionary<string, string> CustomHeaders { get; set; }
         = new Dictionary<string, string>(StringComparer.Ordinal);
 
     /// <summary>
     /// Optional callback producing additional headers computed per-request (e.g., containing
-    /// the request scheme or host). Merged after <see cref="Headers"/>.
+    /// the request scheme or host). Merged after <see cref="CustomHeaders"/>.
     /// </summary>
     public Func<HttpContext, IDictionary<string, string>>? DynamicHeaders { get; set; }
 }

--- a/tests/Asm.AspNetCore.Tests/Extensions/IApplicationBuilderExtensionsSecurityTests.cs
+++ b/tests/Asm.AspNetCore.Tests/Extensions/IApplicationBuilderExtensionsSecurityTests.cs
@@ -32,7 +32,7 @@ public class IApplicationBuilderExtensionsSecurityTests
                 {
                     app.UseSecurityHeaders(opts =>
                     {
-                        opts.Headers["X-Smoke-Test"] = "ok";
+                        opts.CustomHeaders["X-Smoke-Test"] = "ok";
                     });
                     app.Run(async ctx =>
                     {

--- a/tests/Asm.AspNetCore.Tests/Middleware/SecurityHeadersMiddlewareTests.cs
+++ b/tests/Asm.AspNetCore.Tests/Middleware/SecurityHeadersMiddlewareTests.cs
@@ -49,16 +49,126 @@ public class SecurityHeadersMiddlewareTests
         host.GetTestClient();
 
     // ──────────────────────────────────────────────────────────────────────────
-    // Static headers on HTML responses
+    // Default headers emitted on HTML responses
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("Content-Security-Policy", "default-src 'self'")]
+    [InlineData("Cross-Origin-Opener-Policy", "same-origin-allow-popups")]
+    [InlineData("Cross-Origin-Embedder-Policy", "require-corp")]
+    [InlineData("Cross-Origin-Resource-Policy", "same-origin")]
+    [InlineData("X-Frame-Options", "SAMEORIGIN")]
+    [InlineData("X-Content-Type-Options", "nosniff")]
+    [InlineData("Referrer-Policy", "strict-origin-when-cross-origin")]
+    [InlineData("X-Permitted-Cross-Domain-Policies", "none")]
+    public async Task HtmlResponse_DefaultHeaders_ArePresent(string headerName, string expectedValue)
+    {
+        using var host = await BuildHostAsync(opts => { /* use all defaults */ });
+
+        var client = GetClient(host);
+        var response = await client.GetAsync("/", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.True(response.Headers.Contains(headerName), $"{headerName} missing");
+        Assert.Equal(expectedValue, response.Headers.GetValues(headerName).First());
+    }
+
+    [Fact]
+    public async Task HtmlResponse_PermissionsPolicy_NotPresentByDefault()
+    {
+        using var host = await BuildHostAsync(opts => { /* use all defaults */ });
+
+        var client = GetClient(host);
+        var response = await client.GetAsync("/", TestContext.Current.CancellationToken);
+
+        Assert.False(response.Headers.Contains("Permissions-Policy"),
+            "Permissions-Policy should not be emitted by default (null)");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Individual header property overrides
     // ──────────────────────────────────────────────────────────────────────────
 
     [Fact]
-    public async Task HtmlResponse_StaticHeaders_ArePresent()
+    public async Task ContentSecurityPolicy_Override_IsUsed()
+    {
+        using var host = await BuildHostAsync(opts =>
+            opts.ContentSecurityPolicy = "default-src 'self'; img-src *");
+
+        var client = GetClient(host);
+        var response = await client.GetAsync("/", TestContext.Current.CancellationToken);
+
+        Assert.Equal("default-src 'self'; img-src *",
+            response.Headers.GetValues("Content-Security-Policy").First());
+    }
+
+    [Fact]
+    public async Task ReferrerPolicy_Override_IsUsed()
+    {
+        using var host = await BuildHostAsync(opts =>
+            opts.ReferrerPolicy = "no-referrer");
+
+        var client = GetClient(host);
+        var response = await client.GetAsync("/", TestContext.Current.CancellationToken);
+
+        Assert.Equal("no-referrer",
+            response.Headers.GetValues("Referrer-Policy").First());
+    }
+
+    [Fact]
+    public async Task PermissionsPolicy_Set_IsEmitted()
+    {
+        using var host = await BuildHostAsync(opts =>
+            opts.PermissionsPolicy = "geolocation=(), camera=()");
+
+        var client = GetClient(host);
+        var response = await client.GetAsync("/", TestContext.Current.CancellationToken);
+
+        Assert.True(response.Headers.Contains("Permissions-Policy"),
+            "Permissions-Policy should be present when set");
+        Assert.Equal("geolocation=(), camera=()",
+            response.Headers.GetValues("Permissions-Policy").First());
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Setting a property to null suppresses that header
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("Content-Security-Policy", nameof(SecurityHeadersOptions.ContentSecurityPolicy))]
+    [InlineData("Cross-Origin-Opener-Policy", nameof(SecurityHeadersOptions.CrossOriginOpenerPolicy))]
+    [InlineData("Cross-Origin-Embedder-Policy", nameof(SecurityHeadersOptions.CrossOriginEmbedderPolicy))]
+    [InlineData("Cross-Origin-Resource-Policy", nameof(SecurityHeadersOptions.CrossOriginResourcePolicy))]
+    [InlineData("X-Frame-Options", nameof(SecurityHeadersOptions.XFrameOptions))]
+    [InlineData("X-Content-Type-Options", nameof(SecurityHeadersOptions.XContentTypeOptions))]
+    [InlineData("Referrer-Policy", nameof(SecurityHeadersOptions.ReferrerPolicy))]
+    [InlineData("X-Permitted-Cross-Domain-Policies", nameof(SecurityHeadersOptions.XPermittedCrossDomainPolicies))]
+    public async Task NullProperty_SuppressesHeader(string headerName, string propertyName)
     {
         using var host = await BuildHostAsync(opts =>
         {
-            opts.Headers["X-Test-Header"] = "test-value";
-            opts.Headers["X-Another"] = "another-value";
+            var prop = typeof(SecurityHeadersOptions).GetProperty(propertyName)!;
+            prop.SetValue(opts, null);
+        });
+
+        var client = GetClient(host);
+        var response = await client.GetAsync("/", TestContext.Current.CancellationToken);
+
+        Assert.False(response.Headers.Contains(headerName),
+            $"{headerName} should be suppressed when property is null");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // CustomHeaders dict entries appear in response
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task HtmlResponse_CustomHeaders_ArePresent()
+    {
+        using var host = await BuildHostAsync(opts =>
+        {
+            opts.CustomHeaders["X-Test-Header"] = "test-value";
+            opts.CustomHeaders["X-Another"] = "another-value";
         });
 
         var client = GetClient(host);
@@ -71,14 +181,14 @@ public class SecurityHeadersMiddlewareTests
     }
 
     // ──────────────────────────────────────────────────────────────────────────
-    // Non-HTML responses do NOT get static headers
+    // Non-HTML responses do NOT get policy headers
     // ──────────────────────────────────────────────────────────────────────────
 
     [Fact]
-    public async Task NonHtmlResponse_StaticHeaders_AreNotAdded()
+    public async Task NonHtmlResponse_PolicyHeaders_AreNotAdded()
     {
         using var host = await BuildHostAsync(
-            opts => opts.Headers["X-Test-Header"] = "test-value",
+            opts => opts.CustomHeaders["X-Test-Header"] = "test-value",
             responseContentType: "application/json");
 
         var client = GetClient(host);
@@ -86,7 +196,11 @@ public class SecurityHeadersMiddlewareTests
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.False(response.Headers.Contains("X-Test-Header"),
-            "Static security headers should not be added to non-HTML responses");
+            "Custom headers should not be added to non-HTML responses");
+        Assert.False(response.Headers.Contains("Content-Security-Policy"),
+            "CSP should not be added to non-HTML responses");
+        Assert.False(response.Headers.Contains("Referrer-Policy"),
+            "Referrer-Policy should not be added to non-HTML responses");
     }
 
     // ──────────────────────────────────────────────────────────────────────────
@@ -158,7 +272,7 @@ public class SecurityHeadersMiddlewareTests
                     {
                         opts.RemoveServerHeaders = true;
                         opts.ExemptPathPrefixes = ["/api"];
-                        opts.Headers["X-Static"] = "value";
+                        opts.CustomHeaders["X-Static"] = "value";
                     });
 
                     app.Run(async ctx =>
@@ -177,7 +291,7 @@ public class SecurityHeadersMiddlewareTests
         Assert.True(response.Headers.Contains("Server"),
             "Server header should survive on exempt path");
         Assert.False(response.Headers.Contains("X-Static"),
-            "Static headers should not be added on exempt path");
+            "Custom headers should not be added on exempt path");
     }
 
     // ──────────────────────────────────────────────────────────────────────────

--- a/tests/Asm.AspNetCore.Tests/Middleware/SecurityHeadersOptionsTests.cs
+++ b/tests/Asm.AspNetCore.Tests/Middleware/SecurityHeadersOptionsTests.cs
@@ -12,7 +12,16 @@ public class SecurityHeadersOptionsTests
 
         Assert.True(options.RemoveServerHeaders);
         Assert.Empty(options.ExemptPathPrefixes);
-        Assert.Empty(options.Headers);
+        Assert.Equal("default-src 'self'", options.ContentSecurityPolicy);
+        Assert.Equal("same-origin-allow-popups", options.CrossOriginOpenerPolicy);
+        Assert.Equal("require-corp", options.CrossOriginEmbedderPolicy);
+        Assert.Equal("same-origin", options.CrossOriginResourcePolicy);
+        Assert.Equal("SAMEORIGIN", options.XFrameOptions);
+        Assert.Equal("nosniff", options.XContentTypeOptions);
+        Assert.Equal("strict-origin-when-cross-origin", options.ReferrerPolicy);
+        Assert.Null(options.PermissionsPolicy);
+        Assert.Equal("none", options.XPermittedCrossDomainPolicies);
+        Assert.Empty(options.CustomHeaders);
         Assert.Null(options.DynamicHeaders);
     }
 
@@ -34,12 +43,48 @@ public class SecurityHeadersOptionsTests
         Assert.Contains("/api", options.ExemptPathPrefixes);
     }
 
-    [Fact]
-    public void Headers_CanBePopulated()
+    [Theory]
+    [InlineData(nameof(SecurityHeadersOptions.ContentSecurityPolicy), "script-src 'self' cdn.example.com")]
+    [InlineData(nameof(SecurityHeadersOptions.CrossOriginOpenerPolicy), "same-origin")]
+    [InlineData(nameof(SecurityHeadersOptions.CrossOriginEmbedderPolicy), "unsafe-none")]
+    [InlineData(nameof(SecurityHeadersOptions.CrossOriginResourcePolicy), "cross-origin")]
+    [InlineData(nameof(SecurityHeadersOptions.XFrameOptions), "DENY")]
+    [InlineData(nameof(SecurityHeadersOptions.XContentTypeOptions), "nosniff")]
+    [InlineData(nameof(SecurityHeadersOptions.ReferrerPolicy), "no-referrer")]
+    [InlineData(nameof(SecurityHeadersOptions.PermissionsPolicy), "geolocation=()")]
+    [InlineData(nameof(SecurityHeadersOptions.XPermittedCrossDomainPolicies), "master-only")]
+    public void HeaderProperties_CanBeOverridden(string propertyName, string value)
     {
         var options = new SecurityHeadersOptions();
-        options.Headers["X-Custom"] = "value";
-        Assert.Equal("value", options.Headers["X-Custom"]);
+        var prop = typeof(SecurityHeadersOptions).GetProperty(propertyName)!;
+        prop.SetValue(options, value);
+        Assert.Equal(value, prop.GetValue(options));
+    }
+
+    [Theory]
+    [InlineData(nameof(SecurityHeadersOptions.ContentSecurityPolicy))]
+    [InlineData(nameof(SecurityHeadersOptions.CrossOriginOpenerPolicy))]
+    [InlineData(nameof(SecurityHeadersOptions.CrossOriginEmbedderPolicy))]
+    [InlineData(nameof(SecurityHeadersOptions.CrossOriginResourcePolicy))]
+    [InlineData(nameof(SecurityHeadersOptions.XFrameOptions))]
+    [InlineData(nameof(SecurityHeadersOptions.XContentTypeOptions))]
+    [InlineData(nameof(SecurityHeadersOptions.ReferrerPolicy))]
+    [InlineData(nameof(SecurityHeadersOptions.PermissionsPolicy))]
+    [InlineData(nameof(SecurityHeadersOptions.XPermittedCrossDomainPolicies))]
+    public void HeaderProperties_CanBeSetToNull(string propertyName)
+    {
+        var options = new SecurityHeadersOptions();
+        var prop = typeof(SecurityHeadersOptions).GetProperty(propertyName)!;
+        prop.SetValue(options, null);
+        Assert.Null(prop.GetValue(options));
+    }
+
+    [Fact]
+    public void CustomHeaders_CanBePopulated()
+    {
+        var options = new SecurityHeadersOptions();
+        options.CustomHeaders["X-Custom"] = "value";
+        Assert.Equal("value", options.CustomHeaders["X-Custom"]);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- **`SecurityHeadersOptions`** now exposes each standard security header as a typed nullable property with a sensible default. Consumers can override individual headers or set them to `null` to suppress them entirely — no more populating an opaque dictionary by hand.
- **`CustomHeaders`** (renamed from `Headers`) is still available for non-standard or site-specific headers.
- **`DynamicHeaders`** callback is unchanged.
- **HSTS not included** — intentionally delegated to ASP.NET Core's built-in `app.UseHsts()`.
- **Legacy `UseSecurityHeaders()` (parameterless)** is marked `[Obsolete]` with a helpful migration message pointing consumers to `UseSecurityHeaders(_ => {})`. Its body is unchanged so existing consumers keep working with only a compiler warning.

### Default values shipped out of the box

| Header | Default |
|---|---|
| `Content-Security-Policy` | `default-src 'self'` |
| `Cross-Origin-Opener-Policy` | `same-origin-allow-popups` |
| `Cross-Origin-Embedder-Policy` | `require-corp` |
| `Cross-Origin-Resource-Policy` | `same-origin` |
| `X-Frame-Options` | `SAMEORIGIN` |
| `X-Content-Type-Options` | `nosniff` |
| `Referrer-Policy` | `strict-origin-when-cross-origin` |
| `Permissions-Policy` | *(not emitted — no universal default)* |

## Migration

**Before:**
```csharp
app.UseSecurityHeaders(opts =>
{
    opts.Headers["Content-Security-Policy"] = "default-src 'self'; ...";
    opts.Headers["X-Frame-Options"] = "SAMEORIGIN";
    // ... etc
});
```

**After:**
```csharp
app.UseSecurityHeaders(opts =>
{
    opts.ContentSecurityPolicy = "default-src 'self'; ...";
    // X-Frame-Options, X-Content-Type-Options, COOP, COEP, CORP, Referrer-Policy
    // all emit sensible defaults automatically — only override what you need
});
```

## Test plan

- [x] New `[Theory]` tests verify every default header is emitted with the correct value
- [x] Null-suppression tests verify each property can be set to `null` to omit the header
- [x] Override tests verify setting a property changes the emitted value
- [x] `CustomHeaders` dict, `DynamicHeaders` callback, `ExemptPathPrefixes`, `RemoveServerHeaders`, and `AddSecurityReporting()` integration all tested — unchanged behaviour confirmed
- [x] Full solution test run: **0 failures** (165 in `Asm.AspNetCore.Tests`, 847 total across solution)
- [x] Single `CS0618` warning from `TestWebApplication.cs` using the legacy overload — expected and intentional

🤖 Generated with [Claude Code](https://claude.com/claude-code)