### PR TITLE
Phase 5 Batch 4: Hosts redesign

### DIFF
--- a/docs/migration-v4.md
+++ b/docs/migration-v4.md
@@ -105,3 +105,72 @@ MapCommand<TRequest>(pattern, CommandBinding binding = CommandBinding.Parameters
 **What to change:**
 - Void `MapCommand<TRequest>` / `MapPutCommand<TRequest>` are source-compatible with v3 — the status-code parameter is retained (renamed `returnStatusCode` → `statusCode`, same position and `204` default), now with `binding` added after it.
 - If you passed `binding` **positionally** to a body-returning map (`MapCommand<Cmd, Result>(pattern, CommandBinding.Body)`), it now needs to be named — `MapCommand<Cmd, Result>(pattern, binding: CommandBinding.Body)` — because `statusCode` is now the second parameter. Everything else is source-compatible (both `statusCode` and `binding` are optional).
+
+## Batch 4 — Hosts redesign
+
+`Asm.Win32.Hosts` (the Windows hosts-file reader/writer) has been hardened around its entry
+collection, made thread-safe on refresh, annotated as Windows-only, and made strict about
+malformed input. `HostEntry` and `HostEntryType` are unchanged.
+
+### `Entries` is now a read-only snapshot
+
+`Hosts.Entries` changed from a **mutable** `IList<HostEntry>` to an immutable
+`IReadOnlyList<HostEntry>`. Each `get` returns a point-in-time **snapshot**, so it can no longer
+be mutated in place, and a reference you captured earlier does not observe later changes.
+
+Direct mutation is replaced by explicit methods on `Hosts`:
+
+| Old (v3) | New (v4) |
+|---|---|
+| `hosts.Entries.Add(entry)` | `hosts.AddEntry(entry)` |
+| `hosts.Entries.Insert(i, entry)` | `hosts.InsertEntry(i, entry)` |
+| `hosts.Entries[i] = entry` | `hosts.UpdateEntry(i, entry)` |
+| `hosts.Entries.Remove(entry)` | `hosts.RemoveEntry(entry)` |
+| `hosts.Entries.RemoveAt(i)` | `hosts.RemoveEntryAt(i)` |
+| `hosts.Entries.Clear()` | `hosts.ClearEntries()` |
+
+All mutators guard their arguments (`AddEntry`/`InsertEntry`/`UpdateEntry` throw
+`ArgumentNullException` for a null entry; the index-based mutators throw
+`ArgumentOutOfRangeException` for an out-of-range index). This is a breaking, **compile-time**
+change with no `[Obsolete]` shim — the member type itself changed, so old mutation call sites
+will not compile until switched to the methods above. Read access (`Entries[i]`, `.Count`,
+enumeration) is unchanged.
+
+### Refresh is now thread-safe
+
+The internal poll timer calls `Refresh()` on a background thread. Previously the reparse cleared
+and repopulated the live entry list while callers could be enumerating `Entries`, which could
+throw `InvalidOperationException` ("Collection was modified") or observe a half-built list.
+
+Parsing now builds a local list and swaps it into the shared state under a lock, and `Entries`
+returns a locked snapshot. Concurrent reads and a concurrent refresh no longer tear or throw.
+No API change — existing code simply becomes safe.
+
+### `[SupportedOSPlatform("windows")]`
+
+`Hosts` is now annotated `[SupportedOSPlatform("windows")]` (it targets the Windows hosts file at
+`%SystemRoot%\System32\drivers\etc\hosts`). Consumers that call it from code not already scoped to
+Windows will get analyzer warning **CA1416**. Guard usage with `OperatingSystem.IsWindows()`, or
+annotate the calling member/assembly with `[SupportedOSPlatform("windows")]`. The attribute is
+analyzer-only and does not change runtime behaviour, so stream/file-based usage (e.g. in tests)
+continues to work cross-platform. `HostEntry`/`HostEntryType` are pure data types and are **not**
+annotated.
+
+### Malformed entries throw instead of degrading silently
+
+An inconsistent/malformed host line (a non-blank, non-comment line whose first token is not a
+valid IP address) now throws a `FormatException` with an actionable message that names the
+offending line **and its line number**, e.g.:
+
+```
+Malformed host entry at line 2: 'Wibble'. Expected an IP address followed by an optional alias and comment (e.g. '127.0.0.1 localhost #comment').
+```
+
+Previously such input was reported with a terse `Unexpected entry in hosts file: <line>` message
+(no line number). The exception **type is unchanged (`FormatException`)**, so `catch` blocks keep
+working; only the message text and precision improved. Genuinely blank lines and comment lines
+(including `#`-prefixed free text) still parse as `Blank`/`Comment` as before — only truly
+malformed address lines throw.
+
+**What to change:** if you asserted on the exact old message text, update it. If you relied on a
+malformed line being swallowed, either sanitise the file first or catch `FormatException`.

--- a/src/Asm.Win32/Hosts.cs
+++ b/src/Asm.Win32/Hosts.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+using System.Net;
+using System.Runtime.Versioning;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Timers;
@@ -9,6 +10,7 @@ namespace Asm.Win32;
 /// <summary>
 /// Class for controlling the Windows Hosts file.
 /// </summary>
+[SupportedOSPlatform("windows")]
 public sealed partial class Hosts : IDisposable
 {
     #region Constants
@@ -26,6 +28,8 @@ public sealed partial class Hosts : IDisposable
     private static Hosts? _instance;
     private static readonly Lock _lock = new();
     private static string _systemHostsFile = DefaultHostsFile;
+    private readonly Lock _entriesLock = new();
+    private readonly List<HostEntry> _entries = [];
     private readonly string? _hostsFile;
     private readonly Timer? _pollTimer;
     private DateTime _hostsFileLastUpdated;
@@ -82,11 +86,23 @@ public sealed partial class Hosts : IDisposable
     /// <summary>
     /// The host file entries.
     /// </summary>
-    public IList<HostEntry> Entries
+    /// <remarks>
+    /// This is a read-only snapshot taken at the point of access. Use
+    /// <see cref="AddEntry(HostEntry)"/>, <see cref="InsertEntry(int, HostEntry)"/>,
+    /// <see cref="UpdateEntry(int, HostEntry)"/>, <see cref="RemoveEntry(HostEntry)"/>,
+    /// <see cref="RemoveEntryAt(int)"/> and <see cref="ClearEntries"/> to mutate the
+    /// entry collection.
+    /// </remarks>
+    public IReadOnlyList<HostEntry> Entries
     {
-        get;
-        private set;
-    } = new List<HostEntry>();
+        get
+        {
+            lock (_entriesLock)
+            {
+                return _entries.ToArray();
+            }
+        }
+    }
     #endregion
 
     #region Constructors
@@ -134,6 +150,98 @@ public sealed partial class Hosts : IDisposable
             _instance = null;
         }
         instance?.Dispose();
+    }
+
+    /// <summary>
+    /// Adds a host entry to the end of the collection.
+    /// </summary>
+    /// <param name="entry">The entry to add.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="entry"/> is <see langword="null"/>.</exception>
+    public void AddEntry(HostEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        lock (_entriesLock)
+        {
+            _entries.Add(entry);
+        }
+    }
+
+    /// <summary>
+    /// Inserts a host entry at the specified index.
+    /// </summary>
+    /// <param name="index">The zero-based index at which the entry should be inserted.</param>
+    /// <param name="entry">The entry to insert.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="entry"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> is outside the bounds of the collection.</exception>
+    public void InsertEntry(int index, HostEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        lock (_entriesLock)
+        {
+            ArgumentOutOfRangeException.ThrowIfGreaterThan((uint)index, (uint)_entries.Count, nameof(index));
+            _entries.Insert(index, entry);
+        }
+    }
+
+    /// <summary>
+    /// Replaces the host entry at the specified index.
+    /// </summary>
+    /// <param name="index">The zero-based index of the entry to replace.</param>
+    /// <param name="entry">The replacement entry.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="entry"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> is outside the bounds of the collection.</exception>
+    public void UpdateEntry(int index, HostEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        lock (_entriesLock)
+        {
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual((uint)index, (uint)_entries.Count, nameof(index));
+            _entries[index] = entry;
+        }
+    }
+
+    /// <summary>
+    /// Removes the first occurrence of the specified host entry.
+    /// </summary>
+    /// <param name="entry">The entry to remove.</param>
+    /// <returns><see langword="true"/> if the entry was found and removed; otherwise, <see langword="false"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="entry"/> is <see langword="null"/>.</exception>
+    public bool RemoveEntry(HostEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        lock (_entriesLock)
+        {
+            return _entries.Remove(entry);
+        }
+    }
+
+    /// <summary>
+    /// Removes the host entry at the specified index.
+    /// </summary>
+    /// <param name="index">The zero-based index of the entry to remove.</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> is outside the bounds of the collection.</exception>
+    public void RemoveEntryAt(int index)
+    {
+        lock (_entriesLock)
+        {
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual((uint)index, (uint)_entries.Count, nameof(index));
+            _entries.RemoveAt(index);
+        }
+    }
+
+    /// <summary>
+    /// Removes all host entries.
+    /// </summary>
+    public void ClearEntries()
+    {
+        lock (_entriesLock)
+        {
+            _entries.Clear();
+        }
     }
 
     /// <summary>
@@ -215,19 +323,25 @@ public sealed partial class Hosts : IDisposable
 
     private void ReadHosts(Stream hosts)
     {
-        Entries = new List<HostEntry>();
+        // Parse into a local list first, then swap it in atomically under the lock so
+        // concurrent readers (and the poll timer's Refresh) never observe a partially
+        // built collection.
+        List<HostEntry> parsed = [];
         using StreamReader reader = new(hosts);
+        int lineNumber = 0;
         while (!reader.EndOfStream)
         {
             string? line = reader.ReadLine()?.Trim();
 
             if (line == null) break;
 
+            lineNumber++;
+
             Match match = BlankRegex().Match(line);
 
             if (match.Success)
             {
-                Entries.Add(new HostEntry());
+                parsed.Add(new HostEntry());
                 continue;
             }
 
@@ -237,11 +351,11 @@ public sealed partial class Hosts : IDisposable
 
                 if (IPAddress.TryParse(match.Groups[1].Value.Trim(), out IPAddress? ip))
                 {
-                    Entries.Add(new HostEntry { Address = ip, Alias = match.Groups[2].Value.Trim(), Comment = match.Groups[3].Value.Trim(), IsCommented = true });
+                    parsed.Add(new HostEntry { Address = ip, Alias = match.Groups[2].Value.Trim(), Comment = match.Groups[3].Value.Trim(), IsCommented = true });
                 }
                 else
                 {
-                    Entries.Add(new HostEntry(line[1..]));
+                    parsed.Add(new HostEntry(line[1..]));
                 }
                 continue;
             }
@@ -252,11 +366,11 @@ public sealed partial class Hosts : IDisposable
 
                 if (IPAddress.TryParse(match.Groups[1].Value.Trim(), out IPAddress? ip))
                 {
-                    Entries.Add(new HostEntry { Address = ip, Alias = match.Groups[2].Value.Trim(), IsCommented = true });
+                    parsed.Add(new HostEntry { Address = ip, Alias = match.Groups[2].Value.Trim(), IsCommented = true });
                 }
                 else
                 {
-                    Entries.Add(new HostEntry(line[1..]));
+                    parsed.Add(new HostEntry(line[1..]));
                 }
                 continue;
             }
@@ -265,7 +379,7 @@ public sealed partial class Hosts : IDisposable
 
             if (match.Success)
             {
-                Entries.Add(new HostEntry(match.Groups[1].Value));
+                parsed.Add(new HostEntry(match.Groups[1].Value));
                 continue;
             }
 
@@ -276,11 +390,11 @@ public sealed partial class Hosts : IDisposable
 
                 if (IPAddress.TryParse(match.Groups[1].Value.Trim(), out IPAddress? ip))
                 {
-                    Entries.Add(new HostEntry { Address = ip, Alias = match.Groups[2].Value.Trim(), Comment = match.Groups[3].Value.Trim() });
+                    parsed.Add(new HostEntry { Address = ip, Alias = match.Groups[2].Value.Trim(), Comment = match.Groups[3].Value.Trim() });
                 }
                 else
                 {
-                    throw new FormatException(String.Format("Unexpected entry in hosts file: {0}", line));
+                    throw MalformedEntry(lineNumber, line);
                 }
                 continue;
             }
@@ -292,16 +406,22 @@ public sealed partial class Hosts : IDisposable
 
                 if (IPAddress.TryParse(match.Groups[1].Value.Trim(), out IPAddress? ip))
                 {
-                    Entries.Add(new HostEntry { Address = ip, Alias = match.Groups[2].Success ? match.Groups[2].Value.Trim() : null });
+                    parsed.Add(new HostEntry { Address = ip, Alias = match.Groups[2].Success ? match.Groups[2].Value.Trim() : null });
                 }
                 else
                 {
-                    throw new FormatException(String.Format("Unexpected entry in hosts file: {0}", line));
+                    throw MalformedEntry(lineNumber, line);
                 }
                 continue;
             }
 
-            throw new FormatException(String.Format("Unexpected entry in hosts file: {0}", line));
+            throw MalformedEntry(lineNumber, line);
+        }
+
+        lock (_entriesLock)
+        {
+            _entries.Clear();
+            _entries.AddRange(parsed);
         }
     }
 
@@ -332,6 +452,9 @@ public sealed partial class Hosts : IDisposable
     {
         HostsFileChanged?.Invoke(this, EventArgs.Empty);
     }
+
+    private static FormatException MalformedEntry(int lineNumber, string line) =>
+        new($"Malformed host entry at line {lineNumber}: '{line}'. Expected an IP address followed by an optional alias and comment (e.g. '127.0.0.1 localhost #comment').");
 
     [GeneratedRegex(@"^$")]
     private static partial Regex BlankRegex();

--- a/src/Asm.Win32/README.md
+++ b/src/Asm.Win32/README.md
@@ -39,8 +39,8 @@ foreach (var entry in hosts.Entries)
     }
 }
 
-// Add a new entry
-hosts.Entries.Add(new HostEntry
+// Add a new entry (Entries is a read-only snapshot; mutate via the methods below)
+hosts.AddEntry(new HostEntry
 {
     Address = IPAddress.Parse("192.168.1.100"),
     Alias = "myserver.local",
@@ -136,11 +136,14 @@ var commentEntry = new HostEntry("This is a section header");
 // Blank line
 var blankEntry = new HostEntry();
 
-hosts.Entries.Add(entry1);
-hosts.Entries.Add(entry2);
-hosts.Entries.Add(entry3);
-hosts.Entries.Add(commentEntry);
-hosts.Entries.Add(blankEntry);
+hosts.AddEntry(entry1);
+hosts.AddEntry(entry2);
+hosts.AddEntry(entry3);
+hosts.AddEntry(commentEntry);
+hosts.AddEntry(blankEntry);
+
+// Other mutators: InsertEntry(index, entry), UpdateEntry(index, entry),
+// RemoveEntry(entry), RemoveEntryAt(index), ClearEntries()
 
 // Save to file
 hosts.WriteHostsToFile(@"C:\temp\hosts");
@@ -177,7 +180,10 @@ using (var stream = File.Create("hosts-backup.txt"))
 - **Administrator Privileges**: Writing to the Windows hosts file requires administrator privileges
 - **File Location**: The Windows hosts file is typically located at `%SystemRoot%\system32\drivers\etc\hosts`
 - **Automatic Monitoring**: `Hosts.Current` automatically monitors the file for external changes every 10 seconds
-- **Thread Safety**: Be cautious when accessing `Hosts.Current` from multiple threads
+- **Windows only**: `Hosts` is annotated `[SupportedOSPlatform("windows")]`; calling it from non-Windows-scoped code raises analyzer warning CA1416
+- **Read-only entries**: `Entries` is an `IReadOnlyList<HostEntry>` snapshot — mutate with `AddEntry`/`InsertEntry`/`UpdateEntry`/`RemoveEntry`/`RemoveEntryAt`/`ClearEntries`
+- **Thread Safety**: reads of `Entries` and the background `Refresh` are safe to run concurrently; each `Entries` access returns an independent snapshot
+- **Malformed input**: a line that is not blank, not a comment, and not a valid IP entry throws `FormatException` naming the offending line and line number
 
 ## HostEntry Properties
 

--- a/tests/Asm.Win32.Tests/Asm.Win32.Tests.csproj
+++ b/tests/Asm.Win32.Tests/Asm.Win32.Tests.csproj
@@ -2,8 +2,20 @@
 
   <PropertyGroup>
     <CoverletInclude>[Asm.Win32]*</CoverletInclude>
-    <CoverletExcludeByFile>**/*</CoverletExcludeByFile> 
+    <CoverletExcludeByFile>**/*</CoverletExcludeByFile>
   </PropertyGroup>
+
+  <!--
+    Asm.Win32.Hosts is annotated [SupportedOSPlatform("windows")]. These tests deliberately
+    exercise it cross-platform via injected streams and temp files, so the test assembly
+    declares the same platform support to keep the CA1416 analyzer satisfied (the attribute
+    is analyzer-only and does not affect runtime execution on Linux CI).
+  -->
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.Versioning.SupportedOSPlatform">
+      <_Parameter1>windows</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector">

--- a/tests/Asm.Win32.Tests/Hosts.feature
+++ b/tests/Asm.Win32.Tests/Hosts.feature
@@ -59,6 +59,70 @@ Scenario: Invalid entry throws FormatException
     When I create a Hosts instance from the invalid stream
     Then an exception of type 'System.FormatException' is thrown
 
+@Unit
+Scenario: Malformed entry throws an actionable exception naming the line
+    Given I have a hosts file stream with an invalid entry
+    When I create a Hosts instance from the invalid stream
+    Then an exception of type 'System.FormatException' is thrown
+    And the exception message should contain "Wibble"
+    And the exception message should contain "line 2"
+
+@Unit
+Scenario: AddEntry appends a host entry
+    Given I have a hosts file stream with standard entries
+    And I create a Hosts instance from the stream
+    When I add a host entry for "10.0.0.1" aliased "added"
+    Then the hosts file should have 9 entries
+    And entry 8 should have address "10.0.0.1"
+    And entry 8 should have alias "added"
+
+@Unit
+Scenario: InsertEntry inserts a host entry at an index
+    Given I have a hosts file stream with standard entries
+    And I create a Hosts instance from the stream
+    When I insert a host entry for "10.0.0.2" aliased "inserted" at index 0
+    Then the hosts file should have 9 entries
+    And entry 0 should have address "10.0.0.2"
+    And entry 0 should have alias "inserted"
+
+@Unit
+Scenario: UpdateEntry replaces a host entry
+    Given I have a hosts file stream with standard entries
+    And I create a Hosts instance from the stream
+    When I update entry 4 with alias "updated"
+    Then entry 4 should have alias "updated"
+    And the hosts file should have 8 entries
+
+@Unit
+Scenario: ClearEntries removes all host entries
+    Given I have a hosts file stream with standard entries
+    And I create a Hosts instance from the stream
+    When I clear all entries
+    Then the hosts file should have 0 entries
+
+@Unit
+Scenario: AddEntry rejects a null entry
+    Given I have a hosts file stream with standard entries
+    And I create a Hosts instance from the stream
+    When I try to add a null host entry
+    Then an exception of type 'System.ArgumentNullException' is thrown
+
+@Unit
+Scenario: Entries returns an immutable snapshot
+    Given I have a hosts file stream with standard entries
+    And I create a Hosts instance from the stream
+    When I capture the current entries snapshot
+    And I add a host entry for "10.0.0.9" aliased "later"
+    Then the captured snapshot should still have 8 entries
+    And the hosts file should have 9 entries
+
+@Integration
+Scenario: Concurrent refresh and read does not tear
+    Given I have a mock hosts file on disk
+    And I create a Hosts instance from the file path
+    When I concurrently refresh and read the entries
+    Then no exception is thrown
+
 @Integration
 Scenario: Load hosts file from file path
     Given I have a mock hosts file on disk

--- a/tests/Asm.Win32.Tests/Hosts.feature.cs
+++ b/tests/Asm.Win32.Tests/Hosts.feature.cs
@@ -105,7 +105,7 @@ namespace Asm.Win32.Tests
         
         private static global::Reqnroll.Formatters.RuntimeSupport.FeatureLevelCucumberMessages InitializeCucumberMessages()
         {
-            return new global::Reqnroll.Formatters.RuntimeSupport.FeatureLevelCucumberMessages("Hosts.feature.ndjson", 18);
+            return new global::Reqnroll.Formatters.RuntimeSupport.FeatureLevelCucumberMessages("Hosts.feature.ndjson", 26);
         }
         
         async System.Threading.Tasks.ValueTask Xunit.IAsyncLifetime.InitializeAsync()
@@ -436,17 +436,17 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             await this.ScenarioCleanupAsync();
         }
         
-        [global::Xunit.FactAttribute(DisplayName="Load hosts file from file path")]
+        [global::Xunit.FactAttribute(DisplayName="Malformed entry throws an actionable exception naming the line")]
         [global::Xunit.TraitAttribute("FeatureTitle", "Hosts File Parsing")]
-        [global::Xunit.TraitAttribute("Description", "Load hosts file from file path")]
-        [global::Xunit.TraitAttribute("Category", "Integration")]
-        public async global::System.Threading.Tasks.Task LoadHostsFileFromFilePath()
+        [global::Xunit.TraitAttribute("Description", "Malformed entry throws an actionable exception naming the line")]
+        [global::Xunit.TraitAttribute("Category", "Unit")]
+        public async global::System.Threading.Tasks.Task MalformedEntryThrowsAnActionableExceptionNamingTheLine()
         {
             string[] tagsOfScenario = new string[] {
-                    "Integration"};
+                    "Unit"};
             global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
             string pickleIndex = "7";
-            global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Load hosts file from file path", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
+            global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Malformed entry throws an actionable exception naming the line", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
 #line 63
@@ -460,21 +460,357 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             {
                 await this.ScenarioStartAsync();
 #line 64
-    await testRunner.GivenAsync("I have a mock hosts file on disk", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
+    await testRunner.GivenAsync("I have a hosts file stream with an invalid entry", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
 #line 65
-    await testRunner.WhenAsync("I create a Hosts instance from the file path", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
+    await testRunner.WhenAsync("I create a Hosts instance from the invalid stream", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
 #line 66
-    await testRunner.ThenAsync("the hosts file should have 2 entries", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
+    await testRunner.ThenAsync("an exception of type \'System.FormatException\' is thrown", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
 #line 67
-    await testRunner.AndAsync("entry 0 should be an IPv4Entry", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
+    await testRunner.AndAsync("the exception message should contain \"Wibble\"", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
 #line hidden
 #line 68
+    await testRunner.AndAsync("the exception message should contain \"line 2\"", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
+#line hidden
+            }
+            await this.ScenarioCleanupAsync();
+        }
+        
+        [global::Xunit.FactAttribute(DisplayName="AddEntry appends a host entry")]
+        [global::Xunit.TraitAttribute("FeatureTitle", "Hosts File Parsing")]
+        [global::Xunit.TraitAttribute("Description", "AddEntry appends a host entry")]
+        [global::Xunit.TraitAttribute("Category", "Unit")]
+        public async global::System.Threading.Tasks.Task AddEntryAppendsAHostEntry()
+        {
+            string[] tagsOfScenario = new string[] {
+                    "Unit"};
+            global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
+            string pickleIndex = "8";
+            global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("AddEntry appends a host entry", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
+            string[] tagsOfRule = ((string[])(null));
+            global::Reqnroll.RuleInfo ruleInfo = null;
+#line 71
+this.ScenarioInitialize(scenarioInfo, ruleInfo);
+#line hidden
+            if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
+            {
+                await testRunner.SkipScenarioAsync();
+            }
+            else
+            {
+                await this.ScenarioStartAsync();
+#line 72
+    await testRunner.GivenAsync("I have a hosts file stream with standard entries", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
+#line hidden
+#line 73
+    await testRunner.AndAsync("I create a Hosts instance from the stream", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
+#line hidden
+#line 74
+    await testRunner.WhenAsync("I add a host entry for \"10.0.0.1\" aliased \"added\"", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
+#line hidden
+#line 75
+    await testRunner.ThenAsync("the hosts file should have 9 entries", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
+#line hidden
+#line 76
+    await testRunner.AndAsync("entry 8 should have address \"10.0.0.1\"", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
+#line hidden
+#line 77
+    await testRunner.AndAsync("entry 8 should have alias \"added\"", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
+#line hidden
+            }
+            await this.ScenarioCleanupAsync();
+        }
+        
+        [global::Xunit.FactAttribute(DisplayName="InsertEntry inserts a host entry at an index")]
+        [global::Xunit.TraitAttribute("FeatureTitle", "Hosts File Parsing")]
+        [global::Xunit.TraitAttribute("Description", "InsertEntry inserts a host entry at an index")]
+        [global::Xunit.TraitAttribute("Category", "Unit")]
+        public async global::System.Threading.Tasks.Task InsertEntryInsertsAHostEntryAtAnIndex()
+        {
+            string[] tagsOfScenario = new string[] {
+                    "Unit"};
+            global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
+            string pickleIndex = "9";
+            global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("InsertEntry inserts a host entry at an index", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
+            string[] tagsOfRule = ((string[])(null));
+            global::Reqnroll.RuleInfo ruleInfo = null;
+#line 80
+this.ScenarioInitialize(scenarioInfo, ruleInfo);
+#line hidden
+            if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
+            {
+                await testRunner.SkipScenarioAsync();
+            }
+            else
+            {
+                await this.ScenarioStartAsync();
+#line 81
+    await testRunner.GivenAsync("I have a hosts file stream with standard entries", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
+#line hidden
+#line 82
+    await testRunner.AndAsync("I create a Hosts instance from the stream", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
+#line hidden
+#line 83
+    await testRunner.WhenAsync("I insert a host entry for \"10.0.0.2\" aliased \"inserted\" at index 0", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
+#line hidden
+#line 84
+    await testRunner.ThenAsync("the hosts file should have 9 entries", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
+#line hidden
+#line 85
+    await testRunner.AndAsync("entry 0 should have address \"10.0.0.2\"", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
+#line hidden
+#line 86
+    await testRunner.AndAsync("entry 0 should have alias \"inserted\"", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
+#line hidden
+            }
+            await this.ScenarioCleanupAsync();
+        }
+        
+        [global::Xunit.FactAttribute(DisplayName="UpdateEntry replaces a host entry")]
+        [global::Xunit.TraitAttribute("FeatureTitle", "Hosts File Parsing")]
+        [global::Xunit.TraitAttribute("Description", "UpdateEntry replaces a host entry")]
+        [global::Xunit.TraitAttribute("Category", "Unit")]
+        public async global::System.Threading.Tasks.Task UpdateEntryReplacesAHostEntry()
+        {
+            string[] tagsOfScenario = new string[] {
+                    "Unit"};
+            global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
+            string pickleIndex = "10";
+            global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("UpdateEntry replaces a host entry", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
+            string[] tagsOfRule = ((string[])(null));
+            global::Reqnroll.RuleInfo ruleInfo = null;
+#line 89
+this.ScenarioInitialize(scenarioInfo, ruleInfo);
+#line hidden
+            if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
+            {
+                await testRunner.SkipScenarioAsync();
+            }
+            else
+            {
+                await this.ScenarioStartAsync();
+#line 90
+    await testRunner.GivenAsync("I have a hosts file stream with standard entries", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
+#line hidden
+#line 91
+    await testRunner.AndAsync("I create a Hosts instance from the stream", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
+#line hidden
+#line 92
+    await testRunner.WhenAsync("I update entry 4 with alias \"updated\"", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
+#line hidden
+#line 93
+    await testRunner.ThenAsync("entry 4 should have alias \"updated\"", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
+#line hidden
+#line 94
+    await testRunner.AndAsync("the hosts file should have 8 entries", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
+#line hidden
+            }
+            await this.ScenarioCleanupAsync();
+        }
+        
+        [global::Xunit.FactAttribute(DisplayName="ClearEntries removes all host entries")]
+        [global::Xunit.TraitAttribute("FeatureTitle", "Hosts File Parsing")]
+        [global::Xunit.TraitAttribute("Description", "ClearEntries removes all host entries")]
+        [global::Xunit.TraitAttribute("Category", "Unit")]
+        public async global::System.Threading.Tasks.Task ClearEntriesRemovesAllHostEntries()
+        {
+            string[] tagsOfScenario = new string[] {
+                    "Unit"};
+            global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
+            string pickleIndex = "11";
+            global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("ClearEntries removes all host entries", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
+            string[] tagsOfRule = ((string[])(null));
+            global::Reqnroll.RuleInfo ruleInfo = null;
+#line 97
+this.ScenarioInitialize(scenarioInfo, ruleInfo);
+#line hidden
+            if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
+            {
+                await testRunner.SkipScenarioAsync();
+            }
+            else
+            {
+                await this.ScenarioStartAsync();
+#line 98
+    await testRunner.GivenAsync("I have a hosts file stream with standard entries", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
+#line hidden
+#line 99
+    await testRunner.AndAsync("I create a Hosts instance from the stream", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
+#line hidden
+#line 100
+    await testRunner.WhenAsync("I clear all entries", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
+#line hidden
+#line 101
+    await testRunner.ThenAsync("the hosts file should have 0 entries", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
+#line hidden
+            }
+            await this.ScenarioCleanupAsync();
+        }
+        
+        [global::Xunit.FactAttribute(DisplayName="AddEntry rejects a null entry")]
+        [global::Xunit.TraitAttribute("FeatureTitle", "Hosts File Parsing")]
+        [global::Xunit.TraitAttribute("Description", "AddEntry rejects a null entry")]
+        [global::Xunit.TraitAttribute("Category", "Unit")]
+        public async global::System.Threading.Tasks.Task AddEntryRejectsANullEntry()
+        {
+            string[] tagsOfScenario = new string[] {
+                    "Unit"};
+            global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
+            string pickleIndex = "12";
+            global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("AddEntry rejects a null entry", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
+            string[] tagsOfRule = ((string[])(null));
+            global::Reqnroll.RuleInfo ruleInfo = null;
+#line 104
+this.ScenarioInitialize(scenarioInfo, ruleInfo);
+#line hidden
+            if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
+            {
+                await testRunner.SkipScenarioAsync();
+            }
+            else
+            {
+                await this.ScenarioStartAsync();
+#line 105
+    await testRunner.GivenAsync("I have a hosts file stream with standard entries", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
+#line hidden
+#line 106
+    await testRunner.AndAsync("I create a Hosts instance from the stream", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
+#line hidden
+#line 107
+    await testRunner.WhenAsync("I try to add a null host entry", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
+#line hidden
+#line 108
+    await testRunner.ThenAsync("an exception of type \'System.ArgumentNullException\' is thrown", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
+#line hidden
+            }
+            await this.ScenarioCleanupAsync();
+        }
+        
+        [global::Xunit.FactAttribute(DisplayName="Entries returns an immutable snapshot")]
+        [global::Xunit.TraitAttribute("FeatureTitle", "Hosts File Parsing")]
+        [global::Xunit.TraitAttribute("Description", "Entries returns an immutable snapshot")]
+        [global::Xunit.TraitAttribute("Category", "Unit")]
+        public async global::System.Threading.Tasks.Task EntriesReturnsAnImmutableSnapshot()
+        {
+            string[] tagsOfScenario = new string[] {
+                    "Unit"};
+            global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
+            string pickleIndex = "13";
+            global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Entries returns an immutable snapshot", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
+            string[] tagsOfRule = ((string[])(null));
+            global::Reqnroll.RuleInfo ruleInfo = null;
+#line 111
+this.ScenarioInitialize(scenarioInfo, ruleInfo);
+#line hidden
+            if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
+            {
+                await testRunner.SkipScenarioAsync();
+            }
+            else
+            {
+                await this.ScenarioStartAsync();
+#line 112
+    await testRunner.GivenAsync("I have a hosts file stream with standard entries", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
+#line hidden
+#line 113
+    await testRunner.AndAsync("I create a Hosts instance from the stream", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
+#line hidden
+#line 114
+    await testRunner.WhenAsync("I capture the current entries snapshot", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
+#line hidden
+#line 115
+    await testRunner.AndAsync("I add a host entry for \"10.0.0.9\" aliased \"later\"", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
+#line hidden
+#line 116
+    await testRunner.ThenAsync("the captured snapshot should still have 8 entries", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
+#line hidden
+#line 117
+    await testRunner.AndAsync("the hosts file should have 9 entries", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
+#line hidden
+            }
+            await this.ScenarioCleanupAsync();
+        }
+        
+        [global::Xunit.FactAttribute(DisplayName="Concurrent refresh and read does not tear")]
+        [global::Xunit.TraitAttribute("FeatureTitle", "Hosts File Parsing")]
+        [global::Xunit.TraitAttribute("Description", "Concurrent refresh and read does not tear")]
+        [global::Xunit.TraitAttribute("Category", "Integration")]
+        public async global::System.Threading.Tasks.Task ConcurrentRefreshAndReadDoesNotTear()
+        {
+            string[] tagsOfScenario = new string[] {
+                    "Integration"};
+            global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
+            string pickleIndex = "14";
+            global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Concurrent refresh and read does not tear", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
+            string[] tagsOfRule = ((string[])(null));
+            global::Reqnroll.RuleInfo ruleInfo = null;
+#line 120
+this.ScenarioInitialize(scenarioInfo, ruleInfo);
+#line hidden
+            if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
+            {
+                await testRunner.SkipScenarioAsync();
+            }
+            else
+            {
+                await this.ScenarioStartAsync();
+#line 121
+    await testRunner.GivenAsync("I have a mock hosts file on disk", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
+#line hidden
+#line 122
+    await testRunner.AndAsync("I create a Hosts instance from the file path", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
+#line hidden
+#line 123
+    await testRunner.WhenAsync("I concurrently refresh and read the entries", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
+#line hidden
+#line 124
+    await testRunner.ThenAsync("no exception is thrown", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
+#line hidden
+            }
+            await this.ScenarioCleanupAsync();
+        }
+        
+        [global::Xunit.FactAttribute(DisplayName="Load hosts file from file path")]
+        [global::Xunit.TraitAttribute("FeatureTitle", "Hosts File Parsing")]
+        [global::Xunit.TraitAttribute("Description", "Load hosts file from file path")]
+        [global::Xunit.TraitAttribute("Category", "Integration")]
+        public async global::System.Threading.Tasks.Task LoadHostsFileFromFilePath()
+        {
+            string[] tagsOfScenario = new string[] {
+                    "Integration"};
+            global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
+            string pickleIndex = "15";
+            global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Load hosts file from file path", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
+            string[] tagsOfRule = ((string[])(null));
+            global::Reqnroll.RuleInfo ruleInfo = null;
+#line 127
+this.ScenarioInitialize(scenarioInfo, ruleInfo);
+#line hidden
+            if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
+            {
+                await testRunner.SkipScenarioAsync();
+            }
+            else
+            {
+                await this.ScenarioStartAsync();
+#line 128
+    await testRunner.GivenAsync("I have a mock hosts file on disk", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
+#line hidden
+#line 129
+    await testRunner.WhenAsync("I create a Hosts instance from the file path", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
+#line hidden
+#line 130
+    await testRunner.ThenAsync("the hosts file should have 2 entries", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
+#line hidden
+#line 131
+    await testRunner.AndAsync("entry 0 should be an IPv4Entry", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
+#line hidden
+#line 132
     await testRunner.AndAsync("entry 0 should have address \"127.0.0.1\"", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
 #line hidden
-#line 69
+#line 133
     await testRunner.AndAsync("entry 0 should have alias \"localhost\"", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
 #line hidden
             }
@@ -490,11 +826,11 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             string[] tagsOfScenario = new string[] {
                     "Integration"};
             global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
-            string pickleIndex = "8";
+            string pickleIndex = "16";
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Static Current property loads system hosts file", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
-#line 72
+#line 136
 this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
             if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
@@ -504,16 +840,16 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-#line 73
+#line 137
     await testRunner.GivenAsync("I have a mock hosts file configured as the system hosts file", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
-#line 74
+#line 138
     await testRunner.WhenAsync("I access the Current hosts instance", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
-#line 75
+#line 139
     await testRunner.ThenAsync("the hosts file should have 2 entries", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
-#line 76
+#line 140
     await testRunner.AndAsync("entry 0 should have alias \"localhost\"", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
 #line hidden
             }
@@ -529,11 +865,11 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             string[] tagsOfScenario = new string[] {
                     "Integration"};
             global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
-            string pickleIndex = "9";
+            string pickleIndex = "17";
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Refresh reloads hosts file from disk", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
-#line 79
+#line 143
 this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
             if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
@@ -543,19 +879,19 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-#line 80
+#line 144
     await testRunner.GivenAsync("I have a mock hosts file on disk", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
-#line 81
+#line 145
     await testRunner.AndAsync("I create a Hosts instance from the file path", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
 #line hidden
-#line 82
+#line 146
     await testRunner.WhenAsync("I update the mock hosts file with new content", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
-#line 83
+#line 147
     await testRunner.AndAsync("I call Refresh", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
 #line hidden
-#line 84
+#line 148
     await testRunner.ThenAsync("the hosts file should have 3 entries", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }
@@ -571,11 +907,11 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             string[] tagsOfScenario = new string[] {
                     "Unit"};
             global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
-            string pickleIndex = "10";
+            string pickleIndex = "18";
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("WriteHosts writes entries to stream", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
-#line 87
+#line 151
 this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
             if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
@@ -585,16 +921,16 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-#line 88
+#line 152
     await testRunner.GivenAsync("I have a hosts file stream with standard entries", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
-#line 89
+#line 153
     await testRunner.AndAsync("I create a Hosts instance from the stream", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
 #line hidden
-#line 90
+#line 154
     await testRunner.WhenAsync("I write the hosts to an output stream", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
-#line 91
+#line 155
     await testRunner.ThenAsync("the output stream should contain the hosts content", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }
@@ -610,11 +946,11 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             string[] tagsOfScenario = new string[] {
                     "Integration"};
             global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
-            string pickleIndex = "11";
+            string pickleIndex = "19";
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Non-existent file throws ArgumentException", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
-#line 94
+#line 158
 this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
             if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
@@ -624,13 +960,13 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-#line 95
+#line 159
     await testRunner.GivenAsync("I have a path to a non-existent hosts file", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
-#line 96
+#line 160
     await testRunner.WhenAsync("I create a Hosts instance from the non-existent file", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
-#line 97
+#line 161
     await testRunner.ThenAsync("an exception of type \'System.ArgumentException\' is thrown", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }
@@ -646,11 +982,11 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             string[] tagsOfScenario = new string[] {
                     "Unit"};
             global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
-            string pickleIndex = "12";
+            string pickleIndex = "20";
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Address-only line loads without error", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
-#line 100
+#line 164
 this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
             if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
@@ -660,22 +996,22 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-#line 101
+#line 165
     await testRunner.GivenAsync("I have a hosts file stream with an address-only entry", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
-#line 102
+#line 166
     await testRunner.WhenAsync("I create a Hosts instance from the stream", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
-#line 103
+#line 167
     await testRunner.ThenAsync("the hosts file should have 2 entries", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
-#line 104
+#line 168
     await testRunner.AndAsync("entry 0 should have address \"127.0.0.1\"", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
 #line hidden
-#line 105
+#line 169
     await testRunner.AndAsync("entry 1 should have address \"127.0.0.2\"", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
 #line hidden
-#line 106
+#line 170
     await testRunner.AndAsync("entry 1 should have alias \"host2\"", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
 #line hidden
             }
@@ -691,11 +1027,11 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             string[] tagsOfScenario = new string[] {
                     "Integration"};
             global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
-            string pickleIndex = "13";
+            string pickleIndex = "21";
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Writing fewer entries truncates the hosts file", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
-#line 109
+#line 173
 this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
             if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
@@ -705,22 +1041,22 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-#line 110
+#line 174
     await testRunner.GivenAsync("I have a mock hosts file configured as the system hosts file", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
-#line 111
+#line 175
     await testRunner.AndAsync("I create a Hosts instance from the file path", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
 #line hidden
-#line 112
+#line 176
     await testRunner.WhenAsync("I remove the last entry", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
-#line 113
+#line 177
     await testRunner.AndAsync("I write the hosts file", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
 #line hidden
-#line 114
+#line 178
     await testRunner.AndAsync("I call Refresh", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
 #line hidden
-#line 115
+#line 179
     await testRunner.ThenAsync("the hosts file should have 1 entries", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }
@@ -736,11 +1072,11 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             string[] tagsOfScenario = new string[] {
                     "Integration"};
             global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
-            string pickleIndex = "14";
+            string pickleIndex = "22";
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Parameterless write targets the instance\'s own file", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
-#line 118
+#line 182
 this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
             if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
@@ -750,25 +1086,25 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-#line 119
+#line 183
     await testRunner.GivenAsync("I have a mock hosts file configured as the system hosts file", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
-#line 120
+#line 184
     await testRunner.AndAsync("I have a second mock hosts file on disk", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
 #line hidden
-#line 121
+#line 185
     await testRunner.AndAsync("I create a Hosts instance from the second file path", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
 #line hidden
-#line 122
+#line 186
     await testRunner.WhenAsync("I remove the last entry", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
-#line 123
+#line 187
     await testRunner.AndAsync("I write the hosts file", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
 #line hidden
-#line 124
+#line 188
     await testRunner.ThenAsync("the second mock hosts file should have 1 entries on disk", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
-#line 125
+#line 189
     await testRunner.AndAsync("the system hosts file should be unchanged", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
 #line hidden
             }
@@ -784,11 +1120,11 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             string[] tagsOfScenario = new string[] {
                     "Integration"};
             global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
-            string pickleIndex = "15";
+            string pickleIndex = "23";
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Setting SystemHostsFile resets the Current instance", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
-#line 128
+#line 192
 this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
             if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
@@ -798,19 +1134,19 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-#line 129
+#line 193
     await testRunner.GivenAsync("I have a mock hosts file configured as the system hosts file", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
-#line 130
+#line 194
     await testRunner.AndAsync("I access the Current hosts instance", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
 #line hidden
-#line 131
+#line 195
     await testRunner.WhenAsync("I configure a second mock hosts file as the system hosts file", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
-#line 132
+#line 196
     await testRunner.AndAsync("I access the Current hosts instance", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
 #line hidden
-#line 133
+#line 197
     await testRunner.ThenAsync("the hosts file should have 3 entries", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }

--- a/tests/Asm.Win32.Tests/HostsSteps.cs
+++ b/tests/Asm.Win32.Tests/HostsSteps.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Text;
 
 namespace Asm.Win32.Tests;
@@ -6,6 +7,7 @@ namespace Asm.Win32.Tests;
 public class HostsSteps(ScenarioContext context) : IDisposable
 {
     private Hosts _hosts = null!;
+    private IReadOnlyList<HostEntry> _snapshot = null!;
     private MemoryStream _inputStream = null!;
     private MemoryStream _outputStream = null!;
     private string _tempFilePath = null!;
@@ -140,7 +142,77 @@ public class HostsSteps(ScenarioContext context) : IDisposable
     [When(@"I remove the last entry")]
     public void WhenIRemoveTheLastEntry()
     {
-        _hosts.Entries.RemoveAt(_hosts.Entries.Count - 1);
+        _hosts.RemoveEntryAt(_hosts.Entries.Count - 1);
+    }
+
+    [When(@"I add a host entry for ""(.*)"" aliased ""(.*)""")]
+    public void WhenIAddAHostEntry(string address, string alias)
+    {
+        _hosts.AddEntry(new HostEntry(IPAddress.Parse(address), alias, null, false));
+    }
+
+    [When(@"I insert a host entry for ""(.*)"" aliased ""(.*)"" at index (.*)")]
+    public void WhenIInsertAHostEntry(string address, string alias, int index)
+    {
+        _hosts.InsertEntry(index, new HostEntry(IPAddress.Parse(address), alias, null, false));
+    }
+
+    [When(@"I update entry (.*) with alias ""(.*)""")]
+    public void WhenIUpdateEntry(int index, string alias)
+    {
+        HostEntry existing = _hosts.Entries[index];
+        _hosts.UpdateEntry(index, new HostEntry(existing.Address, alias, existing.Comment, existing.IsCommented));
+    }
+
+    [When(@"I clear all entries")]
+    public void WhenIClearAllEntries()
+    {
+        _hosts.ClearEntries();
+    }
+
+    [When(@"I try to add a null host entry")]
+    public void WhenITryToAddANullHostEntry()
+    {
+        context.CatchException(() => _hosts.AddEntry(null!));
+    }
+
+    [When(@"I concurrently refresh and read the entries")]
+    public void WhenIConcurrentlyRefreshAndReadTheEntries()
+    {
+        // Repeatedly refresh on one thread while another enumerates the read-only
+        // snapshot. A non-thread-safe implementation would tear or throw here.
+        using CancellationTokenSource cts = new();
+        Exception failure = null;
+
+        Thread reader = new(() =>
+        {
+            try
+            {
+                while (!cts.Token.IsCancellationRequested)
+                {
+                    foreach (HostEntry entry in _hosts.Entries)
+                    {
+                        _ = entry.EntryType;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                failure = ex;
+            }
+        });
+
+        reader.Start();
+
+        for (int i = 0; i < 200; i++)
+        {
+            _hosts.Refresh();
+        }
+
+        cts.Cancel();
+        reader.Join();
+
+        Assert.Null(failure);
     }
 
     [When(@"I write the hosts file")]
@@ -171,6 +243,12 @@ public class HostsSteps(ScenarioContext context) : IDisposable
         _hosts.Refresh();
     }
 
+    [When(@"I capture the current entries snapshot")]
+    public void WhenICaptureTheCurrentEntriesSnapshot()
+    {
+        _snapshot = _hosts.Entries;
+    }
+
     [When(@"I write the hosts to an output stream")]
     public void WhenIWriteTheHostsToAnOutputStream()
     {
@@ -183,6 +261,20 @@ public class HostsSteps(ScenarioContext context) : IDisposable
     public void ThenTheHostsFileShouldHaveEntries(int count)
     {
         Assert.Equal(count, _hosts.Entries.Count);
+    }
+
+    [Then(@"the captured snapshot should still have (.*) entries")]
+    public void ThenTheCapturedSnapshotShouldStillHaveEntries(int count)
+    {
+        Assert.Equal(count, _snapshot.Count);
+    }
+
+    [Then(@"the exception message should contain ""(.*)""")]
+    public void ThenTheExceptionMessageShouldContain(string fragment)
+    {
+        Exception ex = context.GetException();
+        Assert.NotNull(ex);
+        Assert.Contains(fragment, ex.Message);
     }
 
     [Then(@"entry (.*) should be a Comment")]


### PR DESCRIPTION
## Phase 5 Batch 4 — Hosts redesign

Hardens `Asm.Win32.Hosts` (the Windows hosts-file reader/writer) for v4.0. Targets `release/v4.0`. `HostEntry`/`HostEntryType` are unchanged.

### Changes
1. **Read-only `Entries` + explicit mutators.** `Entries` changes from a mutable `IList<HostEntry>` to an immutable `IReadOnlyList<HostEntry>` snapshot. Mutation now goes through `AddEntry`, `InsertEntry`, `UpdateEntry`, `RemoveEntry`, `RemoveEntryAt`, `ClearEntries` (null-guarded via `ArgumentNullException.ThrowIfNull`; index-guarded via `ArgumentOutOfRangeException`).
2. **Thread-safe refresh.** Parsing builds a local list and swaps it into shared state under a dedicated instance `Lock`; `Entries` returns a locked snapshot. The background poll-timer `Refresh` can now run concurrently with reads without tearing or throwing `InvalidOperationException`.
3. **`[SupportedOSPlatform("windows")]`** on the `Hosts` class (it reads `%SystemRoot%\System32\drivers\etc\hosts`). `HostEntry`/`HostEntryType` stay platform-neutral.
4. **Throw on malformed input.** A non-blank, non-comment line whose first token is not a valid IP now throws `FormatException` with an actionable message naming the offending line **and line number** (e.g. `Malformed host entry at line 2: 'Wibble'. Expected an IP address ...`) instead of a terse message. Type stays `FormatException` so `catch` blocks are unaffected.

### Design decisions
- **`Entries` returns a fresh snapshot per access** (a `HostEntry[]` taken under lock). This is the simplest tear-free contract: consumers can enumerate/index freely while a refresh or mutation happens on another thread. A captured reference does not observe later mutations (documented).
- **Mutators are named `*Entry`** rather than exposing `IList` — keeps the read/write boundary explicit and lets each mutation be guarded and locked.
- **No `[Obsolete]` shim for `Entries`.** This is a *type* change on an existing member, not a rename; old mutation call sites (`Entries.Add(...)`) cannot compile against the new type regardless, so a forwarder is not possible. The rename-with-forwarder rule applies to renamed members, of which there are none here.
- **CA1416 on Linux CI:** the `Asm.Win32.Tests` assembly declares `[assembly: SupportedOSPlatform("windows")]` (via an `AssemblyAttribute` MSBuild item). It is analyzer-only, so the tests still run on Linux CI, and it keeps the annotated type warning-free without suppressions.
- **Malformed commented lines** (e.g. `# some note`) remain valid comments — commenting is inherently free-form, so only genuinely malformed *address* lines throw.

### Tests
- `tests/Asm.Win32.Tests`: **16 → 24** scenarios. New: AddEntry/InsertEntry/UpdateEntry/ClearEntries, null-guard, immutable-snapshot semantics, concurrent refresh-vs-read, and the actionable malformed-line throw (asserts message contains the line text and `line 2`). Existing `RemoveAt` step switched to `RemoveEntryAt`.
- Red→green verified for both bug fixes: the malformed-message test fails against the old terse message; the concurrent-read and snapshot tests fail (`InvalidOperationException` / wrong count) against a live-list getter.
- Full solution `dotnet test Asm.slnx -c Release`: **all projects green**, zero new warnings (only a pre-existing CS8632 in `HostsSteps.cs` remains).

### Docs
- `docs/migration-v4.md`: appended the **Batch 4 — Hosts redesign** section (breaking changes + migration table).
- `src/Asm.Win32/README.md`: updated examples to the new mutator API and notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
