### PR TITLE
feat(domain): route Get(id) overloads through protected virtual GetById

### DIFF
--- a/src/Asm.Domain.Infrastructure/RepositoryBase.cs
+++ b/src/Asm.Domain.Infrastructure/RepositoryBase.cs
@@ -39,16 +39,25 @@ public abstract class RepositoryBase<TContext, TEntity, TKey>(TContext context) 
     /// <inheritdoc/>
     public virtual async Task<TEntity> Get(TKey id, CancellationToken cancellationToken = default)
     {
-        var entity = await Entities.SingleOrDefaultAsync(t => t.Id.Equals(id), cancellationToken);
+        var entity = await GetById(id).SingleOrDefaultAsync(cancellationToken);
         return entity ?? throw new NotFoundException();
     }
 
     /// <inheritdoc/>
     public virtual async Task<TEntity> Get(TKey id, ISpecification<TEntity> specification, CancellationToken cancellationToken = default)
     {
-        var query = specification.Apply(Entities);
-
-        var entity = await query.SingleOrDefaultAsync(t => t.Id.Equals(id), cancellationToken);
+        var entity = await specification.Apply(GetById(id)).SingleOrDefaultAsync(cancellationToken);
         return entity ?? throw new NotFoundException();
     }
+
+    /// <summary>
+    /// Gets a query for a single entity by ID.
+    /// </summary>
+    /// <remarks>
+    /// Override to apply filtering (e.g. tenancy or ownership checks) that all
+    /// <see cref="Get(TKey, CancellationToken)"/> overloads should honour.
+    /// </remarks>
+    /// <param name="id">The ID of the entity.</param>
+    /// <returns>A query filtered to the matching entity.</returns>
+    protected virtual IQueryable<TEntity> GetById(TKey id) => Entities.Where(t => t.Id.Equals(id));
 }


### PR DESCRIPTION
Adds a `protected virtual IQueryable<TEntity> GetById(TKey id)` hook to `RepositoryBase` and routes both `Get(id)` overloads through it.

Derived repositories can override `GetById` to apply filtering (tenancy, ownership) that all Get-by-id overloads honour, without overriding each `Get` method — e.g. MooBank's `LogicalAccountRepository` ownership filter.

Behaviour is unchanged for repositories that don't override the hook: the default is `Entities.Where(t => t.Id.Equals(id))`, the same query as before.

All 73 Asm.Domain.Infrastructure tests (and the full suite) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)