### PR TITLE
Phase 4: Performance (non-breaking)

### DIFF
--- a/.claude/plans/code-audit-action-plan.md
+++ b/.claude/plans/code-audit-action-plan.md
@@ -125,14 +125,17 @@ Highest-value fixes; all non-breaking. Test-first for each.
 
 ## Phase 4 — Performance (non-breaking)
 
-- [ ] `Hosts` parsing: hoist all six regexes to `[GeneratedRegex]` partials.
-- [ ] `Dispatcher`/`Publisher`: replace LazyCache+`MethodInfo.Invoke` with `static ConcurrentDictionary<(Type,Type), …>` of compiled delegates; drop the LazyCache package dependency (verify nothing else uses it).
-- [ ] `AddAggregateRoots`: hoist `MakeGenericMethod` out of the factory lambda; `Add` → `TryAdd`.
-- [ ] `GetUserName` hot path: cache per request in `HttpContext.Items`; single claims scan; avoid the attribute-list copy in `HttpContextLogProcessor` where possible.
-- [ ] `ImgSetTagHelper`: `Image.Identify` instead of `Image.Load`; `ProcessAsync`; cache `image.Url()`; read cache in all environments or don't write it in dev; `string.Join` for srcset.
-- [ ] `RepositoryBase.Get`: use `FindAsync` (tracked-entity short-circuit) — verify `NotFoundException` semantics preserved.
-- [ ] `Entity.Events`: lazy-init the list.
-- [ ] Smaller: `HexColour.TryParse` span-based; `IPAddressExtensions` string building; `WriteTo.Trace()` dev-only; cache `AzureOAuthOptions.Authority`; cache security-reporting headers; remove `Hosts` finalizer; `TryGetValue` in `ProblemDetailsFactory`; `IntegrityTagHelper` dev-mode cache churn + derive `$v` from the content hash (also fixes the restart-busting bug).
+- [x] `Hosts` parsing: six regexes hoisted to `[GeneratedRegex]` partials; needless finalizer removed.
+- [x] `Dispatcher`/`Publisher`: `MethodInfo.Invoke` + LazyCache replaced with a `static ConcurrentDictionary` of Expression-compiled `Handle` invokers; LazyCache packages dropped (nothing else used them). Direct calls also make `DoNotWrapExceptions` unnecessary.
+- [x] `AddAggregateRoots`: generic `Set`/`AsNoTracking` closed once per type at registration; `Add` → `TryAdd`.
+- [x] `GetUserName`: cached per request in `HttpContext.Items`.
+- [x] `ImgSetTagHelper`: `Image.Identify` (header-only) instead of `Image.Load`; base `Url()` cached; `String.Join` for srcset; cache not written in dev.
+- [x] `Entity.Events`: lazy-init the backing list.
+- [x] `WriteTo.Trace()` Development-only (both overloads).
+- [~] `RepositoryBase.Get`: **skipped** — `FindAsync` would bypass the `GetById` filtering override (tenancy/ownership), a correctness/security regression not worth the tracked-entity round-trip.
+- [~] `TryGetValue` in `ProblemDetailsFactory`: already done in Phase 1d.
+- [~] `AzureOAuthOptions.Authority` cache: **skipped** — caching a computed property in a record is fragile under `with`, for a ~2×/setup gain.
+- [ ] Remaining (smaller, next Phase 4 pass): `HexColour.TryParse` span-based; `IPAddressExtensions` string building; cache security-reporting headers; `IntegrityTagHelper` dev-mode cache churn + derive `$v` from the content hash (also fixes the restart cache-busting bug).
 
 **Acceptance:** full suite green; optional micro-benchmark for dispatcher before/after.
 

--- a/.claude/plans/code-audit-action-plan.md
+++ b/.claude/plans/code-audit-action-plan.md
@@ -135,7 +135,10 @@ Highest-value fixes; all non-breaking. Test-first for each.
 - [~] `RepositoryBase.Get`: **skipped** — `FindAsync` would bypass the `GetById` filtering override (tenancy/ownership), a correctness/security regression not worth the tracked-entity round-trip.
 - [~] `TryGetValue` in `ProblemDetailsFactory`: already done in Phase 1d.
 - [~] `AzureOAuthOptions.Authority` cache: **skipped** — caching a computed property in a record is fragile under `with`, for a ~2×/setup gain.
-- [ ] Remaining (smaller, next Phase 4 pass): `HexColour.TryParse` span-based; `IPAddressExtensions` string building; cache security-reporting headers; `IntegrityTagHelper` dev-mode cache churn + derive `$v` from the content hash (also fixes the restart cache-busting bug).
+- [x] `HexColour`: span-based no-throw parse core shared by ctor/`Parse`/`TryParse` (drops the try/catch failure path, the intermediate normalised strings, and the now-dead validation regex).
+- [x] `IPAddressExtensions.ToCidrString`: dotted address rebuilt via `FromUInt32` instead of per-octet `+=` concatenation + trim.
+- [x] Security-reporting headers: endpoint paths memoised per options instance (`ConditionalWeakTable`); only scheme/host interpolated per response.
+- [x] `IntegrityTagHelper`: `$v` derived from the content hash (was `String.GetHashCode`, randomised per process → busted client caches on every restart); dimension/hash cache no longer written in Development.
 
 **Acceptance:** full suite green; optional micro-benchmark for dispatcher before/after.
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,8 +31,6 @@
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.8.2" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
-    <PackageVersion Include="LazyCache" Version="2.4.0" />
-    <PackageVersion Include="LazyCache.AspNetCore" Version="2.4.0" />
     <PackageVersion Include="MailKit" Version="4.16.0" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions" Version="5.2.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />

--- a/src/Asm.AspNetCore.Mvc/TagHelpers/IntegrityTagHelper.cs
+++ b/src/Asm.AspNetCore.Mvc/TagHelpers/IntegrityTagHelper.cs
@@ -122,9 +122,17 @@ public abstract class IntegrityTagHelper : TagHelper
         };
 
         string hashBase64 = $"{prefix}-" + Convert.ToBase64String(hash);
-        string calculatedUrl = UrlHelper.Content(url.Replace("$v", Math.Abs(hashBase64.GetHashCode()).ToString()));
 
-        MemoryCache.Set(cacheKey, (calculatedUrl, hashBase64));
+        // Derive the cache-busting token from the content hash itself. String.GetHashCode is
+        // randomised per process, so hashing the base64 string produced a different $v on every
+        // application restart, busting client caches even when the file had not changed.
+        string version = Convert.ToHexStringLower(hash.AsSpan(0, 8));
+        string calculatedUrl = UrlHelper.Content(url.Replace("$v", version));
+
+        if (!HostingEnvironment.IsDevelopment())
+        {
+            MemoryCache.Set(cacheKey, (calculatedUrl, hashBase64));
+        }
 
         output.Attributes.RemoveAll(UrlSourceAttributeName);
         output.Attributes.RemoveAll(UrlOutputAttributeName);

--- a/src/Asm.AspNetCore/Extensions/HttpContextExtensions.cs
+++ b/src/Asm.AspNetCore/Extensions/HttpContextExtensions.cs
@@ -8,6 +8,8 @@ namespace Asm.AspNetCore;
 /// </summary>
 public static class HttpContextExtensions
 {
+    private const string UserNameItemKey = "Asm.UserName";
+
     /// <summary>
     /// Gets the name of the current user.
     /// </summary>
@@ -15,7 +17,26 @@ public static class HttpContextExtensions
     /// <returns>The current user's name, or "-" if the current user is not available.</returns>
     public static string GetUserName(this HttpContext? context)
     {
-        if (context?.User?.Identity is not ClaimsIdentity identity)
+        if (context is null)
+        {
+            return "-";
+        }
+
+        // Cache per request: this runs once per log record / activity / request-enrichment, so
+        // re-scanning the claims each time would be wasteful.
+        if (context.Items.TryGetValue(UserNameItemKey, out var cached) && cached is string cachedName)
+        {
+            return cachedName;
+        }
+
+        var name = ResolveUserName(context);
+        context.Items[UserNameItemKey] = name;
+        return name;
+    }
+
+    private static string ResolveUserName(HttpContext context)
+    {
+        if (context.User?.Identity is not ClaimsIdentity identity)
         {
             return "-";
         }

--- a/src/Asm.AspNetCore/Reporting/SecurityReportingHeaderBuilder.cs
+++ b/src/Asm.AspNetCore/Reporting/SecurityReportingHeaderBuilder.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Http;
 
 namespace Asm.AspNetCore.Reporting;
@@ -8,14 +9,22 @@ namespace Asm.AspNetCore.Reporting;
 /// </summary>
 public static class SecurityReportingHeaderBuilder
 {
+    // Only the scheme and host vary per request; the endpoint paths depend solely on the
+    // (startup-configured) options. Memoise the trimmed paths per options instance so the
+    // trimming doesn't run on every HTML response. ConditionalWeakTable keeps this bounded —
+    // weak keys, and in practice a single options instance for the app's lifetime.
+    private static readonly ConditionalWeakTable<SecurityReportingOptions, EndpointPaths> PathCache = new();
+
+    private sealed record EndpointPaths(string IntegrityPath, string CspPath);
+
     /// <summary>
     /// Builds the <c>Reporting-Endpoints</c> header value.
     /// </summary>
     public static string BuildReportingEndpoints(HttpContext ctx, SecurityReportingOptions options)
     {
-        var integrityUrl = BuildEndpointUrl(ctx, options.RoutePrefix, options.IntegrityRoute);
-        var cspUrl = BuildEndpointUrl(ctx, options.RoutePrefix, options.CspRoute);
-        return $"{options.IntegrityGroupName}=\"{integrityUrl}\", {options.CspGroupName}=\"{cspUrl}\"";
+        var paths = GetPaths(options);
+        var origin = GetOrigin(ctx);
+        return $"{options.IntegrityGroupName}=\"{origin}{paths.IntegrityPath}\", {options.CspGroupName}=\"{origin}{paths.CspPath}\"";
     }
 
     /// <summary>
@@ -23,12 +32,18 @@ public static class SecurityReportingHeaderBuilder
     /// </summary>
     public static string BuildReportTo(HttpContext ctx, SecurityReportingOptions options)
     {
-        var integrityUrl = BuildEndpointUrl(ctx, options.RoutePrefix, options.IntegrityRoute);
-        var cspUrl = BuildEndpointUrl(ctx, options.RoutePrefix, options.CspRoute);
-        return $"{{\"group\":\"{options.IntegrityGroupName}\",\"max_age\":{options.MaxAgeSeconds},\"endpoints\":[{{\"url\":\"{integrityUrl}\"}}]}}, "
-             + $"{{\"group\":\"{options.CspGroupName}\",\"max_age\":{options.MaxAgeSeconds},\"endpoints\":[{{\"url\":\"{cspUrl}\"}}]}}";
+        var paths = GetPaths(options);
+        var origin = GetOrigin(ctx);
+        return $"{{\"group\":\"{options.IntegrityGroupName}\",\"max_age\":{options.MaxAgeSeconds},\"endpoints\":[{{\"url\":\"{origin}{paths.IntegrityPath}\"}}]}}, "
+             + $"{{\"group\":\"{options.CspGroupName}\",\"max_age\":{options.MaxAgeSeconds},\"endpoints\":[{{\"url\":\"{origin}{paths.CspPath}\"}}]}}";
     }
 
-    private static string BuildEndpointUrl(HttpContext ctx, string routePrefix, string route) =>
-        $"{ctx.Request.Scheme}://{ctx.Request.Host}/{routePrefix.TrimStart('/').TrimEnd('/')}/{route.TrimStart('/')}";
+    private static EndpointPaths GetPaths(SecurityReportingOptions options) =>
+        PathCache.GetValue(options, static o =>
+        {
+            var prefix = o.RoutePrefix.TrimStart('/').TrimEnd('/');
+            return new EndpointPaths($"/{prefix}/{o.IntegrityRoute.TrimStart('/')}", $"/{prefix}/{o.CspRoute.TrimStart('/')}");
+        });
+
+    private static string GetOrigin(HttpContext ctx) => $"{ctx.Request.Scheme}://{ctx.Request.Host}";
 }

--- a/src/Asm.Cqrs/Asm.Cqrs.csproj
+++ b/src/Asm.Cqrs/Asm.Cqrs.csproj
@@ -5,8 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LazyCache" />
-    <PackageReference Include="LazyCache.AspNetCore" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 

--- a/src/Asm.Cqrs/Dispatcher.cs
+++ b/src/Asm.Cqrs/Dispatcher.cs
@@ -1,59 +1,54 @@
-﻿using System.Reflection;
+using System.Collections.Concurrent;
+using System.Linq.Expressions;
 using Asm.Cqrs.Commands;
 using Asm.Cqrs.Queries;
-using LazyCache;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Asm.Cqrs;
 
-internal class Dispatcher(IServiceProvider serviceProvider, IAppCache cache) : IQueryDispatcher, ICommandDispatcher
+internal class Dispatcher(IServiceProvider serviceProvider) : IQueryDispatcher, ICommandDispatcher
 {
     private static readonly Type QueryHandlerGenericType = typeof(IQueryHandler<,>);
     private static readonly Type CommandHandlerGenericType = typeof(ICommandHandler<,>);
     private static readonly Type CommandHandlerVoidGenericType = typeof(ICommandHandler<>);
 
-    // Cache key prefix for combined caching
-    private const string HandlerInfoCacheKeyPrefix = "HandlerInfo_";
+    // Compiled Handle invokers, cached for the process lifetime. Calling Handle through a compiled
+    // delegate avoids per-dispatch reflection (MethodInfo.Invoke + argument array) and surfaces a
+    // handler's exceptions as their own type rather than a TargetInvocationException.
+    private static readonly ConcurrentDictionary<(Type Request, Type Response), (Type HandlerType, Delegate Invoker)> QueryHandlers = new();
+    private static readonly ConcurrentDictionary<(Type Request, Type Response), (Type HandlerType, Delegate Invoker)> CommandHandlers = new();
+    private static readonly ConcurrentDictionary<Type, (Type HandlerType, Delegate Invoker)> VoidCommandHandlers = new();
 
     public ValueTask<TResponse> Dispatch<TResponse>(IQuery<TResponse> query, CancellationToken cancellationToken = default)
     {
         var queryType = query.GetType();
-        var responseType = typeof(TResponse);
 
-        var (handlerType, handleMethod) = cache.GetOrAdd(
-            $"{HandlerInfoCacheKeyPrefix}Query_{queryType.FullName}_{responseType.FullName}",
-            () =>
+        var (handlerType, invoker) = QueryHandlers.GetOrAdd(
+            (queryType, typeof(TResponse)),
+            static key =>
             {
-                var type = QueryHandlerGenericType.MakeGenericType(queryType, responseType);
-                var method = type.GetMethod(nameof(IQueryHandler<IQuery<TResponse>, TResponse>.Handle))!;
-                return (type, method);
+                var handlerType = QueryHandlerGenericType.MakeGenericType(key.Request, key.Response);
+                return (handlerType, BuildInvoker<TResponse>(handlerType, key.Request));
             });
 
         var handler = serviceProvider.GetRequiredService(handlerType);
-        var result = handleMethod.Invoke(handler, BindingFlags.DoNotWrapExceptions, null, [query, cancellationToken], null);
-
-        return (ValueTask<TResponse>)result!;
+        return ((Func<object, object, CancellationToken, ValueTask<TResponse>>)invoker)(handler, query, cancellationToken);
     }
 
     public ValueTask<TResponse> Dispatch<TResponse>(ICommand<TResponse> command, CancellationToken cancellationToken = default)
     {
         var commandType = command.GetType();
-        var responseType = typeof(TResponse);
 
-        // Cache both type and method in a single operation
-        var (handlerType, handleMethod) = cache.GetOrAdd(
-            $"{HandlerInfoCacheKeyPrefix}Command_{commandType.FullName}_{responseType.FullName}",
-            () =>
+        var (handlerType, invoker) = CommandHandlers.GetOrAdd(
+            (commandType, typeof(TResponse)),
+            static key =>
             {
-                var type = CommandHandlerGenericType.MakeGenericType(commandType, responseType);
-                var method = type.GetMethod(nameof(ICommandHandler<ICommand<TResponse>, TResponse>.Handle))!;
-                return (type, method);
+                var handlerType = CommandHandlerGenericType.MakeGenericType(key.Request, key.Response);
+                return (handlerType, BuildInvoker<TResponse>(handlerType, key.Request));
             });
 
         var handler = serviceProvider.GetRequiredService(handlerType);
-        var result = handleMethod.Invoke(handler, BindingFlags.DoNotWrapExceptions, null, [command, cancellationToken], null);
-
-        return (ValueTask<TResponse>)result!;
+        return ((Func<object, object, CancellationToken, ValueTask<TResponse>>)invoker)(handler, command, cancellationToken);
     }
 
     public ValueTask Dispatch(ICommand command, CancellationToken cancellationToken = default)
@@ -70,19 +65,43 @@ internal class Dispatcher(IServiceProvider serviceProvider, IAppCache cache) : I
                 $"Command '{commandType.Name}' returns a response; dispatch it with Dispatch<TResponse>(ICommand<TResponse>) rather than the void Dispatch(ICommand) overload.");
         }
 
-        // Cache both type and method in a single operation
-        var (handlerType, handleMethod) = cache.GetOrAdd(
-            $"{HandlerInfoCacheKeyPrefix}CommandVoid_{commandType.FullName}",
-            () =>
+        var (handlerType, invoker) = VoidCommandHandlers.GetOrAdd(
+            commandType,
+            static request =>
             {
-                var type = CommandHandlerVoidGenericType.MakeGenericType(commandType);
-                var method = type.GetMethod(nameof(ICommandHandler<ICommand>.Handle))!;
-                return (type, method);
+                var handlerType = CommandHandlerVoidGenericType.MakeGenericType(request);
+                return (handlerType, BuildVoidInvoker(handlerType, request));
             });
 
         var handler = serviceProvider.GetRequiredService(handlerType);
-        var result = handleMethod.Invoke(handler, BindingFlags.DoNotWrapExceptions, null, [command, cancellationToken], null);
+        return ((Func<object, object, CancellationToken, ValueTask>)invoker)(handler, command, cancellationToken);
+    }
 
-        return (ValueTask)result!;
+    private static Func<object, object, CancellationToken, ValueTask<TResponse>> BuildInvoker<TResponse>(Type handlerType, Type requestType)
+    {
+        var (handlerParam, requestParam, cancellationTokenParam, call) = BuildHandleCall(handlerType, requestType);
+        return Expression.Lambda<Func<object, object, CancellationToken, ValueTask<TResponse>>>(call, handlerParam, requestParam, cancellationTokenParam).Compile();
+    }
+
+    private static Func<object, object, CancellationToken, ValueTask> BuildVoidInvoker(Type handlerType, Type requestType)
+    {
+        var (handlerParam, requestParam, cancellationTokenParam, call) = BuildHandleCall(handlerType, requestType);
+        return Expression.Lambda<Func<object, object, CancellationToken, ValueTask>>(call, handlerParam, requestParam, cancellationTokenParam).Compile();
+    }
+
+    private static (ParameterExpression Handler, ParameterExpression Request, ParameterExpression CancellationToken, MethodCallExpression Call) BuildHandleCall(Type handlerType, Type requestType)
+    {
+        var handleMethod = handlerType.GetMethod("Handle")!;
+        var handlerParam = Expression.Parameter(typeof(object), "handler");
+        var requestParam = Expression.Parameter(typeof(object), "request");
+        var cancellationTokenParam = Expression.Parameter(typeof(CancellationToken), "cancellationToken");
+
+        var call = Expression.Call(
+            Expression.Convert(handlerParam, handlerType),
+            handleMethod,
+            Expression.Convert(requestParam, requestType),
+            cancellationTokenParam);
+
+        return (handlerParam, requestParam, cancellationTokenParam, call);
     }
 }

--- a/src/Asm.Cqrs/IServiceCollectionExtensions.cs
+++ b/src/Asm.Cqrs/IServiceCollectionExtensions.cs
@@ -44,7 +44,6 @@ public static class IServiceCollectionExtensions
         }
 
         services.TryAddTransient<ICommandDispatcher, Dispatcher>();
-        services.AddLazyCache();
 
         return services;
     }
@@ -62,7 +61,6 @@ public static class IServiceCollectionExtensions
         services.TryAddEnumerable(ServiceDescriptor.Transient<ICommandHandler<TRequest, TResponse>, THandler>());
 
         services.TryAddTransient<ICommandDispatcher, Dispatcher>();
-        services.AddLazyCache();
 
         return services;
     }
@@ -79,7 +77,6 @@ public static class IServiceCollectionExtensions
         services.TryAddEnumerable(ServiceDescriptor.Transient<ICommandHandler<TRequest>, THandler>());
 
         services.TryAddTransient<ICommandDispatcher, Dispatcher>();
-        services.AddLazyCache();
 
         return services;
     }
@@ -110,7 +107,6 @@ public static class IServiceCollectionExtensions
         }
 
         services.TryAddTransient<IQueryDispatcher, Dispatcher>();
-        services.AddLazyCache();
 
         return services;
     }
@@ -128,7 +124,6 @@ public static class IServiceCollectionExtensions
         services.TryAddEnumerable(ServiceDescriptor.Transient<IQueryHandler<TRequest, TResponse>, THandler>());
 
         services.TryAddTransient<IQueryDispatcher, Dispatcher>();
-        services.AddLazyCache();
 
         return services;
     }

--- a/src/Asm.Domain.Infrastructure/Asm.Domain.Infrastructure.csproj
+++ b/src/Asm.Domain.Infrastructure/Asm.Domain.Infrastructure.csproj
@@ -5,8 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LazyCache" />
-    <PackageReference Include="LazyCache.AspNetCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" />

--- a/src/Asm.Domain.Infrastructure/IServiceCollectionExtensions.cs
+++ b/src/Asm.Domain.Infrastructure/IServiceCollectionExtensions.cs
@@ -94,7 +94,6 @@ public static class AsmDomainInfrastructureIServiceCollectionExtensions
         }
 
         services.TryAddTransient<IPublisher, Publisher>();
-        services.AddLazyCache();
 
         return services;
     }
@@ -110,7 +109,6 @@ public static class AsmDomainInfrastructureIServiceCollectionExtensions
     {
         services.TryAddEnumerable(ServiceDescriptor.Transient<IDomainEventHandler<TDomainEvent>, THandler>());
         services.TryAddTransient<IPublisher, Publisher>();
-        services.AddLazyCache();
 
         return services;
     }

--- a/src/Asm.Domain.Infrastructure/IServiceCollectionExtensions.cs
+++ b/src/Asm.Domain.Infrastructure/IServiceCollectionExtensions.cs
@@ -50,19 +50,15 @@ public static class AsmDomainInfrastructureIServiceCollectionExtensions
         {
             var queryableGeneric = IQueryableType.MakeGenericType(type);
 
-            services.Add(new ServiceDescriptor(queryableGeneric, sp =>
+            // Close the generic methods once per type at registration, not on every resolution.
+            var genericSet = DbContextSetMethod.MakeGenericMethod(type);
+            var genericAsNoTracking = AsNoTrackingMethod.MakeGenericMethod(type);
+
+            services.TryAdd(new ServiceDescriptor(queryableGeneric, sp =>
             {
                 IReadOnlyDbContext context = sp.GetRequiredService<TContext>();
-
-                var genericSet = DbContextSetMethod.MakeGenericMethod(type);
-
-                var res = genericSet.Invoke(context, null);
-
-                var genericAsNoTracking = AsNoTrackingMethod.MakeGenericMethod(type);
-
-                var res2 = genericAsNoTracking.Invoke(null, [res]);
-
-                return res2!;
+                var set = genericSet.Invoke(context, null);
+                return genericAsNoTracking.Invoke(null, [set])!;
             }, ServiceLifetime.Transient));
         }
         return services;

--- a/src/Asm.Domain.Infrastructure/Publisher.cs
+++ b/src/Asm.Domain.Infrastructure/Publisher.cs
@@ -1,38 +1,48 @@
-﻿using System.Reflection;
-using LazyCache;
+using System.Collections.Concurrent;
+using System.Linq.Expressions;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Asm.Domain.Infrastructure;
 
-internal class Publisher(IServiceProvider serviceProvider, IAppCache cache) : IPublisher
+internal class Publisher(IServiceProvider serviceProvider) : IPublisher
 {
     private static readonly Type DomainEventHandlerGenericType = typeof(IDomainEventHandler<>);
-    private const string HandlerInfoCacheKeyPrefix = "DomainEventHandler_Info_";
+
+    // Compiled Handle invokers cached for the process lifetime — avoids per-publish reflection and
+    // surfaces a handler's exceptions as their own type rather than a TargetInvocationException.
+    private static readonly ConcurrentDictionary<Type, (Type HandlerType, Func<object, object, CancellationToken, ValueTask> Invoker)> Handlers = new();
 
     public async ValueTask Publish<TDomainEvent>(TDomainEvent domainEvent, CancellationToken cancellationToken = default)
         where TDomainEvent : IDomainEvent
     {
         var eventType = domainEvent.GetType();
 
-        // Cache both type and method in a single operation
-        var (handlerType, handleMethod) = cache.GetOrAdd(
-            $"{HandlerInfoCacheKeyPrefix}{eventType.FullName}",
-            () =>
-            {
-                var type = DomainEventHandlerGenericType.MakeGenericType(eventType);
-                var method = type.GetMethod(nameof(IDomainEventHandler<IDomainEvent>.Handle))!;
-                return (type, method);
-            });
+        var (handlerType, invoker) = Handlers.GetOrAdd(eventType, static type =>
+        {
+            var handlerType = DomainEventHandlerGenericType.MakeGenericType(type);
+            var handleMethod = handlerType.GetMethod("Handle")!;
+
+            var handlerParam = Expression.Parameter(typeof(object), "handler");
+            var eventParam = Expression.Parameter(typeof(object), "domainEvent");
+            var cancellationTokenParam = Expression.Parameter(typeof(CancellationToken), "cancellationToken");
+
+            var call = Expression.Call(
+                Expression.Convert(handlerParam, handlerType),
+                handleMethod,
+                Expression.Convert(eventParam, type),
+                cancellationTokenParam);
+
+            var invoker = Expression.Lambda<Func<object, object, CancellationToken, ValueTask>>(call, handlerParam, eventParam, cancellationTokenParam).Compile();
+            return (handlerType, invoker);
+        });
 
         var handlers = serviceProvider.GetServices(handlerType);
 
         // Publish sequentially: handlers commonly share the scoped DomainDbContext that is
         // mid-save, and EF Core forbids concurrent operations on one context instance.
-        // DoNotWrapExceptions surfaces a handler's synchronous throw as its own type rather
-        // than a TargetInvocationException.
         foreach (var handler in handlers)
         {
-            await ((ValueTask)handleMethod.Invoke(handler, BindingFlags.DoNotWrapExceptions, null, [domainEvent, cancellationToken], null)!).ConfigureAwait(false);
+            await invoker(handler!, domainEvent, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Asm.Domain/Entity.cs
+++ b/src/Asm.Domain/Entity.cs
@@ -5,9 +5,15 @@
 /// </summary>
 public abstract class Entity : IEntity
 {
+    private List<IDomainEvent>? _events;
+
     /// <summary>
     /// Domain events that have been raised by the entity.
     /// </summary>
-    public ICollection<IDomainEvent> Events { get; } = [];
+    /// <remarks>
+    /// The backing list is allocated lazily on first access, so entities materialised from queries
+    /// (which never raise events) don't pay for it.
+    /// </remarks>
+    public ICollection<IDomainEvent> Events => _events ??= [];
 }
 

--- a/src/Asm.Net/IPAddressExtensions.cs
+++ b/src/Asm.Net/IPAddressExtensions.cs
@@ -52,22 +52,9 @@ public static class IPAddressExtensions
             }
         }
 
-        uint byteMask = 0b1111_1111_0000_0000_0000_0000_0000_0000;
+        uint maskedAddress = addressNumber & maskNumber;
 
-        var maskedAddress = (addressNumber & maskNumber);
-
-        string newIp = String.Empty;
-
-        for (int i = 0; i < 4; i++)
-        {
-            newIp += ((maskedAddress & byteMask) >> ((3 - i) * 8)).ToString() + ".";
-
-            byteMask >>= 8;
-        }
-
-        newIp = newIp[0..^1];
-
-        return newIp + "/" + cidrNumber.ToString();
+        return $"{FromUInt32(maskedAddress)}/{cidrNumber}";
     }
 
     /// <summary>

--- a/src/Asm.Serilog/LoggingConfigurator.cs
+++ b/src/Asm.Serilog/LoggingConfigurator.cs
@@ -28,7 +28,6 @@ public static class LoggingConfigurator
             .Enrich.WithProperty("App", appName)
             .Enrich.WithProperty("Env", Env)
             .MinimumLevel.Information()
-            .WriteTo.Trace()
             .WriteTo.Console();
 
         var seqHost = Environment.GetEnvironmentVariable("Seq__Host") ?? Environment.GetEnvironmentVariable("Seq:Host");
@@ -44,6 +43,9 @@ public static class LoggingConfigurator
 
         if (Env == "Development")
         {
+            // Trace goes through OutputDebugString even with no listener attached, so it is
+            // Development-only rather than a per-event cost in production.
+            configuration.WriteTo.Trace();
             configuration.WriteTo.File(Path.Combine("logs", "Log.log"), rollingInterval: RollingInterval.Day);
         }
 
@@ -80,7 +82,6 @@ public static class LoggingConfigurator
             .Enrich.FromLogContext()
             .Enrich.WithProperty("App", appName)
             .Enrich.WithProperty("Env", hostEnvironment.EnvironmentName)
-            .WriteTo.Trace()
             .WriteTo.Console();
 
         IConfigurationSection logLevelConfig = configuration.GetSection("Logging").GetSection("LogLevel");
@@ -113,6 +114,9 @@ public static class LoggingConfigurator
 
         if (hostEnvironment.IsDevelopment())
         {
+            // Trace goes through OutputDebugString even with no listener attached, so it is
+            // Development-only rather than a per-event cost in production.
+            loggerConfiguration.WriteTo.Trace();
             loggerConfiguration.WriteTo.File(Path.Combine("logs", "Log.log"), rollingInterval: RollingInterval.Day);
         }
 

--- a/src/Asm.Umbraco/TagHelpers/ImgSetTagHelper.cs
+++ b/src/Asm.Umbraco/TagHelpers/ImgSetTagHelper.cs
@@ -63,20 +63,16 @@ public class ImgSetTagHelper(IWebHostEnvironment webHostEnvironment, IMemoryCach
         var altText = image.Value<string>("umbracoAltText");
         altText = String.IsNullOrWhiteSpace(altText) ? String.Empty : altText;
 
-        string srcset = String.Empty;
-        foreach (var img in Images.Skip(1))
-        {
-            var scaling = img.Value<float?>("scaling");
+        var url = image.Url();
 
-            if (scaling == null) continue;
-
-            srcset += $", {FormatSrcsetEntry(img.Url(), scaling.Value)}";
-        }
-        srcset = srcset.TrimStart(", ");
+        var srcset = String.Join(", ", Images.Skip(1)
+            .Select(img => (Url: img.Url(), Scaling: img.Value<float?>("scaling")))
+            .Where(x => x.Scaling is not null)
+            .Select(x => FormatSrcsetEntry(x.Url, x.Scaling!.Value)));
 
         output.TagName = "img";
 
-        output.Attributes.Add("src", image.Url());
+        output.Attributes.Add("src", url);
         output.Attributes.Add("srcset", srcset);
         output.Attributes.Add("alt", altText);
 
@@ -85,23 +81,32 @@ public class ImgSetTagHelper(IWebHostEnvironment webHostEnvironment, IMemoryCach
 
         if (height == 0 || width == 0)
         {
-            if (!WebHostEnvironment.IsDevelopment() && MemoryCache.TryGetValue(image.Url(), out (int Width, int Height) data))
+            var development = WebHostEnvironment.IsDevelopment();
+
+            if (!development && MemoryCache.TryGetValue(url, out (int Width, int Height) data))
             {
                 width = data.Width;
                 height = data.Height;
             }
             else
             {
-                string path = ToPhysicalPath(WebHostEnvironment.WebRootPath, image.Url());
+                string path = ToPhysicalPath(WebHostEnvironment.WebRootPath, url);
 
                 if (!File.Exists(path)) return;
 
                 try
                 {
-                    using var imageFile = Image.Load(path);
-                    width = imageFile.Width;
-                    height = imageFile.Height;
-                    MemoryCache.Set(image.Url(), (width, height));
+                    // Identify reads only the image header rather than decoding the whole image.
+                    var info = Image.Identify(path);
+                    if (info is null) return;
+
+                    width = info.Width;
+                    height = info.Height;
+
+                    if (!development)
+                    {
+                        MemoryCache.Set(url, (width, height));
+                    }
                 }
                 catch
                 {

--- a/src/Asm.Win32/Hosts.cs
+++ b/src/Asm.Win32/Hosts.cs
@@ -9,7 +9,7 @@ namespace Asm.Win32;
 /// <summary>
 /// Class for controlling the Windows Hosts file.
 /// </summary>
-public sealed class Hosts : IDisposable
+public sealed partial class Hosts : IDisposable
 {
     #region Constants
     private static readonly string DefaultHostsFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "drivers", "etc", "hosts");
@@ -116,13 +116,6 @@ public sealed class Hosts : IDisposable
         ReadHosts(hosts);
     }
 
-    /// <summary>
-    /// Finializer.
-    /// </summary>
-    ~Hosts()
-    {
-        this.Dispose(false);
-    }
     #endregion
 
     #region Public Methods
@@ -192,8 +185,20 @@ public sealed class Hosts : IDisposable
     /// </summary>
     public void Dispose()
     {
-        Dispose(true);
-        GC.SuppressFinalize(this);
+        if (_disposed)
+        {
+            return;
+        }
+
+        _pollTimer?.Dispose();
+        lock (_lock)
+        {
+            if (ReferenceEquals(_instance, this))
+            {
+                _instance = null;
+            }
+        }
+        _disposed = true;
     }
     #endregion
 
@@ -218,8 +223,7 @@ public sealed class Hosts : IDisposable
 
             if (line == null) break;
 
-            Regex blankRegex = new(@"^$");
-            Match match = blankRegex.Match(line);
+            Match match = BlankRegex().Match(line);
 
             if (match.Success)
             {
@@ -227,8 +231,7 @@ public sealed class Hosts : IDisposable
                 continue;
             }
 
-            Regex commentEntryCommentMatch = new(@"^[#]{1}?([^\s]*)\s?([^#]+)#{1}?(.*)$");
-            match = commentEntryCommentMatch.Match(line);
+            match = CommentedEntryWithCommentRegex().Match(line);
             if (match.Success)
             {
 
@@ -243,8 +246,7 @@ public sealed class Hosts : IDisposable
                 continue;
             }
 
-            Regex commentEntryMatch = new(@"^[#]{1}?([^\s]*)\s?([^#]+)$");
-            match = commentEntryMatch.Match(line);
+            match = CommentedEntryRegex().Match(line);
             if (match.Success)
             {
 
@@ -259,8 +261,7 @@ public sealed class Hosts : IDisposable
                 continue;
             }
 
-            Regex commentMatch = new(@"^[#]{1}?(.*)$");
-            match = commentMatch.Match(line);
+            match = CommentRegex().Match(line);
 
             if (match.Success)
             {
@@ -268,8 +269,7 @@ public sealed class Hosts : IDisposable
                 continue;
             }
 
-            Regex entryCommentMatch = new(@"^([^\s#]+)\s+([^#]+)#(.*)$");
-            match = entryCommentMatch.Match(line);
+            match = EntryWithCommentRegex().Match(line);
 
             if (match.Success)
             {
@@ -285,8 +285,7 @@ public sealed class Hosts : IDisposable
                 continue;
             }
 
-            Regex entryMatch = new(@"^([^\s#]+)(?:\s+([^#]+))?$");
-            match = entryMatch.Match(line);
+            match = EntryRegex().Match(line);
 
             if (match.Success)
             {
@@ -334,23 +333,22 @@ public sealed class Hosts : IDisposable
         HostsFileChanged?.Invoke(this, EventArgs.Empty);
     }
 
-    private void Dispose(bool disposing)
-    {
-        if (!_disposed)
-        {
-            if (disposing)
-            {
-                _pollTimer?.Dispose();
-                lock (_lock)
-                {
-                    if (ReferenceEquals(_instance, this))
-                    {
-                        _instance = null;
-                    }
-                }
-            }
-            _disposed = true;
-        }
-    }
+    [GeneratedRegex(@"^$")]
+    private static partial Regex BlankRegex();
+
+    [GeneratedRegex(@"^[#]{1}?([^\s]*)\s?([^#]+)#{1}?(.*)$")]
+    private static partial Regex CommentedEntryWithCommentRegex();
+
+    [GeneratedRegex(@"^[#]{1}?([^\s]*)\s?([^#]+)$")]
+    private static partial Regex CommentedEntryRegex();
+
+    [GeneratedRegex(@"^[#]{1}?(.*)$")]
+    private static partial Regex CommentRegex();
+
+    [GeneratedRegex(@"^([^\s#]+)\s+([^#]+)#(.*)$")]
+    private static partial Regex EntryWithCommentRegex();
+
+    [GeneratedRegex(@"^([^\s#]+)(?:\s+([^#]+))?$")]
+    private static partial Regex EntryRegex();
     #endregion
 }

--- a/src/Asm/Drawing/HexColour.cs
+++ b/src/Asm/Drawing/HexColour.cs
@@ -2,7 +2,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Text.RegularExpressions;
 
 namespace Asm.Drawing;
 
@@ -11,10 +10,8 @@ namespace Asm.Drawing;
 /// </summary>
 [JsonConverter(typeof(HexColourJsonConverter))]
 [CLSCompliant(false)]
-public readonly partial struct HexColour : IEquatable<HexColour>
+public readonly struct HexColour : IEquatable<HexColour>
 {
-    private static readonly Regex HexColourRegex = GeneratedHexColourRegex();
-
     private readonly uint _value; // Stack-allocated integer instead of heap-allocated string
 
     /// <summary>
@@ -27,12 +24,8 @@ public readonly partial struct HexColour : IEquatable<HexColour>
         if (String.IsNullOrWhiteSpace(hexValue))
             throw new ArgumentException("Hex colour value cannot be null or whitespace.", nameof(hexValue));
 
-        var normalizedValue = NormalizeHexColour(hexValue);
-
-        if (!IsValidHexColour(normalizedValue))
+        if (!TryParseValue(hexValue, out _value))
             throw new FormatException($"Invalid hex colour format: {hexValue}");
-
-        _value = ParseHexToUInt(normalizedValue);
     }
 
     /// <summary>
@@ -66,22 +59,14 @@ public readonly partial struct HexColour : IEquatable<HexColour>
     /// <returns><see langword="true"/> if the parsing was successful; otherwise, <see langword="false"/>.</returns>
     public static bool TryParse(string? hexValue, out HexColour result)
     {
-        if (String.IsNullOrWhiteSpace(hexValue))
+        if (String.IsNullOrWhiteSpace(hexValue) || !TryParseValue(hexValue, out var value))
         {
             result = default;
             return false;
         }
 
-        try
-        {
-            result = new HexColour(hexValue);
-            return true;
-        }
-        catch (Exception ex) when (ex is ArgumentException || ex is FormatException)
-        {
-            result = default;
-            return false;
-        }
+        result = new HexColour(value);
+        return true;
     }
 
     /// <summary>
@@ -92,29 +77,45 @@ public readonly partial struct HexColour : IEquatable<HexColour>
     /// <returns>The parsed <see cref="HexColour"/> instance.</returns>
     public static HexColour Parse(string hexValue) => new(hexValue);
 
-    private static string NormalizeHexColour(string hexValue)
+    /// <summary>
+    /// Parses a hex colour, tolerating an optional leading <c>#</c> and both the shorthand
+    /// (<c>RGB</c>) and full (<c>RRGGBB</c>) forms, without allocating or throwing on failure.
+    /// </summary>
+    private static bool TryParseValue(ReadOnlySpan<char> hexValue, out uint value)
     {
+        value = 0;
+
         var trimmed = hexValue.Trim();
 
-        if (!trimmed.StartsWith('#'))
-            trimmed = '#' + trimmed;
+        // Drop a single leading '#'.
+        if (trimmed.Length > 0 && trimmed[0] == '#')
+            trimmed = trimmed[1..];
 
-        if (trimmed.Length == 4)
+        Span<char> digits = stackalloc char[6];
+
+        if (trimmed.Length == 3)
         {
-            trimmed = $"#{trimmed[1]}{trimmed[1]}{trimmed[2]}{trimmed[2]}{trimmed[3]}{trimmed[3]}";
+            digits[0] = digits[1] = trimmed[0];
+            digits[2] = digits[3] = trimmed[1];
+            digits[4] = digits[5] = trimmed[2];
+        }
+        else if (trimmed.Length == 6)
+        {
+            trimmed.CopyTo(digits);
+        }
+        else
+        {
+            return false;
         }
 
-        return trimmed.ToUpperInvariant();
-    }
+        // Reject anything that isn't a hex digit; HexNumber otherwise tolerates surrounding
+        // whitespace, which the original format did not.
+        foreach (var c in digits)
+        {
+            if (!Uri.IsHexDigit(c)) return false;
+        }
 
-    private static uint ParseHexToUInt(string normalizedHex)
-    {
-        return UInt32.Parse(normalizedHex[1..], NumberStyles.HexNumber);
-    }
-
-    private static bool IsValidHexColour(string hexValue)
-    {
-        return HexColourRegex.IsMatch(hexValue);
+        return UInt32.TryParse(digits, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out value);
     }
 
     /// <summary>
@@ -180,9 +181,6 @@ public readonly partial struct HexColour : IEquatable<HexColour>
     /// <param name="right">The right operand.</param>
     /// <returns><see langword="true"/> if both instances are unequal; otherwise, <see langword="false"/>.</returns>
     public static bool operator !=(HexColour left, HexColour right) => !left.Equals(right);
-
-    [GeneratedRegex(@"^#[0-9A-F]{6}$", RegexOptions.IgnoreCase)]
-    private static partial Regex GeneratedHexColourRegex();
 }
 
 internal class HexColourJsonConverter : JsonConverter<HexColour>

--- a/tests/Asm.Domain.Infrastructure.Tests/AggregateRoots.feature
+++ b/tests/Asm.Domain.Infrastructure.Tests/AggregateRoots.feature
@@ -82,7 +82,7 @@ Scenario: AddAggregateRoots with null services and roots throws exception
     Given I have a null service collection for AggregateRoots
     And I have an assembly with one aggregate root type
     When I call AddAggregateRoots on the null collection
-    Then an exception of type 'System.NullReferenceException' is thrown
+    Then an exception of type 'System.ArgumentNullException' is thrown
 
 @Unit
 Scenario: AddAggregateRoots with null services and no roots returns null

--- a/tests/Asm.Domain.Infrastructure.Tests/AggregateRoots.feature.cs
+++ b/tests/Asm.Domain.Infrastructure.Tests/AggregateRoots.feature.cs
@@ -595,7 +595,7 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
     await testRunner.WhenAsync("I call AddAggregateRoots on the null collection", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
 #line 85
-    await testRunner.ThenAsync("an exception of type \'System.NullReferenceException\' is thrown", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
+    await testRunner.ThenAsync("an exception of type \'System.ArgumentNullException\' is thrown", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }
             await this.ScenarioCleanupAsync();

--- a/tests/Asm.Domain.Infrastructure.Tests/DomainEventRegistration.feature
+++ b/tests/Asm.Domain.Infrastructure.Tests/DomainEventRegistration.feature
@@ -108,12 +108,6 @@ Scenario: AddDomainEvent registers IPublisher only once
     Then only one IPublisher registration should exist
 
 @Unit
-Scenario: AddDomainEvent registers LazyCache
-    Given I have a service collection
-    When I call AddDomainEvent for a specific handler
-    Then IAppCache should be registered
-
-@Unit
 Scenario: Registered handler can be resolved
     Given I have a service collection
     And I call AddDomainEvent for a specific handler

--- a/tests/Asm.Domain.Infrastructure.Tests/DomainEventRegistration.feature.cs
+++ b/tests/Asm.Domain.Infrastructure.Tests/DomainEventRegistration.feature.cs
@@ -105,7 +105,7 @@ namespace Asm.Domain.Infrastructure.Tests
         
         private static global::Reqnroll.Formatters.RuntimeSupport.FeatureLevelCucumberMessages InitializeCucumberMessages()
         {
-            return new global::Reqnroll.Formatters.RuntimeSupport.FeatureLevelCucumberMessages("DomainEventRegistration.feature.ndjson", 20);
+            return new global::Reqnroll.Formatters.RuntimeSupport.FeatureLevelCucumberMessages("DomainEventRegistration.feature.ndjson", 19);
         }
         
         async System.Threading.Tasks.ValueTask Xunit.IAsyncLifetime.InitializeAsync()
@@ -742,17 +742,17 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             await this.ScenarioCleanupAsync();
         }
         
-        [global::Xunit.FactAttribute(DisplayName="AddDomainEvent registers LazyCache")]
+        [global::Xunit.FactAttribute(DisplayName="Registered handler can be resolved")]
         [global::Xunit.TraitAttribute("FeatureTitle", "Domain Event Registration")]
-        [global::Xunit.TraitAttribute("Description", "AddDomainEvent registers LazyCache")]
+        [global::Xunit.TraitAttribute("Description", "Registered handler can be resolved")]
         [global::Xunit.TraitAttribute("Category", "Unit")]
-        public async global::System.Threading.Tasks.Task AddDomainEventRegistersLazyCache()
+        public async global::System.Threading.Tasks.Task RegisteredHandlerCanBeResolved()
         {
             string[] tagsOfScenario = new string[] {
                     "Unit"};
             global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
             string pickleIndex = "16";
-            global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("AddDomainEvent registers LazyCache", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
+            global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Registered handler can be resolved", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
 #line 111
@@ -769,48 +769,12 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
     await testRunner.GivenAsync("I have a service collection", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
 #line 113
-    await testRunner.WhenAsync("I call AddDomainEvent for a specific handler", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
-#line hidden
-#line 114
-    await testRunner.ThenAsync("IAppCache should be registered", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
-#line hidden
-            }
-            await this.ScenarioCleanupAsync();
-        }
-        
-        [global::Xunit.FactAttribute(DisplayName="Registered handler can be resolved")]
-        [global::Xunit.TraitAttribute("FeatureTitle", "Domain Event Registration")]
-        [global::Xunit.TraitAttribute("Description", "Registered handler can be resolved")]
-        [global::Xunit.TraitAttribute("Category", "Unit")]
-        public async global::System.Threading.Tasks.Task RegisteredHandlerCanBeResolved()
-        {
-            string[] tagsOfScenario = new string[] {
-                    "Unit"};
-            global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
-            string pickleIndex = "17";
-            global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Registered handler can be resolved", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
-            string[] tagsOfRule = ((string[])(null));
-            global::Reqnroll.RuleInfo ruleInfo = null;
-#line 117
-this.ScenarioInitialize(scenarioInfo, ruleInfo);
-#line hidden
-            if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
-            {
-                await testRunner.SkipScenarioAsync();
-            }
-            else
-            {
-                await this.ScenarioStartAsync();
-#line 118
-    await testRunner.GivenAsync("I have a service collection", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
-#line hidden
-#line 119
     await testRunner.AndAsync("I call AddDomainEvent for a specific handler", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
 #line hidden
-#line 120
+#line 114
     await testRunner.WhenAsync("I build the service provider", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
-#line 121
+#line 115
     await testRunner.ThenAsync("the handler can be resolved", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }

--- a/tests/Asm.Domain.Infrastructure.Tests/DomainEventRegistrationSteps.cs
+++ b/tests/Asm.Domain.Infrastructure.Tests/DomainEventRegistrationSteps.cs
@@ -1,6 +1,5 @@
 using System.Reflection;
 using Asm.Domain;
-using LazyCache;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Moq;
@@ -334,13 +333,6 @@ public class DomainEventRegistrationSteps(ScenarioContext context)
             d.ImplementationType == typeof(TestDomainEventHandler));
 
         Assert.Equal(1, handlerCount);
-    }
-
-    [Then(@"IAppCache should be registered")]
-    public void ThenIAppCacheShouldBeRegistered()
-    {
-        var lazyCacheDescriptor = _services.FirstOrDefault(d => d.ServiceType == typeof(IAppCache));
-        Assert.NotNull(lazyCacheDescriptor);
     }
 
     [Then(@"the handler can be resolved")]


### PR DESCRIPTION
## Phase 4 — Performance (non-breaking)

Hot-path allocation and reflection removals from the audit. No public API changes; full solution green in Release (908 tests).

### Dispatch / reflection
- **`Dispatcher` / `Publisher`**: replaced `MethodInfo.Invoke` + LazyCache with a `static ConcurrentDictionary` of Expression-compiled `Handle` invokers. Direct calls also make the `DoNotWrapExceptions` dance unnecessary. **LazyCache is dropped entirely** (packages, DI registrations, `Directory.Packages.props`) — nothing else referenced it.
- **`AddAggregateRoots`**: the generic `Set` / `AsNoTracking` methods are now closed once per type at registration instead of on every resolution; `Add` → `TryAdd`.

### Parsing / string building
- **`Hosts`**: six inline regexes hoisted to `[GeneratedRegex]` partials; the redundant finalizer removed.
- **`HexColour`**: a single span-based, no-throw parse core is shared by the constructor, `Parse` and `TryParse` — removing the exception-driven `TryParse` failure path, the intermediate normalised strings, and the now-dead validation regex.
- **`IPAddressExtensions.ToCidrString`**: dotted address rebuilt via `FromUInt32` instead of per-octet `+=` concatenation + trim.

### Request hot paths
- **`GetUserName`**: cached per request in `HttpContext.Items` (runs once per log record / activity / enrichment).
- **`SecurityReportingHeaderBuilder`**: endpoint paths memoised per options instance (`ConditionalWeakTable`); only scheme/host are interpolated per HTML response.
- **`ImgSetTagHelper`**: `Image.Identify` (header-only) instead of `Image.Load` (full decode); base `Url()` cached; `String.Join` srcset; cache not written in Development.
- **`Entity.Events`**: lazy-inits its backing list.
- **`WriteTo.Trace()`**: Development-only in both `ConfigureLogging` overloads.

### Bug fixed along the way
- **`IntegrityTagHelper` `$v` cache-busting token** was derived from `String.GetHashCode`, which is randomised per process — so the token changed on every application restart and busted client caches for files that had not changed. It is now derived from the content hash. The dimension/hash cache is also no longer written in Development, where it is never read.

### Deliberately skipped
- **`RepositoryBase.Get` → `FindAsync`**: would bypass the overridable `GetById` filtering hook (tenancy/ownership) — a correctness/security regression not worth a tracked-entity round-trip.
- **Caching `AzureOAuthOptions.Authority`**: fragile under record `with`, for a ~2×/setup gain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
