### PR TITLE
Phase 5 Batch 3: repositories & specifications

### DIFF
--- a/docs/migration-v4.md
+++ b/docs/migration-v4.md
@@ -300,3 +300,95 @@ services.AddSecurityReporting();
 - The old order-dependent auto-coupling (a `services.FirstOrDefault(...)` probe inside `AddStandardSecurityHeaders`) has been removed.
 
 **What to change:** nothing is required. Behaviour only improves — reporting headers are now emitted regardless of the order in which the two methods were registered. If your code relied on the old behaviour of *suppressing* reporting headers by deliberately registering reporting last, register the two methods in separate service collections instead.
+
+## Batch 3 — Repositories & specifications
+
+This batch tightens the repository generics, adds ergonomic lookup and bulk-add members, and reworks
+`ISpecification<TEntity>` so specifications can target any class and be composed with `And`/`Or`/`Not`.
+
+### Repository key constraint relaxed: `struct` → `notnull`
+
+`IRepository<TEntity, TKey>`, `IWritableRepository<TEntity, TKey>`, `IDeletableRepository<TEntity, TKey>`
+and the `RepositoryBase`/`RepositoryWriteBase`/`RepositoryDeleteBase` classes previously constrained
+`TKey` to `struct` (non-nullable value types only). They now constrain it to `notnull`, which additionally
+permits **reference-type keys** such as `string`.
+
+**What to change:** nothing. `notnull` is a *wider* constraint than `struct`, so every existing value-type
+key (`int`, `Guid`, …) still satisfies it and all existing repositories compile unchanged. You may now
+declare repositories over string- or record-keyed entities.
+
+### `AddRange` is now on `IWritableRepository`
+
+`RepositoryWriteBase` already exposed `AddRange`; the member is now declared on the
+`IWritableRepository<TEntity, TKey>` interface so it can be called through the abstraction. It ships as a
+**default interface method** (adds each entity via `Add`), so existing implementers are not broken;
+`RepositoryWriteBase` overrides it with the provider-optimised `DbSet.AddRange`.
+
+**What to change:** nothing. Override `AddRange` if you want a bulk-optimised path.
+
+### New null-returning lookups: `Find` and `TryGet`
+
+`Get(TKey …)` throws `NotFoundException` when the entity is absent — unchanged. Two new
+**default interface methods** return `TEntity?` (null) instead, for when a missing entity is an expected
+outcome:
+
+```csharp
+Task<TEntity?> Find(TKey id, CancellationToken ct = default);
+Task<TEntity?> Find(TKey id, ISpecification<TEntity> specification, CancellationToken ct = default);
+Task<TEntity?> TryGet(TKey id, CancellationToken ct = default);            // alias for Find
+Task<TEntity?> TryGet(TKey id, ISpecification<TEntity> specification, CancellationToken ct = default);
+```
+
+`RepositoryBase` overrides `Find`/`TryGet` with an efficient keyed query (`SingleOrDefaultAsync`); the
+interface default (filtering the full collection) exists only for hand-rolled implementations.
+
+**What to change:** nothing. Prefer `Get` when absence is an error (it throws `NotFoundException`), and
+`Find`/`TryGet` when absence is normal (they return `null`).
+
+### `ISpecification<TEntity>` — relaxed constraint, expression criteria, and composition
+
+**Breaking (widening):** the constraint changed from `where TEntity : Entity` to `where TEntity : class`,
+so specifications can now target read models, DTOs and projected interfaces — not just domain entities.
+`Entity` is a class, so existing entity specifications are unaffected, and the `IQueryable.Specify(…)`
+extensions were relaxed to `class` to match.
+
+The interface gained an **expression-based criterion** alongside the existing `Apply`:
+
+```csharp
+public interface ISpecification<TEntity> where TEntity : class
+{
+    Expression<Func<TEntity, bool>> Criteria => static _ => true;      // NEW — the filter predicate
+    IQueryable<TEntity> Apply(IQueryable<TEntity> query) => query.Where(Criteria); // now defaulted
+    ISpecification<TEntity> And(ISpecification<TEntity> specification); // NEW
+    ISpecification<TEntity> Or(ISpecification<TEntity> specification);  // NEW
+    ISpecification<TEntity> Not();                                     // NEW
+}
+```
+
+- `Criteria` is a translatable expression tree, so it round-trips through EF Core.
+- `Apply` is now a default method (`query.Where(Criteria)`); override it to add `Include`/`OrderBy`/paging.
+- `And`/`Or`/`Not` combine the operands' **`Criteria`** (via `Expression.AndAlso`/`OrElse`/`Not`), rebinding
+  the two lambdas onto a single parameter with an `ExpressionVisitor` so the result stays EF-translatable.
+  Composition intentionally combines the `Criteria` only — it does **not** merge the `Apply`-side shaping
+  (there is no meaningful way to combine, say, two `OrderBy` clauses under an `OR`).
+
+New supporting types (all in `Asm.Domain`):
+
+- `Specification<TEntity>` — an abstract base; override `Criteria` and optionally `Apply`.
+- `AsmDomainExpressionExtensions` — public `AndAlso`/`OrElse`/`Not` predicate combinators with parameter
+  rebinding, usable directly on `Expression<Func<T, bool>>`.
+
+**What to change:** existing specifications that implement `Apply` continue to work unchanged (their
+`Criteria` defaults to "match all", which only affects composition). To make a specification composable,
+express its filter as `Criteria` (typically by deriving from `Specification<TEntity>`):
+
+```csharp
+public sealed class RecentOrders : Specification<Order>
+{
+    public override Expression<Func<Order, bool>> Criteria => o => o.OrderDate > DateTime.UtcNow.AddDays(-30);
+}
+
+// Compose:
+var spec = new RecentOrders().And(new HighValue()).Not();
+var results = await repository.Get(spec, cancellationToken);
+```

--- a/src/Asm.Domain.Infrastructure/RepositoryBase.cs
+++ b/src/Asm.Domain.Infrastructure/RepositoryBase.cs
@@ -12,7 +12,7 @@ namespace Asm.Domain.Infrastructure;
 public abstract class RepositoryBase<TContext, TEntity, TKey>(TContext context) : IRepository<TEntity, TKey>
     where TEntity : KeyedEntity<TKey>
     where TContext : DbContext
-    where TKey : struct
+    where TKey : notnull
 {
     /// <summary>
     /// Gets the DB context.
@@ -49,6 +49,22 @@ public abstract class RepositoryBase<TContext, TEntity, TKey>(TContext context) 
         var entity = await specification.Apply(GetById(id)).SingleOrDefaultAsync(cancellationToken);
         return entity ?? throw new NotFoundException();
     }
+
+    /// <inheritdoc/>
+    public virtual async Task<TEntity?> Find(TKey id, CancellationToken cancellationToken = default) =>
+        await GetById(id).SingleOrDefaultAsync(cancellationToken);
+
+    /// <inheritdoc/>
+    public virtual async Task<TEntity?> Find(TKey id, ISpecification<TEntity> specification, CancellationToken cancellationToken = default) =>
+        await specification.Apply(GetById(id)).SingleOrDefaultAsync(cancellationToken);
+
+    /// <inheritdoc/>
+    public virtual Task<TEntity?> TryGet(TKey id, CancellationToken cancellationToken = default) =>
+        Find(id, cancellationToken);
+
+    /// <inheritdoc/>
+    public virtual Task<TEntity?> TryGet(TKey id, ISpecification<TEntity> specification, CancellationToken cancellationToken = default) =>
+        Find(id, specification, cancellationToken);
 
     /// <summary>
     /// Gets a query for a single entity by ID.

--- a/src/Asm.Domain.Infrastructure/RepositoryDeleteBase.cs
+++ b/src/Asm.Domain.Infrastructure/RepositoryDeleteBase.cs
@@ -12,7 +12,7 @@ namespace Asm.Domain.Infrastructure;
 public abstract class RepositoryDeleteBase<TContext, TEntity, TKey>(TContext context) : RepositoryWriteBase<TContext, TEntity, TKey>(context), IDeletableRepository<TEntity, TKey>
     where TEntity : KeyedEntity<TKey>
     where TContext : DbContext
-    where TKey : struct
+    where TKey : notnull
 {
     /// <inheritdoc/>
     public abstract void Delete(TKey id);

--- a/src/Asm.Domain.Infrastructure/RepositoryWriteBase.cs
+++ b/src/Asm.Domain.Infrastructure/RepositoryWriteBase.cs
@@ -12,7 +12,7 @@ namespace Asm.Domain.Infrastructure;
 public abstract class RepositoryWriteBase<TContext, TEntity, TKey>(TContext context) : RepositoryBase<TContext, TEntity, TKey>(context), IWritableRepository<TEntity, TKey>
     where TEntity : KeyedEntity<TKey>
     where TContext : DbContext
-    where TKey : struct
+    where TKey : notnull
 {
     /// <inheritdoc/>
     public virtual TEntity Add(TEntity entity)

--- a/src/Asm.Domain/AsmDomainExpressionExtensions.cs
+++ b/src/Asm.Domain/AsmDomainExpressionExtensions.cs
@@ -1,0 +1,71 @@
+﻿using System.Linq.Expressions;
+
+namespace Asm.Domain;
+
+/// <summary>
+/// Extensions for combining boolean predicate expressions so that the result stays translatable by a
+/// query provider (e.g. EF Core).
+/// </summary>
+/// <remarks>
+/// Each combinator rebinds the two lambdas onto a single shared parameter, so the combined expression is a
+/// well-formed tree rather than an <see cref="Expression.Invoke(Expression, Expression[])"/> that most
+/// providers cannot translate.
+/// </remarks>
+public static class AsmDomainExpressionExtensions
+{
+    /// <summary>
+    /// Combines two predicates with a logical <c>AND</c> (<see cref="Expression.AndAlso(Expression, Expression)"/>).
+    /// </summary>
+    /// <typeparam name="T">The parameter type of the predicate.</typeparam>
+    /// <param name="left">The left predicate.</param>
+    /// <param name="right">The right predicate.</param>
+    /// <returns>A predicate that is <see langword="true"/> when both operands are.</returns>
+    public static Expression<Func<T, bool>> AndAlso<T>(this Expression<Func<T, bool>> left, Expression<Func<T, bool>> right) =>
+        Combine(left, right, Expression.AndAlso);
+
+    /// <summary>
+    /// Combines two predicates with a logical <c>OR</c> (<see cref="Expression.OrElse(Expression, Expression)"/>).
+    /// </summary>
+    /// <typeparam name="T">The parameter type of the predicate.</typeparam>
+    /// <param name="left">The left predicate.</param>
+    /// <param name="right">The right predicate.</param>
+    /// <returns>A predicate that is <see langword="true"/> when either operand is.</returns>
+    public static Expression<Func<T, bool>> OrElse<T>(this Expression<Func<T, bool>> left, Expression<Func<T, bool>> right) =>
+        Combine(left, right, Expression.OrElse);
+
+    /// <summary>
+    /// Negates a predicate with a logical <c>NOT</c> (<see cref="Expression.Not(Expression)"/>).
+    /// </summary>
+    /// <typeparam name="T">The parameter type of the predicate.</typeparam>
+    /// <param name="expression">The predicate to negate.</param>
+    /// <returns>A predicate that is <see langword="true"/> when the operand is <see langword="false"/>.</returns>
+    public static Expression<Func<T, bool>> Not<T>(this Expression<Func<T, bool>> expression)
+    {
+        ArgumentNullException.ThrowIfNull(expression);
+
+        return Expression.Lambda<Func<T, bool>>(Expression.Not(expression.Body), expression.Parameters);
+    }
+
+    private static Expression<Func<T, bool>> Combine<T>(Expression<Func<T, bool>> left, Expression<Func<T, bool>> right, Func<Expression, Expression, BinaryExpression> merge)
+    {
+        ArgumentNullException.ThrowIfNull(left);
+        ArgumentNullException.ThrowIfNull(right);
+
+        ParameterExpression parameter = Expression.Parameter(typeof(T), left.Parameters[0].Name);
+
+        Expression leftBody = new ReplaceParameterVisitor(left.Parameters[0], parameter).Visit(left.Body);
+        Expression rightBody = new ReplaceParameterVisitor(right.Parameters[0], parameter).Visit(right.Body);
+
+        return Expression.Lambda<Func<T, bool>>(merge(leftBody, rightBody), parameter);
+    }
+
+    /// <summary>
+    /// Rewrites every occurrence of one <see cref="ParameterExpression"/> with a replacement expression so
+    /// that two independently-authored lambdas can share a single parameter.
+    /// </summary>
+    private sealed class ReplaceParameterVisitor(ParameterExpression from, Expression to) : ExpressionVisitor
+    {
+        protected override Expression VisitParameter(ParameterExpression node) =>
+            node == from ? to : base.VisitParameter(node);
+    }
+}

--- a/src/Asm.Domain/AsmDomainQueryableExtensions.cs
+++ b/src/Asm.Domain/AsmDomainQueryableExtensions.cs
@@ -14,7 +14,7 @@ public static class AsmDomainQueryableExtensions
     /// <param name="query">The queryable that this method extends.</param>
     /// <param name="specification">The specification to be applied.</param>
     /// <returns>The <paramref name="query"/> with the specification applied.</returns>
-    public static IQueryable<T> Specify<T>(this IQueryable<T> query, ISpecification<T> specification) where T : Entity
+    public static IQueryable<T> Specify<T>(this IQueryable<T> query, ISpecification<T> specification) where T : class
         => specification == null ? query : specification.Apply(query);
 
     /// <summary>
@@ -24,7 +24,7 @@ public static class AsmDomainQueryableExtensions
     /// <typeparam name="TSpecification">The specification to be applied.</typeparam>
     /// <param name="query">The queryable that this method extends.</param>
     /// <returns>The <paramref name="query"/> with the specification applied.</returns>
-    public static IQueryable<TEntity> Specify<TEntity, TSpecification>(this IQueryable<TEntity> query) where TEntity : Entity
+    public static IQueryable<TEntity> Specify<TEntity, TSpecification>(this IQueryable<TEntity> query) where TEntity : class
         where TSpecification : ISpecification<TEntity>, new()
         => new TSpecification().Apply(query);
 }

--- a/src/Asm.Domain/IDeletableRepository.cs
+++ b/src/Asm.Domain/IDeletableRepository.cs
@@ -7,7 +7,7 @@
 /// <typeparam name="TKey">The type of the entity's key.</typeparam>
 public interface IDeletableRepository<TEntity, TKey> : IRepository<TEntity, TKey>
     where TEntity : KeyedEntity<TKey>
-    where TKey : struct
+    where TKey : notnull
 {
     /// <summary>
     /// Deletes an entity by its key.

--- a/src/Asm.Domain/IRepository.cs
+++ b/src/Asm.Domain/IRepository.cs
@@ -7,7 +7,7 @@
 /// <typeparam name="TKey">The type of the entity's key.</typeparam>
 public interface IRepository<TEntity, TKey>
     where TEntity : KeyedEntity<TKey>
-    where TKey : struct
+    where TKey : notnull
 {
     /// <summary>
     /// Gets a queryable collection of entities.
@@ -31,19 +31,86 @@ public interface IRepository<TEntity, TKey>
     Task<IEnumerable<TEntity>> Get(ISpecification<TEntity> specification, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Gets an entity by its key.
+    /// Gets an entity by its key, throwing if it does not exist.
     /// </summary>
+    /// <remarks>
+    /// Implementations throw <c>NotFoundException</c> when no entity with the given key exists. Use
+    /// <see cref="Find(TKey, CancellationToken)"/> or <see cref="TryGet(TKey, CancellationToken)"/> to get
+    /// <see langword="null"/> instead of an exception.
+    /// </remarks>
     /// <param name="id">The ID of the entity to get.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
-    /// <returns>An entity.</returns>
+    /// <returns>The matching entity.</returns>
     Task<TEntity> Get(TKey id, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Gets an entity by its key and returns the fields that match a specification.
+    /// Gets an entity by its key and returns the fields that match a specification, throwing if it does not exist.
     /// </summary>
+    /// <remarks>
+    /// Implementations throw <c>NotFoundException</c> when no matching entity exists. Use
+    /// <see cref="Find(TKey, ISpecification{TEntity}, CancellationToken)"/> or
+    /// <see cref="TryGet(TKey, ISpecification{TEntity}, CancellationToken)"/> to get <see langword="null"/>
+    /// instead of an exception.
+    /// </remarks>
     /// <param name="id">The ID of the entity to get.</param>
     /// <param name="specification">The specification.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
-    /// <returns>An entity.</returns>
+    /// <returns>The matching entity.</returns>
     Task<TEntity> Get(TKey id, ISpecification<TEntity> specification, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Finds an entity by its key, returning <see langword="null"/> if it does not exist.
+    /// </summary>
+    /// <remarks>
+    /// This is the null-returning counterpart to <see cref="Get(TKey, CancellationToken)"/>, which throws
+    /// <c>NotFoundException</c> when the entity is absent. Prefer <c>Find</c> when a missing entity is an
+    /// expected, non-exceptional outcome. The default implementation filters the full collection; derived
+    /// repositories override it with a keyed query.
+    /// </remarks>
+    /// <param name="id">The ID of the entity to find.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The matching entity, or <see langword="null"/> if none exists.</returns>
+    async Task<TEntity?> Find(TKey id, CancellationToken cancellationToken = default)
+    {
+        var entities = await Get(cancellationToken).ConfigureAwait(false);
+        return entities.SingleOrDefault(entity => EqualityComparer<TKey>.Default.Equals(entity.Id, id));
+    }
+
+    /// <summary>
+    /// Finds an entity by its key applying a specification, returning <see langword="null"/> if it does not exist.
+    /// </summary>
+    /// <remarks>
+    /// This is the null-returning counterpart to
+    /// <see cref="Get(TKey, ISpecification{TEntity}, CancellationToken)"/>, which throws
+    /// <c>NotFoundException</c> when the entity is absent. The default implementation filters the specified
+    /// collection; derived repositories override it with a keyed query.
+    /// </remarks>
+    /// <param name="id">The ID of the entity to find.</param>
+    /// <param name="specification">The specification.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The matching entity, or <see langword="null"/> if none exists.</returns>
+    async Task<TEntity?> Find(TKey id, ISpecification<TEntity> specification, CancellationToken cancellationToken = default)
+    {
+        var entities = await Get(specification, cancellationToken).ConfigureAwait(false);
+        return entities.SingleOrDefault(entity => EqualityComparer<TKey>.Default.Equals(entity.Id, id));
+    }
+
+    /// <summary>
+    /// Tries to get an entity by its key, returning <see langword="null"/> if it does not exist.
+    /// </summary>
+    /// <remarks>An ergonomic alias for <see cref="Find(TKey, CancellationToken)"/>.</remarks>
+    /// <param name="id">The ID of the entity to get.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The matching entity, or <see langword="null"/> if none exists.</returns>
+    Task<TEntity?> TryGet(TKey id, CancellationToken cancellationToken = default) => Find(id, cancellationToken);
+
+    /// <summary>
+    /// Tries to get an entity by its key applying a specification, returning <see langword="null"/> if it does not exist.
+    /// </summary>
+    /// <remarks>An ergonomic alias for <see cref="Find(TKey, ISpecification{TEntity}, CancellationToken)"/>.</remarks>
+    /// <param name="id">The ID of the entity to get.</param>
+    /// <param name="specification">The specification.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The matching entity, or <see langword="null"/> if none exists.</returns>
+    Task<TEntity?> TryGet(TKey id, ISpecification<TEntity> specification, CancellationToken cancellationToken = default) => Find(id, specification, cancellationToken);
 }

--- a/src/Asm.Domain/ISpecification.cs
+++ b/src/Asm.Domain/ISpecification.cs
@@ -1,15 +1,73 @@
-﻿namespace Asm.Domain;
+﻿using System.Linq.Expressions;
+
+namespace Asm.Domain;
 
 /// <summary>
 /// A specification that can be applied to a query.
 /// </summary>
+/// <remarks>
+/// A specification carries two complementary concerns:
+/// <list type="bullet">
+/// <item>
+/// <see cref="Criteria"/> is a boolean predicate describing <em>which</em> entities match. It is an
+/// expression tree so it stays translatable by query providers such as EF Core, and it is what the
+/// <see cref="And"/>, <see cref="Or"/> and <see cref="Not"/> composition operators combine.
+/// </item>
+/// <item>
+/// <see cref="Apply"/> shapes the query — <c>Include</c>, <c>OrderBy</c>, paging etc. — and by default
+/// simply filters by <see cref="Criteria"/>. Composition operates on <see cref="Criteria"/> only; it does
+/// <em>not</em> attempt to merge the <see cref="Apply"/>-side shaping of two specifications (there is no
+/// meaningful way to combine, say, two <c>OrderBy</c> clauses under an <c>OR</c>).
+/// </item>
+/// </list>
+/// The constraint is <see langword="class"/> (not <c>Entity</c>) so specifications can target read models,
+/// DTOs or projected interfaces as well as domain entities.
+/// </remarks>
 /// <typeparam name="TEntity">The type of entity the specification applies to.</typeparam>
-public interface ISpecification<TEntity> where TEntity : Entity
+public interface ISpecification<TEntity> where TEntity : class
 {
+    /// <summary>
+    /// Gets the predicate describing which entities the specification matches.
+    /// </summary>
+    /// <remarks>
+    /// The default matches every entity (<c>_ =&gt; true</c>). Override to express the filter as an
+    /// expression tree so that it can be translated by the query provider and composed with
+    /// <see cref="And"/>, <see cref="Or"/> and <see cref="Not"/>.
+    /// </remarks>
+    Expression<Func<TEntity, bool>> Criteria => static _ => true;
+
     /// <summary>
     /// Applies the specification to a query.
     /// </summary>
+    /// <remarks>
+    /// The default applies <see cref="Criteria"/> via
+    /// <see cref="Queryable.Where{TSource}(IQueryable{TSource}, Expression{Func{TSource, bool}})"/>.
+    /// Override to add shaping such as <c>Include</c>, <c>OrderBy</c> or paging.
+    /// </remarks>
     /// <param name="query">The query to apply the specification to.</param>
     /// <returns>An <see cref="IQueryable{T}"/> with the specification applied.</returns>
-    IQueryable<TEntity> Apply(IQueryable<TEntity> query);
+    IQueryable<TEntity> Apply(IQueryable<TEntity> query) => query.Where(Criteria);
+
+    /// <summary>
+    /// Combines this specification with another using a logical <c>AND</c>.
+    /// </summary>
+    /// <remarks>Only the <see cref="Criteria"/> of the two specifications are combined.</remarks>
+    /// <param name="specification">The specification to combine with.</param>
+    /// <returns>A specification matching entities that satisfy both.</returns>
+    ISpecification<TEntity> And(ISpecification<TEntity> specification) => new AndSpecification<TEntity>(this, specification);
+
+    /// <summary>
+    /// Combines this specification with another using a logical <c>OR</c>.
+    /// </summary>
+    /// <remarks>Only the <see cref="Criteria"/> of the two specifications are combined.</remarks>
+    /// <param name="specification">The specification to combine with.</param>
+    /// <returns>A specification matching entities that satisfy either.</returns>
+    ISpecification<TEntity> Or(ISpecification<TEntity> specification) => new OrSpecification<TEntity>(this, specification);
+
+    /// <summary>
+    /// Negates this specification using a logical <c>NOT</c>.
+    /// </summary>
+    /// <remarks>Only the <see cref="Criteria"/> is negated.</remarks>
+    /// <returns>A specification matching entities that do <em>not</em> satisfy this one.</returns>
+    ISpecification<TEntity> Not() => new NotSpecification<TEntity>(this);
 }

--- a/src/Asm.Domain/IWritableRepository.cs
+++ b/src/Asm.Domain/IWritableRepository.cs
@@ -5,15 +5,32 @@
 /// </summary>
 /// <typeparam name="TEntity">The type of entity.</typeparam>
 /// <typeparam name="TKey">The type of the entity's key.</typeparam>
-public interface IWritableRepository<TEntity, TKey> : IRepository<TEntity, TKey> where TEntity : KeyedEntity<TKey> where TKey : struct
+public interface IWritableRepository<TEntity, TKey> : IRepository<TEntity, TKey> where TEntity : KeyedEntity<TKey> where TKey : notnull
 {
     /// <summary>
     /// Adds an entity.
     /// </summary>
     /// <param name="entity">The entity to add.</param>
     /// <returns>The entity.</returns>
-
     TEntity Add(TEntity entity);
+
+    /// <summary>
+    /// Adds a range of entities.
+    /// </summary>
+    /// <remarks>
+    /// The default implementation adds each entity in turn via <see cref="Add(TEntity)"/>; override for a
+    /// provider-optimised bulk add.
+    /// </remarks>
+    /// <param name="entities">The entities to add.</param>
+    void AddRange(IEnumerable<TEntity> entities)
+    {
+        ArgumentNullException.ThrowIfNull(entities);
+
+        foreach (TEntity entity in entities)
+        {
+            Add(entity);
+        }
+    }
 
     /// <summary>
     /// Updates an entity.

--- a/src/Asm.Domain/README.md
+++ b/src/Asm.Domain/README.md
@@ -96,17 +96,43 @@ public class OrderCreatedEventHandler : INotificationHandler<OrderCreatedEvent>
 
 ### Specifications
 
-Use specifications to apply common patterns to queries.
+Use specifications to encapsulate a query's filter. Express the filter as a `Criteria` expression (by
+deriving from `Specification<T>`) so it stays translatable by EF Core and can be composed:
 
 ```csharp
+using System.Linq.Expressions;
 using Asm.Domain;
 
-public class RecentOrders : ISpecification<Order>
+public sealed class RecentOrders : Specification<Order>
 {
-    public IQueryable<Order> Apply(IQueryable<Order> query) =>
-        query.Where(o => o.OrderDate > DateTime.UtcNow.AddDays(-30));
+    public override Expression<Func<Order, bool>> Criteria =>
+        o => o.OrderDate > DateTime.UtcNow.AddDays(-30);
 }
 ```
+
+Override `Apply` when you also need shaping such as `Include`, `OrderBy` or paging:
+
+```csharp
+public sealed class RecentOrdersWithCustomer : Specification<Order>
+{
+    public override Expression<Func<Order, bool>> Criteria =>
+        o => o.OrderDate > DateTime.UtcNow.AddDays(-30);
+
+    public override IQueryable<Order> Apply(IQueryable<Order> query) =>
+        query.Where(Criteria).Include(o => o.Customer).OrderByDescending(o => o.OrderDate);
+}
+```
+
+Combine specifications with `And`, `Or` and `Not` — the criteria are merged into a single translatable
+expression:
+
+```csharp
+var spec = new RecentOrders().And(new HighValue());
+var results = await repository.Get(spec, cancellationToken);
+```
+
+The constraint is `where T : class`, so specifications can also target read models, DTOs or interfaces —
+not only entities.
 
 ## Contributing
 

--- a/src/Asm.Domain/Specification.cs
+++ b/src/Asm.Domain/Specification.cs
@@ -1,0 +1,95 @@
+﻿using System.Linq.Expressions;
+
+namespace Asm.Domain;
+
+/// <summary>
+/// A convenience base class for building a <see cref="ISpecification{TEntity}"/> from a
+/// <see cref="Criteria"/> predicate.
+/// </summary>
+/// <remarks>
+/// Derive from this class and provide <see cref="Criteria"/> to describe the filter. The default
+/// <see cref="Apply"/> filters by <see cref="Criteria"/>; override it to add shaping such as
+/// <c>Include</c>, <c>OrderBy</c> or paging.
+/// </remarks>
+/// <typeparam name="TEntity">The type of entity the specification applies to.</typeparam>
+public abstract class Specification<TEntity> : ISpecification<TEntity> where TEntity : class
+{
+    /// <inheritdoc/>
+    public abstract Expression<Func<TEntity, bool>> Criteria { get; }
+
+    /// <inheritdoc/>
+    public virtual IQueryable<TEntity> Apply(IQueryable<TEntity> query) => query.Where(Criteria);
+
+    /// <inheritdoc/>
+    public virtual ISpecification<TEntity> And(ISpecification<TEntity> specification) => new AndSpecification<TEntity>(this, specification);
+
+    /// <inheritdoc/>
+    public virtual ISpecification<TEntity> Or(ISpecification<TEntity> specification) => new OrSpecification<TEntity>(this, specification);
+
+    /// <inheritdoc/>
+    public virtual ISpecification<TEntity> Not() => new NotSpecification<TEntity>(this);
+}
+
+/// <summary>
+/// A specification matching entities that satisfy both operands' criteria.
+/// </summary>
+/// <typeparam name="TEntity">The type of entity the specification applies to.</typeparam>
+internal sealed class AndSpecification<TEntity> : Specification<TEntity> where TEntity : class
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AndSpecification{TEntity}"/> class.
+    /// </summary>
+    /// <param name="left">The left operand.</param>
+    /// <param name="right">The right operand.</param>
+    public AndSpecification(ISpecification<TEntity> left, ISpecification<TEntity> right)
+    {
+        ArgumentNullException.ThrowIfNull(left);
+        ArgumentNullException.ThrowIfNull(right);
+        Criteria = left.Criteria.AndAlso(right.Criteria);
+    }
+
+    /// <inheritdoc/>
+    public override Expression<Func<TEntity, bool>> Criteria { get; }
+}
+
+/// <summary>
+/// A specification matching entities that satisfy either operand's criteria.
+/// </summary>
+/// <typeparam name="TEntity">The type of entity the specification applies to.</typeparam>
+internal sealed class OrSpecification<TEntity> : Specification<TEntity> where TEntity : class
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OrSpecification{TEntity}"/> class.
+    /// </summary>
+    /// <param name="left">The left operand.</param>
+    /// <param name="right">The right operand.</param>
+    public OrSpecification(ISpecification<TEntity> left, ISpecification<TEntity> right)
+    {
+        ArgumentNullException.ThrowIfNull(left);
+        ArgumentNullException.ThrowIfNull(right);
+        Criteria = left.Criteria.OrElse(right.Criteria);
+    }
+
+    /// <inheritdoc/>
+    public override Expression<Func<TEntity, bool>> Criteria { get; }
+}
+
+/// <summary>
+/// A specification matching entities that do <em>not</em> satisfy the wrapped specification's criteria.
+/// </summary>
+/// <typeparam name="TEntity">The type of entity the specification applies to.</typeparam>
+internal sealed class NotSpecification<TEntity> : Specification<TEntity> where TEntity : class
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NotSpecification{TEntity}"/> class.
+    /// </summary>
+    /// <param name="specification">The specification to negate.</param>
+    public NotSpecification(ISpecification<TEntity> specification)
+    {
+        ArgumentNullException.ThrowIfNull(specification);
+        Criteria = specification.Criteria.Not();
+    }
+
+    /// <inheritdoc/>
+    public override Expression<Func<TEntity, bool>> Criteria { get; }
+}

--- a/tests/Asm.Domain.Infrastructure.Tests/RepositoryBaseTests.cs
+++ b/tests/Asm.Domain.Infrastructure.Tests/RepositoryBaseTests.cs
@@ -1,0 +1,160 @@
+﻿using Asm;
+using Asm.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace Asm.Domain.Infrastructure.Tests;
+
+/// <summary>
+/// Behaviour tests for <see cref="RepositoryBase{TContext, TEntity, TKey}"/> and
+/// <see cref="RepositoryWriteBase{TContext, TEntity, TKey}"/> against an in-memory database, covering
+/// <c>Get</c> vs <c>Find</c>/<c>TryGet</c> semantics, <c>AddRange</c>, and reference-type keys enabled by
+/// the relaxed <c>notnull</c> constraint.
+/// </summary>
+public class RepositoryBaseTests
+{
+    private sealed class Widget : KeyedEntity<int>
+    {
+        public Widget() : base(0) { }
+
+        public Widget(int id, string name) : base(id) => Name = name;
+
+        public string Name { get; set; } = String.Empty;
+    }
+
+    // A string-keyed entity: only compilable because TKey is now constrained to notnull (not struct).
+    private sealed class Gadget : KeyedEntity<string>
+    {
+        public Gadget() : base(String.Empty) { }
+
+        public Gadget(string id, string label) : base(id) => Label = label;
+
+        public string Label { get; set; } = String.Empty;
+    }
+
+    private sealed class RepoDbContext(DbContextOptions options, IPublisher publisher) : DomainDbContext(options, publisher)
+    {
+        public DbSet<Widget> Widgets { get; set; } = null!;
+
+        public DbSet<Gadget> Gadgets { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Widget>().HasKey(w => w.Id);
+            modelBuilder.Entity<Gadget>().HasKey(g => g.Id);
+        }
+    }
+
+    private sealed class WidgetRepository(RepoDbContext context) : RepositoryWriteBase<RepoDbContext, Widget, int>(context);
+
+    private sealed class GadgetRepository(RepoDbContext context) : RepositoryWriteBase<RepoDbContext, Gadget, string>(context);
+
+    private sealed class NoOpPublisher : IPublisher
+    {
+        public ValueTask Publish<TDomainEvent>(TDomainEvent domainEvent, CancellationToken cancellationToken = default) where TDomainEvent : IDomainEvent =>
+            ValueTask.CompletedTask;
+    }
+
+    private static RepoDbContext CreateContext() =>
+        new(new DbContextOptionsBuilder<RepoDbContext>().UseInMemoryDatabase(Guid.NewGuid().ToString()).Options, new NoOpPublisher());
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task Get_ByKey_ReturnsEntity()
+    {
+        var token = TestContext.Current.CancellationToken;
+        using var context = CreateContext();
+        context.Widgets.Add(new Widget(1, "One"));
+        await context.SaveChangesAsync(token);
+
+        var repository = new WidgetRepository(context);
+        var widget = await repository.Get(1, token);
+
+        Assert.Equal("One", widget.Name);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task Get_MissingKey_ThrowsNotFoundException()
+    {
+        var token = TestContext.Current.CancellationToken;
+        using var context = CreateContext();
+        var repository = new WidgetRepository(context);
+
+        await Assert.ThrowsAsync<NotFoundException>(() => repository.Get(42, token));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task Find_MissingKey_ReturnsNull()
+    {
+        var token = TestContext.Current.CancellationToken;
+        using var context = CreateContext();
+        var repository = new WidgetRepository(context);
+
+        Assert.Null(await repository.Find(42, token));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task Find_ExistingKey_ReturnsEntity()
+    {
+        var token = TestContext.Current.CancellationToken;
+        using var context = CreateContext();
+        context.Widgets.Add(new Widget(7, "Seven"));
+        await context.SaveChangesAsync(token);
+
+        var repository = new WidgetRepository(context);
+        var widget = await repository.Find(7, token);
+
+        Assert.NotNull(widget);
+        Assert.Equal("Seven", widget.Name);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task TryGet_MatchesFindSemantics()
+    {
+        var token = TestContext.Current.CancellationToken;
+        using var context = CreateContext();
+        context.Widgets.Add(new Widget(3, "Three"));
+        await context.SaveChangesAsync(token);
+
+        var repository = new WidgetRepository(context);
+
+        Assert.NotNull(await repository.TryGet(3, token));
+        Assert.Null(await repository.TryGet(99, token));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task AddRange_PersistsAllEntities()
+    {
+        var token = TestContext.Current.CancellationToken;
+        using var context = CreateContext();
+        var repository = new WidgetRepository(context);
+
+        repository.AddRange([new Widget(1, "One"), new Widget(2, "Two"), new Widget(3, "Three")]);
+        await context.SaveChangesAsync(token);
+
+        var all = await repository.Get(token);
+        Assert.Equal([1, 2, 3], all.Select(w => w.Id).OrderBy(id => id));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task ReferenceTypeKey_IsSupported()
+    {
+        var token = TestContext.Current.CancellationToken;
+        using var context = CreateContext();
+        context.Gadgets.Add(new Gadget("abc", "Alpha"));
+        await context.SaveChangesAsync(token);
+
+        var repository = new GadgetRepository(context);
+
+        var found = await repository.Get("abc", token);
+        Assert.Equal("Alpha", found.Label);
+
+        Assert.Null(await repository.Find("missing", token));
+        await Assert.ThrowsAsync<NotFoundException>(() => repository.Get("missing", token));
+    }
+}

--- a/tests/Asm.Domain.Tests/AsmDomainExpressionExtensionsTests.cs
+++ b/tests/Asm.Domain.Tests/AsmDomainExpressionExtensionsTests.cs
@@ -1,0 +1,67 @@
+﻿using System.Linq.Expressions;
+
+namespace Asm.Domain.Tests;
+
+public class AsmDomainExpressionExtensionsTests
+{
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AndAlso_RebindsParametersAndEvaluates()
+    {
+        Expression<Func<int, bool>> left = x => x > 2;
+        Expression<Func<int, bool>> right = y => y < 5;
+
+        var combined = left.AndAlso(right);
+        var predicate = combined.Compile();
+
+        // Both lambdas used different parameter names; the result must share one parameter.
+        Assert.Single(combined.Parameters);
+        Assert.Equal(System.Linq.Expressions.ExpressionType.AndAlso, combined.Body.NodeType);
+        Assert.True(predicate(3));
+        Assert.False(predicate(2));
+        Assert.False(predicate(5));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void OrElse_RebindsParametersAndEvaluates()
+    {
+        Expression<Func<int, bool>> left = x => x > 4;
+        Expression<Func<int, bool>> right = y => y % 2 == 0;
+
+        var predicate = left.OrElse(right).Compile();
+
+        Assert.True(predicate(6));  // even
+        Assert.True(predicate(5));  // > 4
+        Assert.False(predicate(3)); // neither
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Not_NegatesPredicate()
+    {
+        Expression<Func<int, bool>> expression = x => x > 2;
+
+        var predicate = expression.Not().Compile();
+
+        Assert.False(predicate(3));
+        Assert.True(predicate(1));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AndAlso_NullArguments_Throw()
+    {
+        Expression<Func<int, bool>> expression = x => x > 2;
+
+        Assert.Throws<ArgumentNullException>(() => AsmDomainExpressionExtensions.AndAlso(null!, expression));
+        Assert.Throws<ArgumentNullException>(() => expression.AndAlso(null!));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Not_NullArgument_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => AsmDomainExpressionExtensions.Not<int>(null!));
+    }
+}

--- a/tests/Asm.Domain.Tests/RepositoryDefaultsTests.cs
+++ b/tests/Asm.Domain.Tests/RepositoryDefaultsTests.cs
@@ -1,0 +1,95 @@
+﻿namespace Asm.Domain.Tests;
+
+/// <summary>
+/// Exercises the <em>default interface methods</em> on <see cref="IRepository{TEntity, TKey}"/> and
+/// <see cref="IWritableRepository{TEntity, TKey}"/> through a hand-written in-memory repository that does
+/// <em>not</em> override them.
+/// </summary>
+public class RepositoryDefaultsTests
+{
+    private sealed class InMemoryRepository : IWritableRepository<TestKeyedEntity, int>
+    {
+        private readonly List<TestKeyedEntity> _items = [];
+
+        public IQueryable<TestKeyedEntity> Queryable() => _items.AsQueryable();
+
+        public Task<IEnumerable<TestKeyedEntity>> Get(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IEnumerable<TestKeyedEntity>>(_items);
+
+        public Task<IEnumerable<TestKeyedEntity>> Get(ISpecification<TestKeyedEntity> specification, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IEnumerable<TestKeyedEntity>>(specification.Apply(_items.AsQueryable()).ToArray());
+
+        public Task<TestKeyedEntity> Get(int id, CancellationToken cancellationToken = default) =>
+            Task.FromResult(_items.Single(e => e.Id == id));
+
+        public Task<TestKeyedEntity> Get(int id, ISpecification<TestKeyedEntity> specification, CancellationToken cancellationToken = default) =>
+            Task.FromResult(specification.Apply(_items.AsQueryable()).Single(e => e.Id == id));
+
+        public TestKeyedEntity Add(TestKeyedEntity entity)
+        {
+            _items.Add(entity);
+            return entity;
+        }
+
+        public TestKeyedEntity Update(TestKeyedEntity entity) => entity;
+
+        // AddRange, Find and TryGet are deliberately NOT implemented, so the interface defaults run.
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task AddRange_Default_AddsEachEntity()
+    {
+        IWritableRepository<TestKeyedEntity, int> repository = new InMemoryRepository();
+
+        repository.AddRange([new TestKeyedEntity(1), new TestKeyedEntity(2), new TestKeyedEntity(3)]);
+
+        var all = await repository.Get(TestContext.Current.CancellationToken);
+        Assert.Equal([1, 2, 3], all.Select(e => e.Id));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AddRange_Default_NullEntities_Throws()
+    {
+        IWritableRepository<TestKeyedEntity, int> repository = new InMemoryRepository();
+
+        Assert.Throws<ArgumentNullException>(() => repository.AddRange(null!));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task Find_Default_ReturnsEntityWhenPresent()
+    {
+        IWritableRepository<TestKeyedEntity, int> repository = new InMemoryRepository();
+        repository.AddRange([new TestKeyedEntity(1), new TestKeyedEntity(2)]);
+
+        var found = await repository.Find(2, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(found);
+        Assert.Equal(2, found.Id);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task Find_Default_ReturnsNullWhenAbsent()
+    {
+        IWritableRepository<TestKeyedEntity, int> repository = new InMemoryRepository();
+        repository.AddRange([new TestKeyedEntity(1)]);
+
+        var found = await repository.Find(99, TestContext.Current.CancellationToken);
+
+        Assert.Null(found);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task TryGet_Default_ForwardsToFind()
+    {
+        IWritableRepository<TestKeyedEntity, int> repository = new InMemoryRepository();
+        repository.AddRange([new TestKeyedEntity(5)]);
+
+        Assert.NotNull(await repository.TryGet(5, TestContext.Current.CancellationToken));
+        Assert.Null(await repository.TryGet(6, TestContext.Current.CancellationToken));
+    }
+}

--- a/tests/Asm.Domain.Tests/Specification.feature
+++ b/tests/Asm.Domain.Tests/Specification.feature
@@ -18,3 +18,21 @@ Scenario: Apply specification using generic type parameter
     Given I have a collection of test entities with IDs [1, 2, 3, 4, 5]
     When I apply the GreaterThanTwoSpecification using type parameter
     Then the result should contain entities with IDs [3, 4, 5]
+
+@Unit
+Scenario: Compose specifications with AND
+    Given I have a collection of test entities with IDs [1, 2, 3, 4, 5, 6]
+    When I apply the greater-than-two AND less-than-five specification
+    Then the result should contain entities with IDs [3, 4]
+
+@Unit
+Scenario: Compose specifications with OR
+    Given I have a collection of test entities with IDs [1, 2, 3, 4, 5]
+    When I apply the greater-than-two OR even specification
+    Then the result should contain entities with IDs [2, 3, 4, 5]
+
+@Unit
+Scenario: Negate a specification with NOT
+    Given I have a collection of test entities with IDs [1, 2, 3, 4]
+    When I apply the NOT greater-than-two specification
+    Then the result should contain entities with IDs [1, 2]

--- a/tests/Asm.Domain.Tests/Specification.feature.cs
+++ b/tests/Asm.Domain.Tests/Specification.feature.cs
@@ -105,7 +105,7 @@ namespace Asm.Domain.Tests
         
         private static global::Reqnroll.Formatters.RuntimeSupport.FeatureLevelCucumberMessages InitializeCucumberMessages()
         {
-            return new global::Reqnroll.Formatters.RuntimeSupport.FeatureLevelCucumberMessages("Specification.feature.ndjson", 5);
+            return new global::Reqnroll.Formatters.RuntimeSupport.FeatureLevelCucumberMessages("Specification.feature.ndjson", 8);
         }
         
         async System.Threading.Tasks.ValueTask Xunit.IAsyncLifetime.InitializeAsync()
@@ -236,6 +236,114 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
 #line 20
     await testRunner.ThenAsync("the result should contain entities with IDs [3, 4, 5]", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
+#line hidden
+            }
+            await this.ScenarioCleanupAsync();
+        }
+        
+        [global::Xunit.FactAttribute(DisplayName="Compose specifications with AND")]
+        [global::Xunit.TraitAttribute("FeatureTitle", "Specification Pattern")]
+        [global::Xunit.TraitAttribute("Description", "Compose specifications with AND")]
+        [global::Xunit.TraitAttribute("Category", "Unit")]
+        public async global::System.Threading.Tasks.Task ComposeSpecificationsWithAND()
+        {
+            string[] tagsOfScenario = new string[] {
+                    "Unit"};
+            global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
+            string pickleIndex = "3";
+            global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Compose specifications with AND", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
+            string[] tagsOfRule = ((string[])(null));
+            global::Reqnroll.RuleInfo ruleInfo = null;
+#line 23
+this.ScenarioInitialize(scenarioInfo, ruleInfo);
+#line hidden
+            if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
+            {
+                await testRunner.SkipScenarioAsync();
+            }
+            else
+            {
+                await this.ScenarioStartAsync();
+#line 24
+    await testRunner.GivenAsync("I have a collection of test entities with IDs [1, 2, 3, 4, 5, 6]", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
+#line hidden
+#line 25
+    await testRunner.WhenAsync("I apply the greater-than-two AND less-than-five specification", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
+#line hidden
+#line 26
+    await testRunner.ThenAsync("the result should contain entities with IDs [3, 4]", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
+#line hidden
+            }
+            await this.ScenarioCleanupAsync();
+        }
+        
+        [global::Xunit.FactAttribute(DisplayName="Compose specifications with OR")]
+        [global::Xunit.TraitAttribute("FeatureTitle", "Specification Pattern")]
+        [global::Xunit.TraitAttribute("Description", "Compose specifications with OR")]
+        [global::Xunit.TraitAttribute("Category", "Unit")]
+        public async global::System.Threading.Tasks.Task ComposeSpecificationsWithOR()
+        {
+            string[] tagsOfScenario = new string[] {
+                    "Unit"};
+            global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
+            string pickleIndex = "4";
+            global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Compose specifications with OR", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
+            string[] tagsOfRule = ((string[])(null));
+            global::Reqnroll.RuleInfo ruleInfo = null;
+#line 29
+this.ScenarioInitialize(scenarioInfo, ruleInfo);
+#line hidden
+            if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
+            {
+                await testRunner.SkipScenarioAsync();
+            }
+            else
+            {
+                await this.ScenarioStartAsync();
+#line 30
+    await testRunner.GivenAsync("I have a collection of test entities with IDs [1, 2, 3, 4, 5]", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
+#line hidden
+#line 31
+    await testRunner.WhenAsync("I apply the greater-than-two OR even specification", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
+#line hidden
+#line 32
+    await testRunner.ThenAsync("the result should contain entities with IDs [2, 3, 4, 5]", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
+#line hidden
+            }
+            await this.ScenarioCleanupAsync();
+        }
+        
+        [global::Xunit.FactAttribute(DisplayName="Negate a specification with NOT")]
+        [global::Xunit.TraitAttribute("FeatureTitle", "Specification Pattern")]
+        [global::Xunit.TraitAttribute("Description", "Negate a specification with NOT")]
+        [global::Xunit.TraitAttribute("Category", "Unit")]
+        public async global::System.Threading.Tasks.Task NegateASpecificationWithNOT()
+        {
+            string[] tagsOfScenario = new string[] {
+                    "Unit"};
+            global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
+            string pickleIndex = "5";
+            global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Negate a specification with NOT", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
+            string[] tagsOfRule = ((string[])(null));
+            global::Reqnroll.RuleInfo ruleInfo = null;
+#line 35
+this.ScenarioInitialize(scenarioInfo, ruleInfo);
+#line hidden
+            if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
+            {
+                await testRunner.SkipScenarioAsync();
+            }
+            else
+            {
+                await this.ScenarioStartAsync();
+#line 36
+    await testRunner.GivenAsync("I have a collection of test entities with IDs [1, 2, 3, 4]", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
+#line hidden
+#line 37
+    await testRunner.WhenAsync("I apply the NOT greater-than-two specification", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
+#line hidden
+#line 38
+    await testRunner.ThenAsync("the result should contain entities with IDs [1, 2]", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }
             await this.ScenarioCleanupAsync();

--- a/tests/Asm.Domain.Tests/SpecificationCompositionTests.cs
+++ b/tests/Asm.Domain.Tests/SpecificationCompositionTests.cs
@@ -1,0 +1,131 @@
+﻿using System.Linq.Expressions;
+
+namespace Asm.Domain.Tests;
+
+public class SpecificationCompositionTests
+{
+    private static IQueryable<TestSpecifiableEntity> Entities(params int[] ids) =>
+        ids.Select(id => new TestSpecifiableEntity(id)).AsQueryable();
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void And_MatchesEntitiesSatisfyingBothCriteria()
+    {
+        ISpecification<TestSpecifiableEntity> spec = new IdGreaterThanTwoSpecification().And(new IdLessThanFiveSpecification());
+
+        var result = spec.Apply(Entities(1, 2, 3, 4, 5, 6)).Select(e => e.Id).ToList();
+
+        // > 2 AND < 5 => 3, 4
+        Assert.Equal([3, 4], result);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Or_MatchesEntitiesSatisfyingEitherCriteria()
+    {
+        ISpecification<TestSpecifiableEntity> spec = new IdGreaterThanTwoSpecification().Or(new IdIsEvenSpecification());
+
+        var result = spec.Apply(Entities(1, 2, 3, 4, 5)).Select(e => e.Id).ToList();
+
+        // > 2 OR even => 2, 3, 4, 5
+        Assert.Equal([2, 3, 4, 5], result);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Not_NegatesTheCriteria()
+    {
+        ISpecification<TestSpecifiableEntity> spec = new IdGreaterThanTwoSpecification().Not();
+
+        var result = spec.Apply(Entities(1, 2, 3, 4)).Select(e => e.Id).ToList();
+
+        // NOT (> 2) => 1, 2
+        Assert.Equal([1, 2], result);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Composition_CanBeChained()
+    {
+        // (> 2 AND < 5) OR even
+        ISpecification<TestSpecifiableEntity> spec = new IdGreaterThanTwoSpecification()
+            .And(new IdLessThanFiveSpecification())
+            .Or(new IdIsEvenSpecification());
+
+        var result = spec.Apply(Entities(1, 2, 3, 4, 5, 6)).Select(e => e.Id).ToList();
+
+        // (3,4) OR (2,4,6) => 2, 3, 4, 6
+        Assert.Equal([2, 3, 4, 6], result);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void And_CombinedCriteria_IsASingleTranslatableExpression()
+    {
+        // A hallmark of correct parameter rebinding: the combined body is a BinaryExpression (AndAlso),
+        // not an InvocationExpression that most query providers cannot translate.
+        ISpecification<TestSpecifiableEntity> spec = new IdGreaterThanTwoSpecification().And(new IdLessThanFiveSpecification());
+
+        Expression<Func<TestSpecifiableEntity, bool>> criteria = spec.Criteria;
+
+        Assert.Single(criteria.Parameters);
+        Assert.Equal(System.Linq.Expressions.ExpressionType.AndAlso, criteria.Body.NodeType);
+        Assert.DoesNotContain(criteria.Body.ToString(), "Invoke");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Specification_OverNonEntityReadModel_Filters()
+    {
+        var people = new[]
+        {
+            new PersonReadModel { Name = "Alice", Age = 30 },
+            new PersonReadModel { Name = "Bob", Age = 12 },
+            new PersonReadModel { Name = "Amy", Age = 17 },
+        }.AsQueryable();
+
+        var adults = new AdultSpecification().Apply(people).Select(p => p.Name).ToList();
+
+        Assert.Equal(["Alice"], adults);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Composition_OverNonEntityReadModel_Filters()
+    {
+        var people = new[]
+        {
+            new PersonReadModel { Name = "Alice", Age = 30 },
+            new PersonReadModel { Name = "Bob", Age = 40 },
+            new PersonReadModel { Name = "Amy", Age = 17 },
+        }.AsQueryable();
+
+        // Adult AND name starts with 'A'
+        ISpecification<PersonReadModel> spec = new AdultSpecification().And(new NameStartsWithASpecification());
+
+        var result = spec.Apply(people).Select(p => p.Name).ToList();
+
+        Assert.Equal(["Alice"], result);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void DefaultCriteria_MatchesEverything()
+    {
+        // GreaterThanTwoSpecification only overrides Apply, so its Criteria is the default (match all).
+        ISpecification<TestSpecifiableEntity> spec = new GreaterThanTwoSpecification();
+        var result = spec.Criteria.Compile();
+
+        Assert.True(result(new TestSpecifiableEntity(1)));
+        Assert.True(result(new TestSpecifiableEntity(99)));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void And_NullSpecification_Throws()
+    {
+        var spec = new IdGreaterThanTwoSpecification();
+
+        Assert.Throws<ArgumentNullException>(() => spec.And(null!));
+    }
+}

--- a/tests/Asm.Domain.Tests/SpecificationSteps.cs
+++ b/tests/Asm.Domain.Tests/SpecificationSteps.cs
@@ -32,6 +32,27 @@ public class SpecificationSteps
         _result = _query.Specify<TestSpecifiableEntity, GreaterThanTwoSpecification>();
     }
 
+    [When(@"I apply the greater-than-two AND less-than-five specification")]
+    public void WhenIApplyTheGreaterThanTwoAndLessThanFiveSpecification()
+    {
+        ISpecification<TestSpecifiableEntity> spec = new IdGreaterThanTwoSpecification().And(new IdLessThanFiveSpecification());
+        _result = _query.Specify(spec);
+    }
+
+    [When(@"I apply the greater-than-two OR even specification")]
+    public void WhenIApplyTheGreaterThanTwoOrEvenSpecification()
+    {
+        ISpecification<TestSpecifiableEntity> spec = new IdGreaterThanTwoSpecification().Or(new IdIsEvenSpecification());
+        _result = _query.Specify(spec);
+    }
+
+    [When(@"I apply the NOT greater-than-two specification")]
+    public void WhenIApplyTheNotGreaterThanTwoSpecification()
+    {
+        ISpecification<TestSpecifiableEntity> spec = new IdGreaterThanTwoSpecification().Not();
+        _result = _query.Specify(spec);
+    }
+
     [Then(@"the result should contain entities with IDs \[(.*)\]")]
     public void ThenTheResultShouldContainEntitiesWithIds(string expectedIds)
     {

--- a/tests/Asm.Domain.Tests/TestClasses.cs
+++ b/tests/Asm.Domain.Tests/TestClasses.cs
@@ -1,4 +1,6 @@
-﻿namespace Asm.Domain.Tests;
+﻿using System.Linq.Expressions;
+
+namespace Asm.Domain.Tests;
 
 internal class TestKeyedEntity(int id) : KeyedEntity<int>(id)
 {
@@ -29,4 +31,39 @@ internal class GreaterThanTwoSpecification : ISpecification<TestSpecifiableEntit
 {
     public IQueryable<TestSpecifiableEntity> Apply(IQueryable<TestSpecifiableEntity> query)
         => query.Where(e => e.Id > 2);
+}
+
+// Criteria-based specification built on the abstract base class.
+internal sealed class IdGreaterThanTwoSpecification : Specification<TestSpecifiableEntity>
+{
+    public override Expression<Func<TestSpecifiableEntity, bool>> Criteria => e => e.Id > 2;
+}
+
+// Criteria-based specification implementing the interface directly (exercises the default Apply/And/Or/Not).
+internal sealed class IdLessThanFiveSpecification : ISpecification<TestSpecifiableEntity>
+{
+    public Expression<Func<TestSpecifiableEntity, bool>> Criteria => e => e.Id < 5;
+}
+
+internal sealed class IdIsEvenSpecification : Specification<TestSpecifiableEntity>
+{
+    public override Expression<Func<TestSpecifiableEntity, bool>> Criteria => e => e.Id % 2 == 0;
+}
+
+// A read model / DTO that is NOT an Entity, to prove specifications work over any class.
+internal sealed class PersonReadModel
+{
+    public int Age { get; init; }
+
+    public string Name { get; init; } = String.Empty;
+}
+
+internal sealed class AdultSpecification : Specification<PersonReadModel>
+{
+    public override Expression<Func<PersonReadModel, bool>> Criteria => p => p.Age >= 18;
+}
+
+internal sealed class NameStartsWithASpecification : ISpecification<PersonReadModel>
+{
+    public Expression<Func<PersonReadModel, bool>> Criteria => p => p.Name.StartsWith("A");
 }


### PR DESCRIPTION
## Phase 5 Batch 3 — Repositories & specifications

Part of the v4.0 API redesign (#411). Targets `release/v4.0`. Repository/specification items only — the domain-event dispatch / SaveChanges work is out of scope and untouched.

### 1. `TKey` constraint aligned to `notnull`
`IRepository`, `IWritableRepository`, `IDeletableRepository` and `RepositoryBase`/`RepositoryWriteBase`/`RepositoryDeleteBase` moved from `where TKey : struct` to `where TKey : notnull`. This is a **widening** — every value-type key still satisfies it, and reference-type keys (e.g. `string`) are now allowed. No existing call site changes.

### 2. `AddRange` on `IWritableRepository`
Declared on the interface as a **default interface method** (loops `Add`), so existing implementers are not broken. `RepositoryWriteBase` keeps its `DbSet.AddRange` override.

### 3. `Find` / `TryGet` (null-returning) alongside `Get` (throwing)
`Get(TKey …)` still throws `NotFoundException`; new `Find`/`TryGet` return `TEntity?` (null) for expected-absence cases. Added as default interface methods; `RepositoryBase` overrides them with an efficient `SingleOrDefaultAsync`. NotFoundException-vs-null semantics documented in XML docs.

### 4. `ISpecification<TEntity>` redesign
- Constraint relaxed `Entity` → `class` (specs can target read models / DTOs / interfaces). `IQueryable.Specify(…)` relaxed to match.
- New `Expression<Func<TEntity,bool>> Criteria` (translatable predicate) alongside `Apply` (now defaulted to `query.Where(Criteria)`, still overridable for `Include`/`OrderBy`/paging).
- `And` / `Or` / `Not` compose the operands' **`Criteria`** via `Expression.AndAlso`/`OrElse`/`Not`, rebinding both lambdas onto a single parameter with an `ExpressionVisitor` so the result stays EF-translatable. Composition combines the filter only, not the `Apply`-side shaping (there is no meaningful merge of two `OrderBy`s under an `OR`) — documented.
- New `Specification<T>` abstract base, internal `And`/`Or`/`Not` composite specs, and public `AsmDomainExpressionExtensions` (`AndAlso`/`OrElse`/`Not`) combinators.

`Criteria` and `Apply` are default interface members, so existing `Apply`-only specifications keep compiling unchanged.

### Design decisions (latitude taken)
- **Default interface methods** were used throughout (AddRange, Find, TryGet, Criteria, Apply, And/Or/Not) rather than plain abstract members, to add the features without breaking external direct implementers of the interfaces.
- `TryGet` is a thin alias forwarding to `Find` (async has no `out`, so nullable-return is the idiom).
- The `Find` **interface default** filters the full collection (dependency-free — `Asm.Domain` does not reference `Asm`/`NotFoundException`); `RepositoryBase` overrides it with a keyed DB query. `NotFoundException` is referenced in docs as text, not a `cref`, to avoid coupling `Asm.Domain` to `Asm`.

### Tests
- `Asm.Domain.Tests`: 76 passing (added spec And/Or/Not filtering incl. non-Entity read models, predicate combinators with parameter-rebinding assertions, default-interface-method repository paths — AddRange/Find/TryGet — and 3 new Reqnroll composition scenarios).
- `Asm.Domain.Infrastructure.Tests`: 81 passing (EF InMemory: Get throws `NotFoundException` vs Find/TryGet return null, AddRange persistence, and a string-keyed repository proving the `notnull` relaxation).
- Full `dotnet test Asm.slnx -c Release`: all 15 test projects green, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
