### PR TITLE
Phase 5 Batch 7: options-pattern conformance

### DIFF
--- a/docs/migration-v4.md
+++ b/docs/migration-v4.md
@@ -105,3 +105,67 @@ MapCommand<TRequest>(pattern, CommandBinding binding = CommandBinding.Parameters
 **What to change:**
 - Void `MapCommand<TRequest>` / `MapPutCommand<TRequest>` are source-compatible with v3 — the status-code parameter is retained (renamed `returnStatusCode` → `statusCode`, same position and `204` default), now with `binding` added after it.
 - If you passed `binding` **positionally** to a body-returning map (`MapCommand<Cmd, Result>(pattern, CommandBinding.Body)`), it now needs to be named — `MapCommand<Cmd, Result>(pattern, binding: CommandBinding.Body)` — because `statusCode` is now the second parameter. Everything else is source-compatible (both `statusCode` and `binding` are optional).
+
+
+## Batch 7 — Options-pattern conformance
+
+This batch brings the `Asm.AspNetCore` canonical-URL and security-header/reporting extensions into line with the standard ASP.NET Core options pattern, and makes the reporting↔security-header coupling independent of registration order.
+
+### Canonical URLs: configure via `AddCanonicalUrls`, resolve via DI
+
+`UseCanonicalUrls` no longer builds options inline. Configure `CanonicalUrlOptions` at service-registration time with the new `AddCanonicalUrls`, and call the parameterless `UseCanonicalUrls()`, which resolves `IOptions<CanonicalUrlOptions>` from DI at request time.
+
+```csharp
+// Before (v3)
+app.UseCanonicalUrls(opts => opts.ForceLowercase = false);
+
+// After (v4)
+builder.Services.AddCanonicalUrls(opts => opts.ForceLowercase = false);
+// …
+app.UseCanonicalUrls();
+```
+
+- **New:** `IServiceCollection AddCanonicalUrls(this IServiceCollection, Action<CanonicalUrlOptions>? configure = null)` — registers/configures the options via `services.AddOptions<CanonicalUrlOptions>()`.
+- **New:** `IApplicationBuilder UseCanonicalUrls(this IApplicationBuilder app)` — parameterless; resolves the options from DI. With no `AddCanonicalUrls` call the middleware runs with `CanonicalUrlOptions` defaults supplied by the options infrastructure.
+- **Obsolete forwarder:** `UseCanonicalUrls(this IApplicationBuilder, Action<CanonicalUrlOptions>? configure)` remains for one major cycle, marked `[Obsolete]`. It still works (builds `Options.Create(...)` inline) so existing call sites keep compiling with a deprecation warning.
+
+**What to change:** move your inline `UseCanonicalUrls(configure)` configuration to `AddCanonicalUrls(configure)` at registration time and switch to the parameterless `UseCanonicalUrls()`.
+
+### `AddStandardSecurityHeaders` now returns `IServiceCollection`
+
+**Breaking signature change.** `AddStandardSecurityHeaders` previously returned the `HeaderPolicyCollection` singleton (so callers could mutate it in place). It now returns `IServiceCollection` for idiomatic chaining, and accepts an optional `Action<HeaderPolicyCollection>` to add or override policies (for example, a Content-Security-Policy).
+
+```csharp
+// Before (v3) — mutate the returned collection
+var policies = services.AddStandardSecurityHeaders();
+policies.AddContentSecurityPolicy(csp => csp.AddDefaultSrc().Self());
+
+// After (v4) — supply a configure callback
+services.AddStandardSecurityHeaders(policies =>
+    policies.AddContentSecurityPolicy(csp => csp.AddDefaultSrc().Self()));
+```
+
+- Signature: `IServiceCollection AddStandardSecurityHeaders(this IServiceCollection services, Action<HeaderPolicyCollection>? configure = null)`.
+- The `configure` callback runs after the standard defaults and before the reporting policies are composed.
+- The composed `HeaderPolicyCollection` is still directly resolvable from DI (`GetRequiredService<HeaderPolicyCollection>()`) — it is bridged from `IOptions<HeaderPolicyCollection>.Value`, so `UseStandardSecurityHeaders()` and any consumer that resolved the collection continue to work.
+
+**What to change:** if you captured the return value to mutate the collection, move that mutation into the `configure` callback. If you only called `services.AddStandardSecurityHeaders();` and `app.UseStandardSecurityHeaders();`, nothing changes.
+
+### Security-reporting coupling is now order-independent
+
+Previously `AddSecurityReporting` **had to be called before** `AddStandardSecurityHeaders` for the `Reporting-Endpoints` / `Report-To` header policies to be emitted; calling it afterwards silently did nothing. The coupling is now performed by an `IPostConfigureOptions<HeaderPolicyCollection>` registered by `AddSecurityReporting`, which runs after every `Configure` callback that populates the collection. As a result the two registrations compose correctly **in either order**.
+
+```csharp
+// Both orders now yield identical results:
+services.AddSecurityReporting();
+services.AddStandardSecurityHeaders();
+
+// …or…
+services.AddStandardSecurityHeaders();
+services.AddSecurityReporting();
+```
+
+- `AddSecurityReporting` still registers the `SecurityReportingOptions` singleton (so `MapSecurityReporting` continues to require it), and additionally registers `IPostConfigureOptions<HeaderPolicyCollection>`.
+- The old order-dependent auto-coupling (a `services.FirstOrDefault(...)` probe inside `AddStandardSecurityHeaders`) has been removed.
+
+**What to change:** nothing is required. Behaviour only improves — reporting headers are now emitted regardless of the order in which the two methods were registered. If your code relied on the old behaviour of *suppressing* reporting headers by deliberately registering reporting last, register the two methods in separate service collections instead.

--- a/src/Asm.AspNetCore/Extensions/AsmAspNetCoreApplicationBuilderExtensions.cs
+++ b/src/Asm.AspNetCore/Extensions/AsmAspNetCoreApplicationBuilderExtensions.cs
@@ -31,17 +31,42 @@ public static class AsmAspNetCoreApplicationBuilderExtensions
         });
 
     /// <summary>
-    /// Adds <see cref="CanonicalUrlMiddleware"/> to the pipeline.
+    /// Adds <see cref="CanonicalUrlMiddleware"/> to the pipeline, resolving
+    /// <see cref="CanonicalUrlOptions"/> from dependency injection.
     /// </summary>
+    /// <remarks>
+    /// Configure the options at service-registration time with
+    /// <see cref="AsmAspNetCoreServiceCollectionExtensions.AddCanonicalUrls"/>. When no options are
+    /// registered the middleware runs with the <see cref="CanonicalUrlOptions"/> defaults supplied by
+    /// the options infrastructure.
+    /// </remarks>
     /// <param name="app">The application builder.</param>
-    /// <param name="configure">Optional callback to configure canonicalisation options.</param>
     /// <returns>The application builder.</returns>
-    public static IApplicationBuilder UseCanonicalUrls(this IApplicationBuilder app, Action<CanonicalUrlOptions>? configure = null)
+    public static IApplicationBuilder UseCanonicalUrls(this IApplicationBuilder app)
     {
         ArgumentNullException.ThrowIfNull(app);
 
+        return app.UseMiddleware<CanonicalUrlMiddleware>();
+    }
+
+    /// <summary>
+    /// Adds <see cref="CanonicalUrlMiddleware"/> to the pipeline, configuring options inline.
+    /// </summary>
+    /// <param name="app">The application builder.</param>
+    /// <param name="configure">Callback to configure canonicalisation options.</param>
+    /// <returns>The application builder.</returns>
+    [Obsolete("Configure options via AddCanonicalUrls(...) at service-registration time and call the parameterless UseCanonicalUrls(). This overload will be removed in a future major version.")]
+    public static IApplicationBuilder UseCanonicalUrls(this IApplicationBuilder app, Action<CanonicalUrlOptions>? configure)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+
+        if (configure is null)
+        {
+            return app.UseMiddleware<CanonicalUrlMiddleware>();
+        }
+
         var options = new CanonicalUrlOptions();
-        configure?.Invoke(options);
+        configure.Invoke(options);
 
         return app.UseMiddleware<CanonicalUrlMiddleware>(Options.Create(options));
     }

--- a/src/Asm.AspNetCore/Extensions/AsmAspNetCoreServiceCollectionExtensions.cs
+++ b/src/Asm.AspNetCore/Extensions/AsmAspNetCoreServiceCollectionExtensions.cs
@@ -1,8 +1,11 @@
+using Asm.AspNetCore.Middleware;
 using Asm.AspNetCore.Reporting;
 using Asm.AspNetCore.Security;
 using Asm.Security;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -30,38 +33,47 @@ public static class AsmAspNetCoreServiceCollectionExtensions
     ///   <item><description>Server-fingerprint header removal</description></item>
     /// </list>
     /// <para>HSTS is intentionally not included — use ASP.NET Core's <c>AddHsts()</c> and <c>UseHsts()</c> instead.</para>
-    /// <para><b>Auto-coupling:</b> if <see cref="AddSecurityReporting"/> was called before this
-    /// method, <c>Reporting-Endpoints</c> and <c>Report-To</c> header policies are automatically
-    /// included in the collection. <see cref="AddSecurityReporting"/> <b>must</b> be called first
-    /// for auto-emit to work; calling it after this method has no effect on the header policies.</para>
+    /// <para><b>Reporting coupling (order-independent):</b> if <see cref="AddSecurityReporting"/> is
+    /// called — <em>before or after</em> this method — the <c>Reporting-Endpoints</c> and
+    /// <c>Report-To</c> header policies are automatically composed into the collection via an
+    /// <see cref="Options.IPostConfigureOptions{TOptions}"/>. Registration order no longer matters.</para>
     /// </remarks>
     /// <param name="services">The service collection.</param>
-    /// <returns>The registered <see cref="HeaderPolicyCollection"/>, returned so the caller can chain additional policy configuration. Mutations to the returned instance are visible at request time because it is the same singleton registered in <paramref name="services"/>.</returns>
-    public static HeaderPolicyCollection AddStandardSecurityHeaders(this IServiceCollection services)
+    /// <param name="configure">
+    /// Optional callback to add or override policies on the standard <see cref="HeaderPolicyCollection"/>
+    /// (for example, to add a Content-Security-Policy). Runs after the standard defaults and before the
+    /// reporting policies are composed.
+    /// </param>
+    /// <returns>The <see cref="IServiceCollection"/> so that calls can be chained.</returns>
+    public static IServiceCollection AddStandardSecurityHeaders(this IServiceCollection services, Action<HeaderPolicyCollection>? configure = null)
     {
         ArgumentNullException.ThrowIfNull(services);
 
-        var policies = new HeaderPolicyCollection();
+        services.AddOptions<HeaderPolicyCollection>()
+            .Configure(static policies =>
+            {
+                policies.AddCrossOriginOpenerPolicy(b => b.SameOriginAllowPopups());
+                policies.AddCrossOriginEmbedderPolicy(b => b.RequireCorp());
+                policies.AddCrossOriginResourcePolicy(b => b.SameOrigin());
+                policies.AddFrameOptionsSameOrigin();
+                policies.AddContentTypeOptionsNoSniff();
+                policies.AddReferrerPolicyStrictOriginWhenCrossOrigin();
+                policies.AddCustomHeader("X-Permitted-Cross-Domain-Policies", "none");
+                policies.RemoveServerHeader();
+            });
 
-        policies.AddCrossOriginOpenerPolicy(b => b.SameOriginAllowPopups());
-        policies.AddCrossOriginEmbedderPolicy(b => b.RequireCorp());
-        policies.AddCrossOriginResourcePolicy(b => b.SameOrigin());
-        policies.AddFrameOptionsSameOrigin();
-        policies.AddContentTypeOptionsNoSniff();
-        policies.AddReferrerPolicyStrictOriginWhenCrossOrigin();
-        policies.AddCustomHeader("X-Permitted-Cross-Domain-Policies", "none");
-        policies.RemoveServerHeader();
-
-        // Auto-coupling: if AddSecurityReporting was called first, the SecurityReportingOptions
-        // singleton is already registered. Lift it and apply the reporting header policies.
-        var reportingDescriptor = services.FirstOrDefault(d => d.ServiceType == typeof(SecurityReportingOptions));
-        if (reportingDescriptor?.ImplementationInstance is SecurityReportingOptions reportingOptions)
+        if (configure is not null)
         {
-            policies.AddSecurityReportingHeaders(reportingOptions);
+            services.AddOptions<HeaderPolicyCollection>().Configure(configure);
         }
 
-        services.AddSingleton(policies);
-        return policies;
+        // Bridge the configured options instance to a directly-resolvable singleton so that
+        // UseStandardSecurityHeaders (and any consumer resolving HeaderPolicyCollection) sees the
+        // fully-composed collection, including any reporting policies contributed via
+        // IPostConfigureOptions regardless of registration order.
+        services.TryAddSingleton(static sp => sp.GetRequiredService<Options.IOptions<HeaderPolicyCollection>>().Value);
+
+        return services;
     }
 
     /// <summary>
@@ -84,15 +96,17 @@ public static class AsmAspNetCoreServiceCollectionExtensions
     }
 
     /// <summary>
-    /// Registers <see cref="SecurityReportingOptions"/> in the service collection.
-    /// When registered before <see cref="AddStandardSecurityHeaders"/>, the resulting
-    /// <see cref="HeaderPolicyCollection"/> automatically includes <c>Reporting-Endpoints</c>
-    /// and <c>Report-To</c> header policies via
-    /// <see cref="HeaderPolicyCollectionReportingExtensions.AddSecurityReportingHeaders"/>.
+    /// Registers <see cref="SecurityReportingOptions"/> in the service collection and couples the
+    /// <c>Reporting-Endpoints</c> and <c>Report-To</c> header policies into the standard
+    /// <see cref="HeaderPolicyCollection"/> via an
+    /// <see cref="Options.IPostConfigureOptions{TOptions}"/>.
     /// </summary>
     /// <remarks>
-    /// Call this method <b>before</b> <see cref="AddStandardSecurityHeaders"/> for the
-    /// auto-coupling to take effect. Registering after has no effect on the header policies.
+    /// The coupling with <see cref="AddStandardSecurityHeaders"/> is <b>order-independent</b>: this
+    /// method may be called before or after <c>AddStandardSecurityHeaders</c> and the reporting
+    /// header policies will still be composed into the collection, because they are contributed by an
+    /// <see cref="Options.IPostConfigureOptions{TOptions}"/> that runs after every <c>Configure</c>
+    /// callback.
     /// </remarks>
     /// <param name="services">The service collection.</param>
     /// <param name="configure">Optional callback to customise options.</param>
@@ -106,10 +120,39 @@ public static class AsmAspNetCoreServiceCollectionExtensions
         var options = new SecurityReportingOptions();
         configure?.Invoke(options);
 
-        // Registered as a singleton (not via services.Configure<T>) so that
-        // AddStandardSecurityHeaders can detect its presence via FirstOrDefault —
-        // IOptions<T> is always resolvable and wouldn't signal "reporting not configured".
+        // Registered as a singleton so that MapSecurityReporting can require its presence
+        // (GetRequiredService throws when reporting was not configured).
         services.AddSingleton(options);
+
+        // Contribute the reporting header policies via IPostConfigureOptions so the coupling with
+        // AddStandardSecurityHeaders is order-independent. The presence of this registration is the
+        // signal that reporting is enabled — nothing is contributed unless this method was called.
+        services.AddSingleton<Options.IPostConfigureOptions<HeaderPolicyCollection>, SecurityReportingHeaderPostConfigure>();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers and configures <see cref="CanonicalUrlOptions"/> using the options pattern, for use
+    /// by <see cref="AsmAspNetCoreApplicationBuilderExtensions.UseCanonicalUrls(IApplicationBuilder)"/>.
+    /// </summary>
+    /// <remarks>
+    /// Call this at service-registration time; <c>UseCanonicalUrls()</c> then resolves the configured
+    /// <see cref="Options.IOptions{TOptions}"/> from DI at request time.
+    /// </remarks>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configure">Optional callback to configure canonicalisation options.</param>
+    /// <returns>The <see cref="IServiceCollection"/> so that calls can be chained.</returns>
+    public static IServiceCollection AddCanonicalUrls(this IServiceCollection services, Action<CanonicalUrlOptions>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        var builder = services.AddOptions<CanonicalUrlOptions>();
+        if (configure is not null)
+        {
+            builder.Configure(configure);
+        }
+
         return services;
     }
 }

--- a/src/Asm.AspNetCore/Reporting/SecurityReportingHeaderPostConfigure.cs
+++ b/src/Asm.AspNetCore/Reporting/SecurityReportingHeaderPostConfigure.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Options;
+
+namespace Asm.AspNetCore.Reporting;
+
+/// <summary>
+/// Post-configures the standard <see cref="HeaderPolicyCollection"/> with the
+/// <c>Reporting-Endpoints</c> and <c>Report-To</c> header policies.
+/// </summary>
+/// <remarks>
+/// Registered by <c>AddSecurityReporting</c>.
+/// Because it runs as an <see cref="IPostConfigureOptions{TOptions}"/> — after every
+/// <c>Configure</c> callback that populates the collection — the reporting headers compose
+/// correctly regardless of whether <c>AddSecurityReporting</c> or
+/// <c>AddStandardSecurityHeaders</c> was registered first. This replaces the previous
+/// call-order-dependent auto-coupling.
+/// </remarks>
+internal sealed class SecurityReportingHeaderPostConfigure(SecurityReportingOptions options) : IPostConfigureOptions<HeaderPolicyCollection>
+{
+    private readonly SecurityReportingOptions _options = options;
+
+    /// <inheritdoc />
+    public void PostConfigure(string? name, HeaderPolicyCollection options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        options.AddSecurityReportingHeaders(_options);
+    }
+}

--- a/tests/Asm.AspNetCore.Tests/Extensions/IApplicationBuilderExtensionsSecurityTests.cs
+++ b/tests/Asm.AspNetCore.Tests/Extensions/IApplicationBuilderExtensionsSecurityTests.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace Asm.AspNetCore.Tests.Extensions;
@@ -48,19 +49,21 @@ public class IApplicationBuilderExtensionsSecurityTests
     }
 
     // ──────────────────────────────────────────────────────────────────────────
-    // UseCanonicalUrls with configure — smoke test
+    // AddCanonicalUrls(configure) + DI-resolved UseCanonicalUrls() — options applied
     // ──────────────────────────────────────────────────────────────────────────
 
     [Fact]
-    public async Task UseCanonicalUrls_WithConfigure_PipelineRunsAndOptionsApplied()
+    public async Task AddCanonicalUrls_ConfiguredOptions_ResolvedByUseCanonicalUrls()
     {
         using var host = await new HostBuilder()
             .ConfigureWebHost(webHost =>
             {
                 webHost.UseTestServer();
+                webHost.ConfigureServices(services =>
+                    services.AddCanonicalUrls(opts => opts.ForceLowercase = false));
                 webHost.Configure(app =>
                 {
-                    app.UseCanonicalUrls(opts => opts.ForceLowercase = false);
+                    app.UseCanonicalUrls();
                     app.Run(async ctx =>
                     {
                         ctx.Response.ContentType = "text/html";
@@ -71,7 +74,37 @@ public class IApplicationBuilderExtensionsSecurityTests
             .StartAsync(TestContext.Current.CancellationToken);
 
         var client = host.GetTestClient();
-        // With ForceLowercase=false, /Hello should pass through (200)
+        // With ForceLowercase=false configured via DI, /Hello should pass through (200)
+        var response = await client.GetAsync("/Hello", TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Obsolete inline-configure overload still forwards correctly
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UseCanonicalUrls_ObsoleteInlineConfigure_StillApplies()
+    {
+        using var host = await new HostBuilder()
+            .ConfigureWebHost(webHost =>
+            {
+                webHost.UseTestServer();
+                webHost.Configure(app =>
+                {
+#pragma warning disable CS0618 // Type or member is obsolete
+                    app.UseCanonicalUrls(opts => opts.ForceLowercase = false);
+#pragma warning restore CS0618
+                    app.Run(async ctx =>
+                    {
+                        ctx.Response.ContentType = "text/html";
+                        await ctx.Response.WriteAsync("ok");
+                    });
+                });
+            })
+            .StartAsync(TestContext.Current.CancellationToken);
+
+        var client = host.GetTestClient();
         var response = await client.GetAsync("/Hello", TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }

--- a/tests/Asm.AspNetCore.Tests/Extensions/IApplicationBuilderExtensionsStandardSecurityTests.cs
+++ b/tests/Asm.AspNetCore.Tests/Extensions/IApplicationBuilderExtensionsStandardSecurityTests.cs
@@ -40,8 +40,7 @@ public class IApplicationBuilderExtensionsStandardSecurityTests
                 webHost.ConfigureServices(services =>
                 {
                     configureServices?.Invoke(services);
-                    var policies = services.AddStandardSecurityHeaders();
-                    extend?.Invoke(policies);
+                    services.AddStandardSecurityHeaders(extend);
                 });
                 webHost.Configure(app =>
                 {
@@ -184,6 +183,48 @@ public class IApplicationBuilderExtensionsStandardSecurityTests
                 "Reporting-Endpoints should be emitted when AddSecurityReporting is called before AddStandardSecurityHeaders");
             Assert.True(response.Headers.Contains("Report-To"),
                 "Report-To should be emitted when AddSecurityReporting is called before AddStandardSecurityHeaders");
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Order-independence: AddSecurityReporting AFTER AddStandardSecurityHeaders
+    // still emits the reporting headers at runtime
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task WithAddSecurityReportingAfterAddStandardHeaders_ReportingHeadersEmitted()
+    {
+        var host = await new HostBuilder()
+            .ConfigureWebHost(webHost =>
+            {
+                webHost.UseTestServer();
+                webHost.ConfigureServices(services =>
+                {
+                    services.AddStandardSecurityHeaders();   // headers first
+                    services.AddSecurityReporting();         // reporting AFTER — must still couple
+                });
+                webHost.Configure(app =>
+                {
+                    app.UseStandardSecurityHeaders();
+                    app.Run(async ctx =>
+                    {
+                        ctx.Response.ContentType = "text/html";
+                        await ctx.Response.WriteAsync("ok");
+                    });
+                });
+            })
+            .StartAsync(TestContext.Current.CancellationToken);
+
+        using (host)
+        {
+            var client = host.GetTestServer().CreateClient();
+            var response = await client.GetAsync("/", TestContext.Current.CancellationToken);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.True(response.Headers.Contains("Reporting-Endpoints"),
+                "Reporting-Endpoints should be emitted even when AddSecurityReporting is called AFTER AddStandardSecurityHeaders");
+            Assert.True(response.Headers.Contains("Report-To"),
+                "Report-To should be emitted even when AddSecurityReporting is called AFTER AddStandardSecurityHeaders");
         }
     }
 

--- a/tests/Asm.AspNetCore.Tests/Extensions/IServiceCollectionExtensionsCanonicalUrlTests.cs
+++ b/tests/Asm.AspNetCore.Tests/Extensions/IServiceCollectionExtensionsCanonicalUrlTests.cs
@@ -1,0 +1,74 @@
+using Asm.AspNetCore.Middleware;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Asm.AspNetCore.Tests.Extensions;
+
+/// <summary>
+/// Tests for <see cref="AsmAspNetCoreServiceCollectionExtensions.AddCanonicalUrls"/>.
+/// </summary>
+public class IServiceCollectionExtensionsCanonicalUrlTests
+{
+    // ──────────────────────────────────────────────────────────────────────────
+    // Null guard
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void AddCanonicalUrls_NullServices_ThrowsArgumentNullException()
+    {
+        IServiceCollection services = null!;
+        Assert.Throws<ArgumentNullException>(() => services.AddCanonicalUrls());
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Chaining
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void AddCanonicalUrls_ReturnsTheSameServiceCollection()
+    {
+        var services = new ServiceCollection();
+        var returned = services.AddCanonicalUrls();
+
+        Assert.Same(services, returned);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // No configure → defaults resolvable via IOptions
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void AddCanonicalUrls_NoConfigure_RegistersDefaultOptions()
+    {
+        var services = new ServiceCollection();
+        services.AddCanonicalUrls();
+
+        var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<CanonicalUrlOptions>>().Value;
+
+        Assert.True(options.ForceLowercase);
+        Assert.True(options.RemoveTrailingSlash);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Configure callback flows into resolved options
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void AddCanonicalUrls_WithConfigure_AppliesCustomOptions()
+    {
+        var services = new ServiceCollection();
+        services.AddCanonicalUrls(opts =>
+        {
+            opts.ForceLowercase = false;
+            opts.ExemptPathPrefixes = ["/umbraco"];
+        });
+
+        var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<CanonicalUrlOptions>>().Value;
+
+        Assert.False(options.ForceLowercase);
+        Assert.Single(options.ExemptPathPrefixes);
+        Assert.Equal("/umbraco", options.ExemptPathPrefixes[0]);
+    }
+}

--- a/tests/Asm.AspNetCore.Tests/Extensions/IServiceCollectionExtensionsStandardSecurityTests.cs
+++ b/tests/Asm.AspNetCore.Tests/Extensions/IServiceCollectionExtensionsStandardSecurityTests.cs
@@ -59,41 +59,54 @@ public class IServiceCollectionExtensionsStandardSecurityTests
     }
 
     // ──────────────────────────────────────────────────────────────────────────
-    // extend callback
+    // Return value — IServiceCollection for chaining
     // ──────────────────────────────────────────────────────────────────────────
 
     [Fact]
-    public void AddStandardSecurityHeaders_PostRegistrationMutation_VisibleViaResolvedSingleton()
+    public void AddStandardSecurityHeaders_ReturnsTheSameServiceCollection()
     {
         var services = new ServiceCollection();
-        var policies = services.AddStandardSecurityHeaders();
-        policies.AddCustomHeader("X-Custom-Test", "custom-value");
+        var returned = services.AddStandardSecurityHeaders();
+
+        Assert.Same(services, returned);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // configure callback — additional/overriding policies are composed in
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void AddStandardSecurityHeaders_ConfigureCallback_ContributesAdditionalPolicies()
+    {
+        var services = new ServiceCollection();
+        services.AddStandardSecurityHeaders(policies => policies.AddCustomHeader("X-Custom-Test", "custom-value"));
 
         var provider = services.BuildServiceProvider();
         var resolved = provider.GetRequiredService<HeaderPolicyCollection>();
 
-        Assert.True(resolved.ContainsKey("X-Custom-Test"), "Post-registration mutation of returned HeaderPolicyCollection should be visible on the resolved singleton.");
-        Assert.Same(policies, resolved);
+        Assert.True(resolved.ContainsKey("X-Custom-Test"), "The configure callback should contribute additional policies to the resolved collection.");
+        // Standard defaults are still present alongside the custom policy.
+        Assert.True(resolved.ContainsKey("X-Frame-Options"), "Standard defaults should remain when a configure callback is supplied.");
     }
 
     // ──────────────────────────────────────────────────────────────────────────
-    // Auto-coupling: AddSecurityReporting BEFORE AddStandardSecurityHeaders
+    // Order-independent reporting coupling: AddSecurityReporting BEFORE
     // ──────────────────────────────────────────────────────────────────────────
 
     [Fact]
     public void AddStandardSecurityHeaders_AfterAddSecurityReporting_ReportingPoliciesIncluded()
     {
         var services = new ServiceCollection();
-        services.AddSecurityReporting();                 // must come first
+        services.AddSecurityReporting();
         services.AddStandardSecurityHeaders();
 
         var provider = services.BuildServiceProvider();
         var collection = provider.GetRequiredService<HeaderPolicyCollection>();
 
         Assert.True(collection.ContainsKey("Reporting-Endpoints"),
-            "Reporting-Endpoints policy should be auto-coupled when AddSecurityReporting is called first");
+            "Reporting-Endpoints policy should be coupled when AddSecurityReporting is called first");
         Assert.True(collection.ContainsKey("Report-To"),
-            "Report-To policy should be auto-coupled when AddSecurityReporting is called first");
+            "Report-To policy should be coupled when AddSecurityReporting is called first");
     }
 
     // ──────────────────────────────────────────────────────────────────────────
@@ -116,24 +129,46 @@ public class IServiceCollectionExtensionsStandardSecurityTests
     }
 
     // ──────────────────────────────────────────────────────────────────────────
-    // Auto-coupling: AddSecurityReporting AFTER AddStandardSecurityHeaders → NOT coupled
+    // Order-independent reporting coupling: AddSecurityReporting AFTER
     // ──────────────────────────────────────────────────────────────────────────
 
     [Fact]
-    public void AddStandardSecurityHeaders_BeforeAddSecurityReporting_ReportingPoliciesNotPresent()
+    public void AddStandardSecurityHeaders_BeforeAddSecurityReporting_ReportingPoliciesIncluded()
     {
-        // Documents the ordering requirement: AddSecurityReporting must come BEFORE
-        // AddStandardSecurityHeaders for auto-coupling to take effect.
+        // Order-independence (item 2): AddSecurityReporting composes the reporting policies via an
+        // IPostConfigureOptions, so calling it AFTER AddStandardSecurityHeaders still works.
         var services = new ServiceCollection();
         services.AddStandardSecurityHeaders();           // called first
-        services.AddSecurityReporting();                 // too late — no effect on the already-built collection
+        services.AddSecurityReporting();                 // still composes via IPostConfigureOptions
 
         var provider = services.BuildServiceProvider();
         var collection = provider.GetRequiredService<HeaderPolicyCollection>();
 
-        Assert.False(collection.ContainsKey("Reporting-Endpoints"),
-            "Reporting-Endpoints should be absent when AddSecurityReporting is called AFTER AddStandardSecurityHeaders");
-        Assert.False(collection.ContainsKey("Report-To"),
-            "Report-To should be absent when AddSecurityReporting is called AFTER AddStandardSecurityHeaders");
+        Assert.True(collection.ContainsKey("Reporting-Endpoints"),
+            "Reporting-Endpoints should be present regardless of registration order");
+        Assert.True(collection.ContainsKey("Report-To"),
+            "Report-To should be present regardless of registration order");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Order-independence: both registration orders produce the same composed result
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void AddStandardSecurityHeaders_ReportingCoupling_IsOrderIndependent()
+    {
+        var reportingFirst = new ServiceCollection();
+        reportingFirst.AddSecurityReporting();
+        reportingFirst.AddStandardSecurityHeaders();
+
+        var headersFirst = new ServiceCollection();
+        headersFirst.AddStandardSecurityHeaders();
+        headersFirst.AddSecurityReporting();
+
+        var a = reportingFirst.BuildServiceProvider().GetRequiredService<HeaderPolicyCollection>();
+        var b = headersFirst.BuildServiceProvider().GetRequiredService<HeaderPolicyCollection>();
+
+        // Same set of header keys regardless of registration order.
+        Assert.Equal(a.Keys.OrderBy(k => k), b.Keys.OrderBy(k => k));
     }
 }

--- a/tests/Asm.AspNetCore.Tests/Middleware/CanonicalUrlMiddlewareTests.cs
+++ b/tests/Asm.AspNetCore.Tests/Middleware/CanonicalUrlMiddlewareTests.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace Asm.AspNetCore.Tests.Middleware;
@@ -27,9 +28,11 @@ public class CanonicalUrlMiddlewareTests
             .ConfigureWebHost(webHost =>
             {
                 webHost.UseTestServer();
+                webHost.ConfigureServices(services => services.AddCanonicalUrls(configure));
                 webHost.Configure(app =>
                 {
-                    app.UseCanonicalUrls(configure);
+                    // Options are resolved from DI (the options pattern).
+                    app.UseCanonicalUrls();
                     app.Run(async ctx =>
                     {
                         ctx.Response.StatusCode = 200;


### PR DESCRIPTION
## Phase 5 Batch 7 — Options-pattern conformance (`Asm.AspNetCore`)

Brings the canonical-URL middleware and the security-header / security-reporting extensions into line with the standard ASP.NET Core options pattern, and makes the reporting↔security-header coupling independent of registration order. Targets `release/v4.0` (major).

### 1. Canonical URLs — configure via DI
- **New** `IServiceCollection AddCanonicalUrls(Action<CanonicalUrlOptions>? = null)` — registers/configures options via `AddOptions<CanonicalUrlOptions>()`.
- **Changed** `UseCanonicalUrls()` is now parameterless and resolves `IOptions<CanonicalUrlOptions>` from DI (the middleware already took `IOptions<T>`).
- **Obsolete forwarder** `UseCanonicalUrls(Action<CanonicalUrlOptions>?)` retained for one major cycle so existing call sites still compile (with a deprecation warning).

### 2. Order-independent security-header / reporting coupling
- `AddSecurityReporting` now registers an **`IPostConfigureOptions<HeaderPolicyCollection>`** (`SecurityReportingHeaderPostConfigure`) that composes the `Reporting-Endpoints` / `Report-To` policies after every `Configure` callback.
- The old order-dependent probe (`services.FirstOrDefault(...)` inside `AddStandardSecurityHeaders`) is removed. `AddSecurityReporting` and `AddStandardSecurityHeaders` now compose correctly **in either order**.

### 3. `AddStandardSecurityHeaders` returns `IServiceCollection`
- **Breaking**: return type changed from `HeaderPolicyCollection` to `IServiceCollection` for idiomatic chaining, plus an optional `Action<HeaderPolicyCollection>` to add/override policies.
- The composed collection is still directly resolvable (`GetRequiredService<HeaderPolicyCollection>()`), bridged from `IOptions<HeaderPolicyCollection>.Value`, so `UseStandardSecurityHeaders()` is unaffected.

### Design decisions
- **`HeaderPolicyCollection` modelled as options** (`AddOptions<HeaderPolicyCollection>().Configure(...)`) so `IPostConfigureOptions` can compose reporting policies order-independently; a `TryAddSingleton` bridge preserves direct DI resolution and public API.
- **`SecurityReportingOptions` kept as a singleton** (not switched to `IOptions`-only) so `MapSecurityReporting`'s `GetRequiredService<SecurityReportingOptions>()` still throws when reporting was not configured — preserving existing behaviour and tests.
- Customisation moved from *mutate-the-returned-collection* to a **`configure` callback**, the idiomatic options shape and a prerequisite for lazy, order-independent composition.

### Tests
- `Asm.AspNetCore.Tests`: **153 passing, 0 warnings** (`-c Release`). Full solution `dotnet test Asm.slnx -c Release`: **all green**.
- Added/updated: `AddCanonicalUrls` DI registration + DI-resolved `UseCanonicalUrls`, obsolete-forwarder coverage, order-independent header/reporting composition (both orders → same composed keys, plus a runtime AFTER-order emit test), and the new `AddStandardSecurityHeaders` return value / `configure` callback.

Breaking changes are documented under **"Batch 7 — Options-pattern conformance"** in `docs/migration-v4.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
