### PR TITLE
fix(aspnetcore): appName is a friendly name, not the application assembly

### DIFF
--- a/src/Asm.AspNetCore/Extensions/IHostApplicationBuilderExtensions.cs
+++ b/src/Asm.AspNetCore/Extensions/IHostApplicationBuilderExtensions.cs
@@ -20,14 +20,23 @@ public static class IHostApplicationBuilderExtensions
     /// </summary>
     /// <param name="builder">The <see cref="IHostApplicationBuilder"/> instance that this method extends.</param>
     /// <returns>The <see cref="IHostApplicationBuilder"/> instance so that calls can be chained.</returns>
-    public static IHostApplicationBuilder AddStandardOpenTelemetry(this IHostApplicationBuilder builder)
+    public static IHostApplicationBuilder AddStandardOpenTelemetry(this IHostApplicationBuilder builder) =>
+        builder.AddStandardOpenTelemetry(builder.Environment.ApplicationName);
+
+    /// <summary>
+    /// Adds the standard OpenTelemetry configuration.
+    /// </summary>
+    /// <param name="builder">The <see cref="IHostApplicationBuilder"/> instance that this method extends.</param>
+    /// <param name="serviceName">The friendly service name used for the OpenTelemetry resource.</param>
+    /// <returns>The <see cref="IHostApplicationBuilder"/> instance so that calls can be chained.</returns>
+    public static IHostApplicationBuilder AddStandardOpenTelemetry(this IHostApplicationBuilder builder, string serviceName)
     {
         bool hasAppInsights = Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING") != null;
 
         builder.Services.AddOpenTelemetry()
             .ConfigureResource(resourceBuilder =>
             {
-                resourceBuilder.AddService(builder.Environment.ApplicationName, serviceInstanceId: builder.Environment.EnvironmentName);
+                resourceBuilder.AddService(serviceName, serviceInstanceId: builder.Environment.EnvironmentName);
             })
             .WithMetrics(options =>
             {

--- a/src/Asm.AspNetCore/WebApplicationStart.cs
+++ b/src/Asm.AspNetCore/WebApplicationStart.cs
@@ -22,7 +22,7 @@ public class WebApplicationStart
     /// Builds and runs the web application.
     /// </summary>
     /// <param name="args">Command line arguments.</param>
-    /// <param name="appName">The name of the application.</param>
+    /// <param name="appName">The friendly name of the application, used for logging and telemetry.</param>
     /// <param name="addServices">A method to add service mappings.</param>
     /// <param name="addApp">Set up custom middleware.</param>
     /// <param name="addHealthChecks">A method to add health checks.</param>
@@ -36,7 +36,7 @@ public class WebApplicationStart
         {
             Log.Information($"{appName} Starting...");
 
-            var builder = WebApplication.CreateBuilder(new WebApplicationOptions { ApplicationName = appName, Args = args, });
+            var builder = WebApplication.CreateBuilder(args);
 
             if (builder.Environment.IsDevelopment())
             {
@@ -45,8 +45,8 @@ public class WebApplicationStart
                 builder.Logging.AddConsole();
             }
 
-            builder.Host.UseCustomSerilog();
-            builder.AddStandardOpenTelemetry();
+            builder.Host.UseCustomSerilog(appName);
+            builder.AddStandardOpenTelemetry(appName);
 
             addServices(builder);
 

--- a/src/Asm.AspNetCore/WebJobStart.cs
+++ b/src/Asm.AspNetCore/WebJobStart.cs
@@ -86,11 +86,7 @@ public static class WebJobStart
         Host.CreateDefaultBuilder(args)
         .ConfigureWebJobs(configureWebJobs)
         .ConfigureDefaults(args)
-        .ConfigureAppConfiguration((context, appBuilder) =>
-        {
-            context.HostingEnvironment.ApplicationName = appName;
-        })
         .UseEnvironment(Environment.GetEnvironmentVariable(EnvironmentVariables.AspNetCoreEnvironment) ?? Environment.GetEnvironmentVariable(EnvironmentVariables.DotNetEnvironment) ?? "Development")
-        .UseCustomSerilog()
+        .UseCustomSerilog(appName)
         .ConfigureServices(configureServices);
 }

--- a/src/Asm.AspNetCore/WebStart.cs
+++ b/src/Asm.AspNetCore/WebStart.cs
@@ -48,9 +48,8 @@ public static class WebStart<T> where T : class
     /// <returns>The <see cref="IHostBuilder"/> instance.</returns>
     public static IHostBuilder CreateHostBuilder(string[] args, string appName) =>
         Host.CreateDefaultBuilder(args)
-            .UseCustomSerilog()
+            .UseCustomSerilog(appName)
             .ConfigureWebHostDefaults(webBuilder => webBuilder
-                .UseSetting(WebHostDefaults.ApplicationKey, appName)
                 .UseStartup<T>());
 
 }

--- a/src/Asm.Serilog/IHostBuilderExtensions.cs
+++ b/src/Asm.Serilog/IHostBuilderExtensions.cs
@@ -15,4 +15,13 @@ public static class IHostBuilderExtensions
     /// <returns>The <see cref="IHostBuilder"/> instance so that calls can be chained.</returns>
     public static IHostBuilder UseCustomSerilog(this IHostBuilder builder) =>
         builder.UseSerilog((context, configuration) => LoggingConfigurator.ConfigureLogging(configuration, context.Configuration, context.HostingEnvironment));
+
+    /// <summary>
+    /// Use the ASM default Serilog configuration.
+    /// </summary>
+    /// <param name="builder">The <see cref="IHostBuilder"/> instance that this method extends.</param>
+    /// <param name="appName">The friendly application name used for log enrichment.</param>
+    /// <returns>The <see cref="IHostBuilder"/> instance so that calls can be chained.</returns>
+    public static IHostBuilder UseCustomSerilog(this IHostBuilder builder, string appName) =>
+        builder.UseSerilog((context, configuration) => LoggingConfigurator.ConfigureLogging(configuration, context.Configuration, context.HostingEnvironment, appName));
 }

--- a/src/Asm.Serilog/LoggingConfigurator.cs
+++ b/src/Asm.Serilog/LoggingConfigurator.cs
@@ -58,7 +58,19 @@ public static class LoggingConfigurator
     /// <param name="hostEnvironment">The host environment.</param>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="loggerConfiguration"/>, <paramref name="configuration"/>, or <paramref name="hostEnvironment"/> is <c>null</c>.</exception>
     /// <returns>The configured Serilog logger configuration.</returns>
-    public static LoggerConfiguration ConfigureLogging(LoggerConfiguration loggerConfiguration, IConfiguration configuration, IHostEnvironment hostEnvironment)
+    public static LoggerConfiguration ConfigureLogging(LoggerConfiguration loggerConfiguration, IConfiguration configuration, IHostEnvironment hostEnvironment) =>
+        ConfigureLogging(loggerConfiguration, configuration, hostEnvironment, hostEnvironment?.ApplicationName!);
+
+    /// <summary>
+    /// Configures Serilog logging with the specified configuration.
+    /// </summary>
+    /// <param name="loggerConfiguration">The Serilog configuration.</param>
+    /// <param name="configuration">The application configuration.</param>
+    /// <param name="hostEnvironment">The host environment.</param>
+    /// <param name="appName">The friendly application name used for log enrichment.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="loggerConfiguration"/>, <paramref name="configuration"/>, or <paramref name="hostEnvironment"/> is <c>null</c>.</exception>
+    /// <returns>The configured Serilog logger configuration.</returns>
+    public static LoggerConfiguration ConfigureLogging(LoggerConfiguration loggerConfiguration, IConfiguration configuration, IHostEnvironment hostEnvironment, string appName)
     {
         ArgumentNullException.ThrowIfNull(loggerConfiguration);
         ArgumentNullException.ThrowIfNull(configuration);
@@ -66,7 +78,7 @@ public static class LoggingConfigurator
 
         loggerConfiguration
             .Enrich.FromLogContext()
-            .Enrich.WithProperty("App", hostEnvironment.ApplicationName)
+            .Enrich.WithProperty("App", appName)
             .Enrich.WithProperty("Env", hostEnvironment.EnvironmentName)
             .WriteTo.Trace()
             .WriteTo.Console();


### PR DESCRIPTION
`WebApplicationStart`/`WebStart`/`WebJobStart` accepted an `appName` intended as a friendly display name but assigned it to `ApplicationName`, which ASP.NET Core contractually treats as the entry assembly's name. Consequences of passing a genuinely friendly name: hosting startups log a `FileNotFoundException` at every boot (observed in MooBank), Development user secrets resolution via the application assembly silently no-ops, and MVC application-part discovery roots at a nonexistent assembly.

**Change:** `ApplicationName` keeps its framework default (the entry assembly). The friendly name is threaded explicitly to its two real consumers:
- `UseCustomSerilog(string appName)` → `LoggingConfigurator.ConfigureLogging(..., string appName)` — the runtime `App` log property now carries the friendly name (previously it silently used `ApplicationName`, so only the bootstrap logger ever showed the friendly name).
- `AddStandardOpenTelemetry(string serviceName)` — the OTel resource service name.

Existing parameterless overloads keep their current behaviour (derive from `ApplicationName`) for callers outside the start classes.

**Compatibility:** apps passing their real assembly name see identical behaviour. Apps passing friendly names stop logging the startup exception, gain working default user-secrets resolution, and their runtime logs/telemetry now actually carry the friendly name as originally intended.

Build clean; all 839 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)