### PR TITLE
Phase 5 Batch 6: Nybble arithmetic

### DIFF
--- a/docs/migration-v4.md
+++ b/docs/migration-v4.md
@@ -105,3 +105,66 @@ MapCommand<TRequest>(pattern, CommandBinding binding = CommandBinding.Parameters
 **What to change:**
 - Void `MapCommand<TRequest>` / `MapPutCommand<TRequest>` are source-compatible with v3 — the status-code parameter is retained (renamed `returnStatusCode` → `statusCode`, same position and `204` default), now with `binding` added after it.
 - If you passed `binding` **positionally** to a body-returning map (`MapCommand<Cmd, Result>(pattern, CommandBinding.Body)`), it now needs to be named — `MapCommand<Cmd, Result>(pattern, binding: CommandBinding.Body)` — because `statusCode` is now the second parameter. Everything else is source-compatible (both `statusCode` and `binding` are optional).
+
+## Batch 6 — Nybble arithmetic
+
+> ⚠️ **Silent behavioural change — no compiler will flag most call sites.** The `+` operator on `Asm.Nybble` now performs **arithmetic addition**. In v3 it performed **concatenation** (packing two 4-bit values into a byte). Code that compiles unchanged against v4 will silently compute different results.
+
+### What changed
+
+In v3 the `+` operators (and the underlying `Add` methods) were documented as "adds" but actually **concatenated** — they shifted the left operand up four bits and OR-ed the nybble into the low four bits:
+
+```csharp
+// v3
+Nybble a = new(0x5), b = new(0x3);
+byte result = a + b;   // 0x53 == 83  (concatenation, despite the "Add" name)
+```
+
+In v4 `+` does what the documentation always promised — it **adds**:
+
+```csharp
+// v4
+Nybble a = new(0x5), b = new(0x3);
+Nybble result = a + b; // 0x8 == 8   (arithmetic sum)
+```
+
+### Overflow decision
+
+`Nybble + Nybble` **wraps modulo 16** (only the low four bits are kept), mirroring how a physical 4-bit register overflows. It never throws and always yields a valid `Nybble`:
+
+```csharp
+Nybble max = new(0xF);
+Nybble wrapped = max + max;  // 30 & 0xF == 14  (0xE)
+```
+
+The integer-mixed operators wrap in the usual unchecked manner for their result type.
+
+### Return types are now coherent (breaking)
+
+Each operator now returns the type that arithmetic addition naturally yields, rather than the old mismatched set (`byte` / `ulong` / `int`):
+
+| Expression        | v3 return (concatenation) | v4 return (arithmetic)      |
+|-------------------|---------------------------|-----------------------------|
+| `Nybble + Nybble` | `byte`                    | `Nybble` (wraps mod 16)     |
+| `uint + Nybble`   | `ulong`                   | `uint`                      |
+| `byte + Nybble`   | `int`                     | `int`                       |
+
+The `Nybble.Add(...)` static methods changed correspondingly — they too now add instead of concatenate, matching their long-standing XML docs.
+
+### Keeping the old concatenation behaviour
+
+The v3 concatenation is preserved under explicit, well-named members — replace old `+`/`Add` concatenation call sites with these:
+
+```csharp
+Nybble.Combine(high, low);      // two nybbles -> byte  (was: nybbleA + nybbleB)
+Nybble.Append(uintValue, n);    // append nybble -> ulong (was: uintValue + nybble)
+Nybble.Append(byteValue, n);    // append nybble -> int   (was: byteValue + nybble)
+```
+
+`Combine(0x5, 0x3)` returns `0x53` (83) — identical to what `+` produced in v3.
+
+### What to change
+
+- **Audit every `a + b` / `Nybble.Add(...)` involving a `Nybble`.** If you relied on the packing behaviour (building a byte/word out of nybbles), switch to `Nybble.Combine` / `Nybble.Append`.
+- If you genuinely wanted addition, you were previously getting the wrong answer — `+` now returns the correct arithmetic sum (and, for two nybbles, a `Nybble` that wraps mod 16).
+- Update any variable declarations whose type was inferred from the old return type (e.g. `byte r = a + b;` no longer compiles for two nybbles — the result is now a `Nybble`).

--- a/src/Asm/Nybble.cs
+++ b/src/Asm/Nybble.cs
@@ -77,87 +77,101 @@ public readonly struct Nybble
     }
 
     /// <summary>
-    ///
-    /// </summary>
-    /// <param name="a"></param>
-    /// <param name="b"></param>
-    /// <returns></returns>
-    public static byte operator +(Nybble a, Nybble b)
-    {
-        return Add(a, b);
-    }
-
-    /// <summary>
-    ///
-    /// </summary>
-    /// <param name="a"></param>
-    /// <param name="b"></param>
-    /// <returns></returns>
-    public static ulong operator +(uint a, Nybble b)
-    {
-        return Add(a, b);
-    }
-
-    /// <summary>
-    ///
-    /// </summary>
-    /// <param name="a"></param>
-    /// <param name="b"></param>
-    /// <returns></returns>
-    public static int operator +(byte a, Nybble b)
-    {
-        return Add(a, b);
-    }
-
-    /// <summary>
-    /// Adds two nybbles together.
+    /// Adds two nybbles together arithmetically.
     /// </summary>
     /// <param name="a">The first nybble.</param>
     /// <param name="b">The second nybble.</param>
-    /// <returns>the sum of the two nybbles.</returns>
-    public static byte Add(Nybble a, Nybble b)
-    {
-        byte aa = a.ByteValue;
-        byte bb = b.ByteValue;
-
-        aa <<= 4;
-
-        return Convert.ToByte(aa | bb);
-    }
+    /// <returns>
+    /// A <see cref="Nybble"/> holding the arithmetic sum. The result wraps modulo 16 (that is, only the
+    /// low four bits are kept), so <c>15 + 15</c> yields <c>14</c>, mirroring how a 4-bit register overflows.
+    /// To concatenate two nybbles into a byte (the pre-v4 behaviour of this operator) use <see cref="Combine"/>.
+    /// </returns>
+    public static Nybble operator +(Nybble a, Nybble b) => Add(a, b);
 
     /// <summary>
-    /// Adds a nybble to an integer.
+    /// Adds a nybble to an unsigned integer arithmetically.
     /// </summary>
-    /// <param name="a">The integer to add to.</param>
+    /// <param name="a">The unsigned integer to add to.</param>
     /// <param name="b">The nybble to add.</param>
-    /// <returns>the sum of the two numbers.</returns>
-    public static ulong Add(uint a, Nybble b)
-    {
-        long aa = a;
-        byte bb = b.ByteValue;
-
-        aa <<= 4;
-
-        long cc = aa | bb;
-
-        return Convert.ToUInt64(cc);
-    }
+    /// <returns>
+    /// The arithmetic sum as a <see cref="uint"/>. The result wraps in the usual unchecked <see cref="uint"/>
+    /// manner on overflow. To append the nybble as an extra hexadecimal digit (the pre-v4 behaviour of this
+    /// operator) use <see cref="Append(uint, Nybble)"/>.
+    /// </returns>
+    public static uint operator +(uint a, Nybble b) => Add(a, b);
 
     /// <summary>
-    /// Adds a nybble to a byte.
+    /// Adds a nybble to a byte arithmetically.
     /// </summary>
     /// <param name="a">The byte to add to.</param>
     /// <param name="b">The nybble to add.</param>
-    /// <returns>the sum of the two numbers.</returns>
-    public static int Add(byte a, Nybble b)
-    {
-        int aa = a;
-        byte bb = b.ByteValue;
+    /// <returns>
+    /// The arithmetic sum as an <see cref="int"/> (matching C# numeric promotion for <see cref="byte"/> addition).
+    /// To append the nybble as an extra hexadecimal digit (the pre-v4 behaviour of this operator) use
+    /// <see cref="Append(byte, Nybble)"/>.
+    /// </returns>
+    public static int operator +(byte a, Nybble b) => Add(a, b);
 
-        aa <<= 4;
+    /// <summary>
+    /// Adds two nybbles together arithmetically, wrapping modulo 16.
+    /// </summary>
+    /// <param name="a">The first nybble.</param>
+    /// <param name="b">The second nybble.</param>
+    /// <returns>The arithmetic sum as a <see cref="Nybble"/>; values above 15 wrap modulo 16.</returns>
+    public static Nybble Add(Nybble a, Nybble b) => new((byte)((a.ByteValue + b.ByteValue) & MaxValue));
 
-        return aa | bb;
-    }
+    /// <summary>
+    /// Adds a nybble to an unsigned integer arithmetically.
+    /// </summary>
+    /// <param name="a">The unsigned integer to add to.</param>
+    /// <param name="b">The nybble to add.</param>
+    /// <returns>The arithmetic sum as a <see cref="uint"/>.</returns>
+    public static uint Add(uint a, Nybble b) => a + (uint)b.ByteValue;
+
+    /// <summary>
+    /// Adds a nybble to a byte arithmetically.
+    /// </summary>
+    /// <param name="a">The byte to add to.</param>
+    /// <param name="b">The nybble to add.</param>
+    /// <returns>The arithmetic sum as an <see cref="int"/>.</returns>
+    public static int Add(byte a, Nybble b) => a + b.ByteValue;
+
+    /// <summary>
+    /// Combines two nybbles into a single byte, placing <paramref name="high"/> in the upper four bits
+    /// and <paramref name="low"/> in the lower four bits.
+    /// </summary>
+    /// <param name="high">The nybble to place in the most-significant four bits.</param>
+    /// <param name="low">The nybble to place in the least-significant four bits.</param>
+    /// <returns>The combined byte. For example, <c>Combine(0x5, 0x3)</c> returns <c>0x53</c> (83).</returns>
+    /// <remarks>
+    /// This is the concatenation behaviour that the <c>+</c> operator performed prior to v4. Use this method
+    /// where you previously relied on <c>nybbleA + nybbleB</c> producing a combined byte.
+    /// </remarks>
+    public static byte Combine(Nybble high, Nybble low) => (byte)((high.ByteValue << 4) | low.ByteValue);
+
+    /// <summary>
+    /// Appends a nybble to an unsigned integer as an extra least-significant hexadecimal digit
+    /// (shifts <paramref name="value"/> left four bits and stores <paramref name="nybble"/> in the low four bits).
+    /// </summary>
+    /// <param name="value">The value to shift left and append to.</param>
+    /// <param name="nybble">The nybble to place in the least-significant four bits.</param>
+    /// <returns>The combined value as a <see cref="ulong"/>. For example, <c>Append(0x5u, 0x3)</c> returns <c>0x53</c> (83).</returns>
+    /// <remarks>
+    /// This is the concatenation behaviour that the <c>uint + Nybble</c> operator performed prior to v4.
+    /// </remarks>
+    public static ulong Append(uint value, Nybble nybble) => ((ulong)value << 4) | nybble.ByteValue;
+
+    /// <summary>
+    /// Appends a nybble to a byte as an extra least-significant hexadecimal digit
+    /// (shifts <paramref name="value"/> left four bits and stores <paramref name="nybble"/> in the low four bits).
+    /// </summary>
+    /// <param name="value">The value to shift left and append to.</param>
+    /// <param name="nybble">The nybble to place in the least-significant four bits.</param>
+    /// <returns>The combined value as an <see cref="int"/>. For example, <c>Append((byte)0x5, 0x3)</c> returns <c>0x53</c> (83).</returns>
+    /// <remarks>
+    /// This is the concatenation behaviour that the <c>byte + Nybble</c> operator performed prior to v4.
+    /// </remarks>
+    public static int Append(byte value, Nybble nybble) => (value << 4) | nybble.ByteValue;
 
     /// <summary>
     /// Checks equality a given nybble against this one.

--- a/tests/Asm.Tests/Nybble.feature
+++ b/tests/Asm.Tests/Nybble.feature
@@ -17,6 +17,20 @@ Scenario: Add two Nybbles
     Given I have a Nybble with value 5
     And I have another Nybble with value 3
     When I add the two Nybbles
+    Then the byte result should be 8
+
+@Unit
+Scenario: Adding two Nybbles wraps modulo 16 on overflow
+    Given I have a Nybble with value 15
+    And I have another Nybble with value 15
+    When I add the two Nybbles
+    Then the byte result should be 14
+
+@Unit
+Scenario: Combine two Nybbles into a byte
+    Given I have a Nybble with value 5
+    And I have another Nybble with value 3
+    When I combine the two Nybbles
     Then the byte result should be 83
 
 @Unit
@@ -59,6 +73,13 @@ Scenario: Add uint and Nybble
     Given I have a uint value 5
     And I have a Nybble with value 3
     When I add the uint and Nybble
+    Then the uint result should be 8
+
+@Unit
+Scenario: Append a Nybble to a uint
+    Given I have a uint value 5
+    And I have a Nybble with value 3
+    When I append the Nybble to the uint
     Then the ulong result should be 83
 
 @Unit
@@ -66,6 +87,13 @@ Scenario: Add byte and Nybble
     Given I have a byte value 5
     And I have a Nybble with value 3
     When I add the byte and Nybble
+    Then the integer result should be 8
+
+@Unit
+Scenario: Append a Nybble to a byte
+    Given I have a byte value 5
+    And I have a Nybble with value 3
+    When I append the Nybble to the byte
     Then the integer result should be 83
 
 @Unit

--- a/tests/Asm.Tests/Nybble.feature.cs
+++ b/tests/Asm.Tests/Nybble.feature.cs
@@ -105,7 +105,7 @@ namespace Asm.Tests
         
         private static global::Reqnroll.Formatters.RuntimeSupport.FeatureLevelCucumberMessages InitializeCucumberMessages()
         {
-            return new global::Reqnroll.Formatters.RuntimeSupport.FeatureLevelCucumberMessages("Nybble.feature.ndjson", 19);
+            return new global::Reqnroll.Formatters.RuntimeSupport.FeatureLevelCucumberMessages("Nybble.feature.ndjson", 23);
         }
         
         async System.Threading.Tasks.ValueTask Xunit.IAsyncLifetime.InitializeAsync()
@@ -238,6 +238,84 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
     await testRunner.WhenAsync("I add the two Nybbles", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
 #line 20
+    await testRunner.ThenAsync("the byte result should be 8", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
+#line hidden
+            }
+            await this.ScenarioCleanupAsync();
+        }
+        
+        [global::Xunit.FactAttribute(DisplayName="Adding two Nybbles wraps modulo 16 on overflow")]
+        [global::Xunit.TraitAttribute("FeatureTitle", "Nybble")]
+        [global::Xunit.TraitAttribute("Description", "Adding two Nybbles wraps modulo 16 on overflow")]
+        [global::Xunit.TraitAttribute("Category", "Unit")]
+        public async global::System.Threading.Tasks.Task AddingTwoNybblesWrapsModulo16OnOverflow()
+        {
+            string[] tagsOfScenario = new string[] {
+                    "Unit"};
+            global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
+            string pickleIndex = "3";
+            global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Adding two Nybbles wraps modulo 16 on overflow", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
+            string[] tagsOfRule = ((string[])(null));
+            global::Reqnroll.RuleInfo ruleInfo = null;
+#line 23
+this.ScenarioInitialize(scenarioInfo, ruleInfo);
+#line hidden
+            if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
+            {
+                await testRunner.SkipScenarioAsync();
+            }
+            else
+            {
+                await this.ScenarioStartAsync();
+#line 24
+    await testRunner.GivenAsync("I have a Nybble with value 15", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
+#line hidden
+#line 25
+    await testRunner.AndAsync("I have another Nybble with value 15", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
+#line hidden
+#line 26
+    await testRunner.WhenAsync("I add the two Nybbles", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
+#line hidden
+#line 27
+    await testRunner.ThenAsync("the byte result should be 14", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
+#line hidden
+            }
+            await this.ScenarioCleanupAsync();
+        }
+        
+        [global::Xunit.FactAttribute(DisplayName="Combine two Nybbles into a byte")]
+        [global::Xunit.TraitAttribute("FeatureTitle", "Nybble")]
+        [global::Xunit.TraitAttribute("Description", "Combine two Nybbles into a byte")]
+        [global::Xunit.TraitAttribute("Category", "Unit")]
+        public async global::System.Threading.Tasks.Task CombineTwoNybblesIntoAByte()
+        {
+            string[] tagsOfScenario = new string[] {
+                    "Unit"};
+            global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
+            string pickleIndex = "4";
+            global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Combine two Nybbles into a byte", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
+            string[] tagsOfRule = ((string[])(null));
+            global::Reqnroll.RuleInfo ruleInfo = null;
+#line 30
+this.ScenarioInitialize(scenarioInfo, ruleInfo);
+#line hidden
+            if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
+            {
+                await testRunner.SkipScenarioAsync();
+            }
+            else
+            {
+                await this.ScenarioStartAsync();
+#line 31
+    await testRunner.GivenAsync("I have a Nybble with value 5", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
+#line hidden
+#line 32
+    await testRunner.AndAsync("I have another Nybble with value 3", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
+#line hidden
+#line 33
+    await testRunner.WhenAsync("I combine the two Nybbles", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
+#line hidden
+#line 34
     await testRunner.ThenAsync("the byte result should be 83", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }
@@ -253,11 +331,11 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             string[] tagsOfScenario = new string[] {
                     "Unit"};
             global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
-            string pickleIndex = "3";
+            string pickleIndex = "5";
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Convert Nybble array to uint", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
-#line 23
+#line 37
 this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
             if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
@@ -267,13 +345,13 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-#line 24
+#line 38
     await testRunner.GivenAsync("I have a Nybble array with values 1, 2, 3, 4", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
-#line 25
+#line 39
     await testRunner.WhenAsync("I convert the array to uint", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
-#line 26
+#line 40
     await testRunner.ThenAsync("the uint result should be 0x1234", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }
@@ -284,9 +362,9 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
         [global::Xunit.TraitAttribute("FeatureTitle", "Nybble")]
         [global::Xunit.TraitAttribute("Description", "Check equality of two Nybbles")]
         [global::Xunit.TraitAttribute("Category", "Unit")]
-        [global::Xunit.InlineDataAttribute("5", "5", "true", "4", new string[0])]
-        [global::Xunit.InlineDataAttribute("5", "3", "false", "5", new string[0])]
-        [global::Xunit.InlineDataAttribute("3", "5", "false", "6", new string[0])]
+        [global::Xunit.InlineDataAttribute("5", "5", "true", "6", new string[0])]
+        [global::Xunit.InlineDataAttribute("5", "3", "false", "7", new string[0])]
+        [global::Xunit.InlineDataAttribute("3", "5", "false", "8", new string[0])]
         public async global::System.Threading.Tasks.Task CheckEqualityOfTwoNybbles(string nybble, string otherNybble, string result, string @__pickleIndex, string[] exampleTags)
         {
             string[] @__tags = new string[] {
@@ -304,7 +382,7 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Check equality of two Nybbles", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
-#line 29
+#line 43
 this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
             if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
@@ -314,16 +392,16 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-#line 30
+#line 44
     await testRunner.GivenAsync(string.Format("I have a Nybble with value {0}", nybble), ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
-#line 31
+#line 45
     await testRunner.AndAsync(string.Format("I have another Nybble with value {0}", otherNybble), ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
 #line hidden
-#line 32
+#line 46
     await testRunner.WhenAsync("I check equality", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
-#line 33
+#line 47
     await testRunner.ThenAsync(string.Format("the boolean result should be {0}", result), ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }
@@ -339,11 +417,11 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             string[] tagsOfScenario = new string[] {
                     "Unit"};
             global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
-            string pickleIndex = "7";
+            string pickleIndex = "9";
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Convert byte to Nybbles", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
-#line 41
+#line 55
 this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
             if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
@@ -353,13 +431,13 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-#line 42
+#line 56
     await testRunner.GivenAsync("I have a byte with value 0x12", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
-#line 43
+#line 57
     await testRunner.WhenAsync("I convert the byte to Nybbles", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
-#line 44
+#line 58
     await testRunner.ThenAsync("the Nybble array should be 1, 2", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }
@@ -375,11 +453,11 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             string[] tagsOfScenario = new string[] {
                     "Unit"};
             global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
-            string pickleIndex = "8";
+            string pickleIndex = "10";
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Convert bytes to Nybbles", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
-#line 47
+#line 61
 this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
             if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
@@ -389,13 +467,13 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-#line 48
+#line 62
     await testRunner.GivenAsync("I have a byte array with values 0x12, 0x34", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
-#line 49
+#line 63
     await testRunner.WhenAsync("I convert the byte array to Nybbles", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
-#line 50
+#line 64
     await testRunner.ThenAsync("the Nybble array should be 1, 2, 3, 4", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }
@@ -409,11 +487,11 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
         {
             string[] tagsOfScenario = ((string[])(null));
             global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
-            string pickleIndex = "9";
+            string pickleIndex = "11";
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Convert int to Nybbles", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
-#line 52
+#line 66
 this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
             if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
@@ -423,13 +501,13 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-#line 53
+#line 67
     await testRunner.GivenAsync("I have an int with value 0x12345678", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
-#line 54
+#line 68
     await testRunner.WhenAsync("I convert the int to Nybbles", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
-#line 55
+#line 69
     await testRunner.ThenAsync("the full Nybble array should be 1, 2, 3, 4, 5, 6, 7, 8", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }
@@ -445,11 +523,11 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             string[] tagsOfScenario = new string[] {
                     "Unit"};
             global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
-            string pickleIndex = "10";
+            string pickleIndex = "12";
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Add uint and Nybble", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
-#line 58
+#line 72
 this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
             if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
@@ -459,16 +537,55 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-#line 59
+#line 73
     await testRunner.GivenAsync("I have a uint value 5", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
-#line 60
+#line 74
     await testRunner.AndAsync("I have a Nybble with value 3", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
 #line hidden
-#line 61
+#line 75
     await testRunner.WhenAsync("I add the uint and Nybble", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
-#line 62
+#line 76
+    await testRunner.ThenAsync("the uint result should be 8", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
+#line hidden
+            }
+            await this.ScenarioCleanupAsync();
+        }
+        
+        [global::Xunit.FactAttribute(DisplayName="Append a Nybble to a uint")]
+        [global::Xunit.TraitAttribute("FeatureTitle", "Nybble")]
+        [global::Xunit.TraitAttribute("Description", "Append a Nybble to a uint")]
+        [global::Xunit.TraitAttribute("Category", "Unit")]
+        public async global::System.Threading.Tasks.Task AppendANybbleToAUint()
+        {
+            string[] tagsOfScenario = new string[] {
+                    "Unit"};
+            global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
+            string pickleIndex = "13";
+            global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Append a Nybble to a uint", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
+            string[] tagsOfRule = ((string[])(null));
+            global::Reqnroll.RuleInfo ruleInfo = null;
+#line 79
+this.ScenarioInitialize(scenarioInfo, ruleInfo);
+#line hidden
+            if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
+            {
+                await testRunner.SkipScenarioAsync();
+            }
+            else
+            {
+                await this.ScenarioStartAsync();
+#line 80
+    await testRunner.GivenAsync("I have a uint value 5", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
+#line hidden
+#line 81
+    await testRunner.AndAsync("I have a Nybble with value 3", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
+#line hidden
+#line 82
+    await testRunner.WhenAsync("I append the Nybble to the uint", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
+#line hidden
+#line 83
     await testRunner.ThenAsync("the ulong result should be 83", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }
@@ -484,11 +601,11 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             string[] tagsOfScenario = new string[] {
                     "Unit"};
             global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
-            string pickleIndex = "11";
+            string pickleIndex = "14";
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Add byte and Nybble", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
-#line 65
+#line 86
 this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
             if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
@@ -498,16 +615,55 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-#line 66
+#line 87
     await testRunner.GivenAsync("I have a byte value 5", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
-#line 67
+#line 88
     await testRunner.AndAsync("I have a Nybble with value 3", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
 #line hidden
-#line 68
+#line 89
     await testRunner.WhenAsync("I add the byte and Nybble", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
-#line 69
+#line 90
+    await testRunner.ThenAsync("the integer result should be 8", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
+#line hidden
+            }
+            await this.ScenarioCleanupAsync();
+        }
+        
+        [global::Xunit.FactAttribute(DisplayName="Append a Nybble to a byte")]
+        [global::Xunit.TraitAttribute("FeatureTitle", "Nybble")]
+        [global::Xunit.TraitAttribute("Description", "Append a Nybble to a byte")]
+        [global::Xunit.TraitAttribute("Category", "Unit")]
+        public async global::System.Threading.Tasks.Task AppendANybbleToAByte()
+        {
+            string[] tagsOfScenario = new string[] {
+                    "Unit"};
+            global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
+            string pickleIndex = "15";
+            global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Append a Nybble to a byte", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
+            string[] tagsOfRule = ((string[])(null));
+            global::Reqnroll.RuleInfo ruleInfo = null;
+#line 93
+this.ScenarioInitialize(scenarioInfo, ruleInfo);
+#line hidden
+            if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
+            {
+                await testRunner.SkipScenarioAsync();
+            }
+            else
+            {
+                await this.ScenarioStartAsync();
+#line 94
+    await testRunner.GivenAsync("I have a byte value 5", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
+#line hidden
+#line 95
+    await testRunner.AndAsync("I have a Nybble with value 3", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
+#line hidden
+#line 96
+    await testRunner.WhenAsync("I append the Nybble to the byte", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
+#line hidden
+#line 97
     await testRunner.ThenAsync("the integer result should be 83", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }
@@ -523,11 +679,11 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             string[] tagsOfScenario = new string[] {
                     "Unit"};
             global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
-            string pickleIndex = "12";
+            string pickleIndex = "16";
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Check inequality of two Nybbles", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
-#line 72
+#line 100
 this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
             if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
@@ -537,16 +693,16 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-#line 73
+#line 101
     await testRunner.GivenAsync("I have a Nybble with value 5", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
-#line 74
+#line 102
     await testRunner.AndAsync("I have another Nybble with value 3", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
 #line hidden
-#line 75
+#line 103
     await testRunner.WhenAsync("I check inequality", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
-#line 76
+#line 104
     await testRunner.ThenAsync("the boolean result should be true", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }
@@ -562,11 +718,11 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             string[] tagsOfScenario = new string[] {
                     "Unit"};
             global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
-            string pickleIndex = "13";
+            string pickleIndex = "17";
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Check inequality returns false for equal Nybbles", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
-#line 79
+#line 107
 this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
             if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
@@ -576,16 +732,16 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-#line 80
+#line 108
     await testRunner.GivenAsync("I have a Nybble with value 5", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
-#line 81
+#line 109
     await testRunner.AndAsync("I have another Nybble with value 5", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
 #line hidden
-#line 82
+#line 110
     await testRunner.WhenAsync("I check inequality", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
-#line 83
+#line 111
     await testRunner.ThenAsync("the boolean result should be false", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }
@@ -601,11 +757,11 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             string[] tagsOfScenario = new string[] {
                     "Unit"};
             global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
-            string pickleIndex = "14";
+            string pickleIndex = "18";
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Get Nybble hash code", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
-#line 86
+#line 114
 this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
             if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
@@ -615,13 +771,13 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-#line 87
+#line 115
     await testRunner.GivenAsync("I have a Nybble with value 10", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
-#line 88
+#line 116
     await testRunner.WhenAsync("I get the Nybble hash code", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
-#line 89
+#line 117
     await testRunner.ThenAsync("the hash code should match the byte value hash code", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }
@@ -637,11 +793,11 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             string[] tagsOfScenario = new string[] {
                     "Unit"};
             global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
-            string pickleIndex = "15";
+            string pickleIndex = "19";
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Check Nybble equality with null object", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
-#line 92
+#line 120
 this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
             if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
@@ -651,13 +807,13 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-#line 93
+#line 121
     await testRunner.GivenAsync("I have a Nybble with value 5", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
-#line 94
+#line 122
     await testRunner.WhenAsync("I check equality with null object", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
-#line 95
+#line 123
     await testRunner.ThenAsync("the boolean result should be false", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }
@@ -673,11 +829,11 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             string[] tagsOfScenario = new string[] {
                     "Unit"};
             global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
-            string pickleIndex = "16";
+            string pickleIndex = "20";
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Check Nybble equality with non-Nybble object", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
-#line 98
+#line 126
 this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
             if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
@@ -687,13 +843,13 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-#line 99
+#line 127
     await testRunner.GivenAsync("I have a Nybble with value 5", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
-#line 100
+#line 128
     await testRunner.WhenAsync("I check equality with a string object", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
-#line 101
+#line 129
     await testRunner.ThenAsync("the boolean result should be false", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }

--- a/tests/Asm.Tests/NybbleSteps.cs
+++ b/tests/Asm.Tests/NybbleSteps.cs
@@ -47,7 +47,13 @@ public class NybbleSteps(ScenarioContext context)
     [When(@"I add the two Nybbles")]
     public void WhenIAddTheTwoNybbles()
     {
-        context.AddResult(_nybble1 + _nybble2);
+        context.AddResult((_nybble1 + _nybble2).ByteValue);
+    }
+
+    [When(@"I combine the two Nybbles")]
+    public void WhenICombineTheTwoNybbles()
+    {
+        context.AddResult(Nybble.Combine(_nybble1, _nybble2));
     }
 
     [Given(@"I have a Nybble array with values (.*)")]
@@ -153,10 +159,22 @@ public class NybbleSteps(ScenarioContext context)
         context.AddResult(_uintValue + _nybble1);
     }
 
+    [When(@"I append the Nybble to the uint")]
+    public void WhenIAppendTheNybbleToTheUint()
+    {
+        context.AddResult(Nybble.Append(_uintValue, _nybble1));
+    }
+
     [When(@"I add the byte and Nybble")]
     public void WhenIAddTheByteAndNybble()
     {
         context.AddResult(_byteValue + _nybble1);
+    }
+
+    [When(@"I append the Nybble to the byte")]
+    public void WhenIAppendTheNybbleToTheByte()
+    {
+        context.AddResult(Nybble.Append(_byteValue, _nybble1));
     }
 
     [When(@"I check inequality")]


### PR DESCRIPTION
## Phase 5 Batch 6 — Nybble arithmetic

Part of the v4.0 API redesign (#411). Targets `release/v4.0`.

### Summary
The `+` operator on `Asm.Nybble` now performs **arithmetic addition**, matching what its XML docs always claimed. In v3 `+` (and the `Add` methods behind it) silently **concatenated** two 4-bit values into a byte (`0x5 + 0x3 == 0x53 == 83`). It now adds (`0x5 + 0x3 == 0x8`).

> ⚠️ **This is a silent behavioural change.** Most `a + b` call sites still compile against v4 but compute a different result. Flagged prominently in `docs/migration-v4.md`.

### Overflow decision
`Nybble + Nybble` **wraps modulo 16** (keeps only the low four bits), mirroring how a physical 4-bit register overflows — e.g. `0xF + 0xF == 0xE (14)`. It never throws and always yields a valid `Nybble`. The integer-mixed operators wrap in the usual unchecked manner for their result type. Rationale: keeps the type closed under addition and stays deterministic/non-throwing, consistent with hardware 4-bit arithmetic.

### Return types unified (breaking)
Each operator now returns the type arithmetic naturally yields, replacing the old mismatched set:

| Expression        | v3 (concatenation) | v4 (arithmetic)         |
|-------------------|--------------------|-------------------------|
| `Nybble + Nybble` | `byte`             | `Nybble` (wraps mod 16) |
| `uint + Nybble`   | `ulong`            | `uint`                  |
| `byte + Nybble`   | `int`              | `int`                   |

The `Nybble.Add(...)` statics changed correspondingly (they now add, matching their long-standing docs).

### Old concatenation preserved
The v3 packing behaviour lives on under explicit, well-named members:

```csharp
Nybble.Combine(high, low);      // two nybbles -> byte  (was: a + b)
Nybble.Append(uintValue, n);    // append nybble -> ulong (was: uintValue + n)
Nybble.Append(byteValue, n);    // append nybble -> int   (was: byteValue + n)
```

`Combine(0x5, 0x3) == 0x53 (83)`, identical to old `+`.

### Public API
No public member removed or renamed — `+` and `Add` keep their names and now behave per their documentation; `Combine`/`Append` are additive. No other code in the solution references `Nybble`.

### Tests
Implemented test-first (added the arithmetic expectation, watched it fail at `83 != 8` against the old concat behaviour, then fixed). Existing concatenation scenarios re-pointed at `Combine`/`Append`. Added arithmetic and modulo-16 overflow coverage.

- `dotnet test tests/Asm.Tests` (Release): **393 passed**, 0 failed (Nybble: 23).
- `dotnet test Asm.slnx` (Release): full solution green, no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
