### PR TITLE
feat(cqrs): MapPostCreate overloads with request in route params

### DIFF
--- a/src/Asm.Cqrs.AspNetCore/Handlers.cs
+++ b/src/Asm.Cqrs.AspNetCore/Handlers.cs
@@ -41,14 +41,17 @@ internal static class Handlers
     #endregion
 
     #region Advanced CQRS Handlers
-    internal static Delegate CreateCreateHandler<TRequest, TResult>(string routeName, Func<TResult, object> getRouteParams, CommandBinding binding = CommandBinding.None) where TRequest : ICommand<TResult>
+    internal static Delegate CreateCreateHandler<TRequest, TResult>(string routeName, Func<TResult, object> getRouteParams, CommandBinding binding = CommandBinding.None) where TRequest : ICommand<TResult> =>
+        CreateCreateHandler<TRequest, TResult>(routeName, (_, result) => getRouteParams(result), binding);
+
+    internal static Delegate CreateCreateHandler<TRequest, TResult>(string routeName, Func<TRequest, TResult, object> getRouteParams, CommandBinding binding = CommandBinding.None) where TRequest : ICommand<TResult>
     {
         return ParameterBinding<TRequest, TResult>(
             async (request, dispatcher, cancellationToken) =>
             {
                 var result = await dispatcher.Dispatch(request!, cancellationToken);
 
-                return Results.CreatedAtRoute(routeName, getRouteParams(result), result);
+                return Results.CreatedAtRoute(routeName, getRouteParams(request, result), result);
             },
             binding
         );

--- a/src/Asm.Cqrs.AspNetCore/IEndpointRouteBuilderExtensions.cs
+++ b/src/Asm.Cqrs.AspNetCore/IEndpointRouteBuilderExtensions.cs
@@ -63,6 +63,35 @@ public static class IEndpointRouteBuilderExtensions
                  .Produces<TResponse>(StatusCodes.Status201Created);
 
     /// <summary>
+    /// Map a POST request to a command that creates a resource.
+    /// </summary>
+    /// <typeparam name="TRequest">The type of the command.</typeparam>
+    /// <typeparam name="TResponse">The type of the response.</typeparam>
+    /// <param name="endpoints">The <see cref="IEndpointRouteBuilder"/> to add the route to.</param>
+    /// <param name="pattern">The route pattern.</param>
+    /// <param name="routeName">The name of the route that can be used to get the newly created resource.</param>
+    /// <param name="getRouteParams">A delegate that creates the route parameters from the command and the response.</param>
+    /// <returns>A <see cref="RouteHandlerBuilder"/> that can be used to further customise the endpoint.</returns>
+    public static RouteHandlerBuilder MapPostCreate<TRequest, TResponse>(this IEndpointRouteBuilder endpoints, string pattern, string routeName, Func<TRequest, TResponse, object> getRouteParams) where TRequest : ICommand<TResponse> =>
+        endpoints.MapPost(pattern, Handlers.CreateCreateHandler<TRequest, TResponse>(routeName, getRouteParams))
+                 .Produces<TResponse>(StatusCodes.Status201Created);
+
+    /// <summary>
+    /// Map a POST request to a command that creates a resource.
+    /// </summary>
+    /// <typeparam name="TRequest">The type of the command.</typeparam>
+    /// <typeparam name="TResponse">The type of the response.</typeparam>
+    /// <param name="endpoints">The <see cref="IEndpointRouteBuilder"/> to add the route to.</param>
+    /// <param name="pattern">The route pattern.</param>
+    /// <param name="routeName">The name of the route that can be used to get the newly created resource.</param>
+    /// <param name="getRouteParams">A delegate that creates the route parameters from the command and the response.</param>
+    /// <param name="binding">How the handler should bind parameters.</param>
+    /// <returns>A <see cref="RouteHandlerBuilder"/> that can be used to further customise the endpoint.</returns>
+    public static RouteHandlerBuilder MapPostCreate<TRequest, TResponse>(this IEndpointRouteBuilder endpoints, string pattern, string routeName, Func<TRequest, TResponse, object> getRouteParams, CommandBinding binding) where TRequest : ICommand<TResponse> =>
+        endpoints.MapPost(pattern, Handlers.CreateCreateHandler<TRequest, TResponse>(routeName, getRouteParams, binding))
+                 .Produces<TResponse>(StatusCodes.Status201Created);
+
+    /// <summary>
     /// Map a PUT request to a command that creates a resource.
     /// </summary>
     /// <typeparam name="TRequest">The type of the command.</typeparam>


### PR DESCRIPTION
Adds `Func<TRequest, TResponse, object>` overloads of `MapPostCreate` (and the underlying `CreateCreateHandler`) so CreatedAtRoute locations can be built from the command as well as the response — e.g. a route year or parent id that isn't part of the created resource model. The existing response-only overloads delegate to the new one; no behaviour changes for current callers.

Build clean; all 43 Asm.Cqrs.AspNetCore tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)