### PR TITLE
Support additional OAuth issuers and audiences

### DIFF
--- a/src/Asm.AspNetCore/Authentication/Authentication.cs
+++ b/src/Asm.AspNetCore/Authentication/Authentication.cs
@@ -62,6 +62,8 @@ public static class Authentication
                 ValidateIssuerSigningKey = true,
                 ValidateIssuer = true,
                 ValidateAudience = _jwtOptions.OAuthOptions.ValidateAudience,
+                ValidIssuers = _jwtOptions.OAuthOptions.AdditionalIssuers,
+                ValidAudiences = _jwtOptions.OAuthOptions.AdditionalAudiences,
             };
         }
 

--- a/src/Asm.OAuth/OAuthOptions.cs
+++ b/src/Asm.OAuth/OAuthOptions.cs
@@ -16,6 +16,16 @@ public record OAuthOptions
     public required string Audience { get; init; }
 
     /// <summary>
+    /// Gets any additional audiences.
+    /// </summary>
+    public IEnumerable<string> AdditionalAudiences { get; init; } = [];
+
+    /// <summary>
+    /// Gets any additional issuers.
+    /// </summary>
+    public IEnumerable<string> AdditionalIssuers { get; init; } = [];
+
+    /// <summary>
     /// Gets or sets the client ID.
     /// </summary>
     public required string ClientId { get; init; }


### PR DESCRIPTION
## Summary
- Add `AdditionalIssuers` and `AdditionalAudiences` to `OAuthOptions` (default to empty collections)
- Wire them through to `TokenValidationParameters.ValidIssuers` / `ValidAudiences` in `Asm.AspNetCore.Authentication`

This lets consuming apps accept JWTs from multiple trusted issuers/audiences without overriding the auth bootstrap.

## Test plan
- [ ] Build solution
- [ ] Confirm existing OAuth-using apps still authenticate with no additional config (defaults are empty)
- [ ] Configure `AdditionalIssuers` / `AdditionalAudiences` and verify tokens from those sources validate

🤖 Generated with [Claude Code](https://claude.com/claude-code)