### PR TITLE
Phase 5 Batch 9: consistency

### DIFF
--- a/docs/migration-v4.md
+++ b/docs/migration-v4.md
@@ -330,22 +330,22 @@ The OAuth `AddMicrosoftAccount` handler is retained (this is **not** a switch to
 - Update the Entra **app-registration redirect URI** from `https://<host>/signin-oidc` to `https://<host>/signin-entraid`.
 - Existing back-office external logins keyed on the old `"OpenIdConnect"` scheme name may need to be **re-linked** (the persisted login provider key changes).
 
-### `EndpointGroupBase` — nullable sentinels, per-endpoint names, multiple tags, anonymous opt-out
+### `EndpointGroupBase` — `Name` removed, nullable sentinels, multiple tags, anonymous opt-out
 
 `Asm.AspNetCore.Routing.EndpointGroupBase` no longer uses `String.Empty` sentinels and now supports richer configuration:
 
 | Member | Before | After |
 |---|---|---|
-| `Name` | `abstract string` | `virtual string?` (default `null`) |
+| `Name` | `abstract string` | **removed** |
 | `Tags` | `virtual string` (`String.Empty`) | `virtual string[]?` (default `null`) |
 | `AuthorisationPolicy` | `virtual string` (`String.Empty`) | `virtual string?` (default `null`) |
 | `AllowAnonymous` | — | `virtual bool` (default `false`) |
 
-- **Per-endpoint names:** when `Name` is `null` (the new default) no group-level `WithName` is applied, so individual endpoints can supply their own names without colliding with the group.
+- **`Name` removed (endpoint names are per-endpoint):** the base previously called `WithName(Name)` on the *group*, which stamps that name onto **every** endpoint in the group — and endpoint names must be globally unique, so any group with more than one endpoint threw `InvalidOperationException` at startup. `WithName` is not an OpenAPI grouping mechanism. Group-level labelling is `Tags` (Swagger UI sections); set endpoint names on individual endpoints inside `MapEndpoints` (`builder.MapGet(...).WithName("GetFoo")`).
 - **Multiple tags:** `Tags` is now a `string[]`, applied via `WithTags(params string[])`.
 - **Anonymous opt-out:** override `AllowAnonymous => true` to make the whole group anonymous (calls `AllowAnonymous()` instead of `RequireAuthorization`).
 
-**What to change:** derived groups that `override string Tags` / `override string AuthorisationPolicy` / `override string Name` must update the member type. For example `public override string Tags => "a,b";` becomes `public override string[] Tags => ["a", "b"];`. Groups that only override `Path` and `MapEndpoints` are unaffected.
+**What to change:** remove any `override string Name` from derived groups (move the name to the individual endpoint via `.WithName(...)` if you relied on it). Derived groups that `override string Tags` / `override string AuthorisationPolicy` must update the member type — e.g. `public override string Tags => "a,b";` becomes `public override string[] Tags => ["a", "b"];`. Groups that only override `Path` and `MapEndpoints` are unaffected.
 
 ### `IEnumerable<T>.Page` / `IQueryable<T>.Page` now validate arguments
 

--- a/docs/migration-v4.md
+++ b/docs/migration-v4.md
@@ -300,3 +300,89 @@ services.AddSecurityReporting();
 - The old order-dependent auto-coupling (a `services.FirstOrDefault(...)` probe inside `AddStandardSecurityHeaders`) has been removed.
 
 **What to change:** nothing is required. Behaviour only improves — reporting headers are now emitted regardless of the order in which the two methods were registered. If your code relied on the old behaviour of *suppressing* reporting headers by deliberately registering reporting last, register the two methods in separate service collections instead.
+
+## Batch 9 — Consistency
+
+A grab-bag of consistency and correctness fixes. Additive/annotation-only items (`ToIPAddress`, Reqnroll numeric null transforms, nullability attributes, `MockDbSet` refactor, MCP referenced-assembly loading) are source-compatible and listed briefly at the end; the breaking changes are detailed first.
+
+### `AsmException` is now `abstract`
+
+`Asm.AsmException` is now `abstract` with `protected` constructors. It exists purely as a base so consumers can derive their own exception types and so ASM exceptions can be distinguished from framework ones. The existing concrete ASM exception types (`NotFoundException`, `ExistsException`, `NotAuthorisedException`, `BoundExceededException`) are unaffected — they derive from the most appropriate framework base, not `AsmException`.
+
+**What to change:** stop instantiating `AsmException` directly (`new AsmException(...)` no longer compiles). Derive a concrete type and construct that instead:
+
+```csharp
+public sealed class MyException(string message, int errorId) : AsmException(message, errorId);
+```
+
+### `EntraId` back-office scheme name and callback path (Umbraco)
+
+The Umbraco Entra ID back-office login provider previously named its scheme `"OpenIdConnect"` and squatted on `/signin-oidc` — the default callback path of the real OpenID Connect handler — even though it uses the OAuth 2.0 `AddMicrosoftAccount` handler, not OIDC. Both have been renamed to provider-specific values:
+
+| | Before | After |
+|---|---|---|
+| `EntraIdLoginOptions.SchemeName` | `"OpenIdConnect"` | `"EntraId"` |
+| `MicrosoftAccountOptions.CallbackPath` | `/signin-oidc` | `/signin-entraid` |
+
+The OAuth `AddMicrosoftAccount` handler is retained (this is **not** a switch to `AddOpenIdConnect`).
+
+**What to change (breaking — `SchemeName` is a `const` so it cannot carry an `[Obsolete]` shim):**
+- Update the Entra **app-registration redirect URI** from `https://<host>/signin-oidc` to `https://<host>/signin-entraid`.
+- Existing back-office external logins keyed on the old `"OpenIdConnect"` scheme name may need to be **re-linked** (the persisted login provider key changes).
+
+### `EndpointGroupBase` — nullable sentinels, per-endpoint names, multiple tags, anonymous opt-out
+
+`Asm.AspNetCore.Routing.EndpointGroupBase` no longer uses `String.Empty` sentinels and now supports richer configuration:
+
+| Member | Before | After |
+|---|---|---|
+| `Name` | `abstract string` | `virtual string?` (default `null`) |
+| `Tags` | `virtual string` (`String.Empty`) | `virtual string[]?` (default `null`) |
+| `AuthorisationPolicy` | `virtual string` (`String.Empty`) | `virtual string?` (default `null`) |
+| `AllowAnonymous` | — | `virtual bool` (default `false`) |
+
+- **Per-endpoint names:** when `Name` is `null` (the new default) no group-level `WithName` is applied, so individual endpoints can supply their own names without colliding with the group.
+- **Multiple tags:** `Tags` is now a `string[]`, applied via `WithTags(params string[])`.
+- **Anonymous opt-out:** override `AllowAnonymous => true` to make the whole group anonymous (calls `AllowAnonymous()` instead of `RequireAuthorization`).
+
+**What to change:** derived groups that `override string Tags` / `override string AuthorisationPolicy` / `override string Name` must update the member type. For example `public override string Tags => "a,b";` becomes `public override string[] Tags => ["a", "b"];`. Groups that only override `Path` and `MapEndpoints` are unaffected.
+
+### `IEnumerable<T>.Page` / `IQueryable<T>.Page` now validate arguments
+
+Both `Page` overloads now throw `ArgumentOutOfRangeException` when `pageSize` or `pageNumber` is less than one, and `ArgumentNullException` for a null source/`IPageable`. Previously an invalid page number silently produced the wrong page (a negative `Skip` is ignored) and a negative page size silently returned an empty sequence.
+
+**What to change:** ensure callers pass `pageSize >= 1` and `pageNumber >= 1` (pages are 1-based).
+
+### `IEnumerator.GetEnumerator<T>()` renamed to `AsGeneric<T>()`
+
+The `System.Collections.IEnumerator` extension that adapts to `IEnumerator<T>` was named `GetEnumerator<T>`, which is confusing (it is not the `foreach` pattern method). It is renamed to `AsGeneric<T>`. The old name remains as an `[Obsolete]` forwarder for one major cycle.
+
+**What to change:** replace `enumerator.GetEnumerator<T>()` with `enumerator.AsGeneric<T>()`.
+
+### `RouteHandlerBuilder.WithValidation<T>` locates the parameter by type
+
+`WithValidation<T>()` now finds the argument to validate by its **type** rather than by position. The positional `WithValidation<T>(int parameterIndex)` overload is retained but `[Obsolete]`.
+
+**What to change:** prefer `WithValidation<T>()` (no index). The positional overload still works but is deprecated.
+
+### `OneOfAuthorisationRequirementHandler` — correct any-of semantics
+
+The handler for `OneOfAuthorisationRequirement` had three problems, now fixed:
+- It called `context.Fail()` when no sub-requirement passed. In an any-of handler a single failing option must **not** veto the whole requirement, so `context.Fail()` is no longer called — an unmet requirement is denied by the middleware anyway, but other handlers for the same requirement can still succeed.
+- It passed `null` as the resource to each sub-check; it now passes `context.Resource` through.
+- The `abstract IsAuthorised` hook was never invoked. It is now consulted (with the resource) when none of the sub-requirements succeed, and its signature is `ValueTask<bool> IsAuthorised(object? resource)`.
+
+**What to change:** implementations of `IsAuthorised` should accept `object?` (the resource) and return whether to grant the custom check. Return `false` to preserve pure any-of behaviour.
+
+### `RouteParamAuthorisationHandler` — new strongly-typed variant
+
+A new `RouteParamAuthorisationHandler<TRequirement, TValue>` extracts the route value as a strongly-typed `TValue` (via `TypeConverter`, overridable through `TryConvert`) before calling `ValueTask<bool> IsAuthorised(TValue value)`. The original stringly-typed `RouteParamAuthorisationHandler<TRequirement>` is unchanged.
+
+### Additive / source-compatible changes
+
+- **`Asm.Net`:** added `uint.ToIPAddress()`, the inverse of `IPAddress.ToUInt32()`.
+- **`Asm.Reqnroll`:** added `<NULL>` step-argument transforms for `long?`, `decimal?`, and `double?`, mirroring the existing `int?` transform.
+- **Nullability:** `IsNullOrEmpty` extensions (enumerable/list/array) are annotated `[NotNullWhen(false)]`; `Asm.Reqnroll` `DecodeWhitespace` is annotated `[return: NotNullIfNotNull]` and accepts `string?`.
+- **`WebApplicationStart`:** is now a `static` class and gained `RunAsync`; `AppStart.Run`/`RunAsync` share a single implementation.
+- **`Asm.Testing.Domain`:** `MockDbSet<T>` now delegates its setup to `MockDbSetFactory` (no duplicated Moq wiring).
+- **`Asm.ModelContextProtocol`:** `WithToolsFromAssemblies` guards null/empty inputs and also loads matching *referenced* assemblies that are not yet loaded.

--- a/src/Asm.AspNetCore.Modules/Routing/EndpointGroupBase.cs
+++ b/src/Asm.AspNetCore.Modules/Routing/EndpointGroupBase.cs
@@ -10,9 +10,13 @@ namespace Asm.AspNetCore.Routing;
 public abstract class EndpointGroupBase : IEndpointGroup
 {
     /// <summary>
-    /// Gets the Open API name of the group.
+    /// Gets the Open API name of the group, or <c>null</c> to let individual endpoints supply their own names.
     /// </summary>
-    public abstract string Name { get; }
+    /// <remarks>
+    /// When <c>null</c> (the default) no group-level name is applied, so each endpoint mapped in
+    /// <see cref="MapEndpoints"/> can define its own name via <c>WithName</c> without colliding with the group.
+    /// </remarks>
+    public virtual string? Name => null;
 
     /// <summary>
     /// Gets the URL path of the group.
@@ -20,21 +24,26 @@ public abstract class EndpointGroupBase : IEndpointGroup
     public abstract string Path { get; }
 
     /// <summary>
-    /// Gets the Open API tags of the group.
+    /// Gets the Open API tags of the group, or <c>null</c> for no tags.
     /// </summary>
-    public virtual string Tags => String.Empty;
+    public virtual string[]? Tags => null;
 
     /// <summary>
-    /// Gets the authorisation policy name that is applied to the group.
+    /// Gets the authorisation policy name that is applied to the group, or <c>null</c> to apply the default (any authenticated user).
     /// </summary>
     /// <remarks>
-    /// Do not override if a policy does not apply to the group.
+    /// Leave as <c>null</c> if no specific policy applies to the group. To make the whole group anonymous, override <see cref="AllowAnonymous"/> instead.
     /// </remarks>
-    public virtual string AuthorisationPolicy => String.Empty;
+    public virtual string? AuthorisationPolicy => null;
+
+    /// <summary>
+    /// Gets a value indicating whether the group is anonymous (opts out of authorisation entirely).
+    /// </summary>
+    public virtual bool AllowAnonymous => false;
 
     /// <summary>
     /// Maps the group endpoints.
-    /// </summary>r
+    /// </summary>
     /// <remarks>
     /// Sets the operation name, display name, tags, authorisation policy and maps the endpoints.
     /// </remarks>
@@ -47,11 +56,30 @@ public abstract class EndpointGroupBase : IEndpointGroup
     /// </returns>
     public virtual RouteGroupBuilder MapGroup(IEndpointRouteBuilder builder)
     {
-        var subBuilder = builder.MapGroup(Path)
-            .WithName(Name)
-            .WithTags(Tags);
+        var subBuilder = builder.MapGroup(Path);
 
-        subBuilder = String.IsNullOrEmpty(AuthorisationPolicy) ? subBuilder.RequireAuthorization() : subBuilder.RequireAuthorization(AuthorisationPolicy);
+        if (!String.IsNullOrEmpty(Name))
+        {
+            subBuilder.WithName(Name);
+        }
+
+        if (Tags is { Length: > 0 } tags)
+        {
+            subBuilder.WithTags(tags);
+        }
+
+        if (AllowAnonymous)
+        {
+            subBuilder.AllowAnonymous();
+        }
+        else if (String.IsNullOrEmpty(AuthorisationPolicy))
+        {
+            subBuilder.RequireAuthorization();
+        }
+        else
+        {
+            subBuilder.RequireAuthorization(AuthorisationPolicy);
+        }
 
         MapEndpoints(subBuilder);
 

--- a/src/Asm.AspNetCore.Modules/Routing/EndpointGroupBase.cs
+++ b/src/Asm.AspNetCore.Modules/Routing/EndpointGroupBase.cs
@@ -10,15 +10,6 @@ namespace Asm.AspNetCore.Routing;
 public abstract class EndpointGroupBase : IEndpointGroup
 {
     /// <summary>
-    /// Gets the Open API name of the group, or <c>null</c> to let individual endpoints supply their own names.
-    /// </summary>
-    /// <remarks>
-    /// When <c>null</c> (the default) no group-level name is applied, so each endpoint mapped in
-    /// <see cref="MapEndpoints"/> can define its own name via <c>WithName</c> without colliding with the group.
-    /// </remarks>
-    public virtual string? Name => null;
-
-    /// <summary>
     /// Gets the URL path of the group.
     /// </summary>
     public abstract string Path { get; }
@@ -45,7 +36,9 @@ public abstract class EndpointGroupBase : IEndpointGroup
     /// Maps the group endpoints.
     /// </summary>
     /// <remarks>
-    /// Sets the operation name, display name, tags, authorisation policy and maps the endpoints.
+    /// Applies the group tags and authorisation policy, then maps the endpoints. Endpoint names
+    /// (<c>WithName</c>) are the responsibility of individual endpoints in <see cref="MapEndpoints"/>,
+    /// since a group-level name would be applied to every endpoint and endpoint names must be unique.
     /// </remarks>
     /// <param name="builder">The builder instance that this group attaches to.</param>
     /// <returns>
@@ -57,11 +50,6 @@ public abstract class EndpointGroupBase : IEndpointGroup
     public virtual RouteGroupBuilder MapGroup(IEndpointRouteBuilder builder)
     {
         var subBuilder = builder.MapGroup(Path);
-
-        if (!String.IsNullOrEmpty(Name))
-        {
-            subBuilder.WithName(Name);
-        }
 
         if (Tags is { Length: > 0 } tags)
         {

--- a/src/Asm.AspNetCore/Authorisation/OneOfAuthorisationRequirementHandler.cs
+++ b/src/Asm.AspNetCore/Authorisation/OneOfAuthorisationRequirementHandler.cs
@@ -3,7 +3,8 @@
 namespace Asm.AspNetCore.Authorisation;
 
 /// <summary>
-/// Route parameter authorisation handler.
+/// Authorisation handler for a <see cref="OneOfAuthorisationRequirement"/> that succeeds when any of
+/// the sub-requirements pass, or when the derived <see cref="IsAuthorised"/> check grants access.
 /// </summary>
 /// <param name="authorisationService">An <see cref="IAuthorizationService"/> instance.</param>
 public abstract class OneOfAuthorisationRequirementHandler(IAuthorizationService authorisationService) : AuthorizationHandler<OneOfAuthorisationRequirement>
@@ -13,7 +14,8 @@ public abstract class OneOfAuthorisationRequirementHandler(IAuthorizationService
     {
         foreach (var subRequirement in requirement.Requirements)
         {
-            var result = await authorisationService.AuthorizeAsync(context.User, null, subRequirement);
+            // Pass the resource through so resource-based sub-requirements can evaluate it.
+            var result = await authorisationService.AuthorizeAsync(context.User, context.Resource, subRequirement);
 
             if (result.Succeeded)
             {
@@ -22,12 +24,20 @@ public abstract class OneOfAuthorisationRequirementHandler(IAuthorizationService
             }
         }
 
-        context.Fail();
+        // Give derived handlers a final, custom say based on the resource. In an any-of handler a
+        // single failing option must never veto the whole requirement, so we never call context.Fail();
+        // an unmet requirement is denied by the authorisation middleware anyway.
+        if (await IsAuthorised(context.Resource))
+        {
+            context.Succeed(requirement);
+        }
     }
 
     /// <summary>
-    /// Performs authorisation based on the route parameter value.
+    /// Performs a custom authorisation check for the requirement's resource, consulted when none of the
+    /// sub-requirements succeed.
     /// </summary>
-    protected abstract ValueTask<bool> IsAuthorised(object value);
-
+    /// <param name="resource">The resource associated with the current authorisation context, or <c>null</c>.</param>
+    /// <returns><c>true</c> to grant access; otherwise <c>false</c>.</returns>
+    protected abstract ValueTask<bool> IsAuthorised(object? resource);
 }

--- a/src/Asm.AspNetCore/Authorisation/RouteParamAuthorisationHandler.cs
+++ b/src/Asm.AspNetCore/Authorisation/RouteParamAuthorisationHandler.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Authorization;
+﻿using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 
 namespace Asm.AspNetCore.Authorisation;
@@ -29,4 +32,71 @@ public abstract class RouteParamAuthorisationHandler<TRequirement>(IHttpContextA
     /// </summary>
     protected abstract ValueTask<bool> IsAuthorised(object value);
 
+}
+
+/// <summary>
+/// Route parameter authorisation handler that extracts the route value as a strongly-typed
+/// <typeparamref name="TValue"/> before performing authorisation.
+/// </summary>
+/// <typeparam name="TRequirement">The requirement type.</typeparam>
+/// <typeparam name="TValue">The type the route parameter is converted to.</typeparam>
+/// <param name="httpContextAccessor">An <see cref="IHttpContextAccessor"/> instance.</param>
+public abstract class RouteParamAuthorisationHandler<TRequirement, TValue>(IHttpContextAccessor httpContextAccessor) : AuthorizationHandler<TRequirement> where TRequirement : RouteParamAuthorisationRequirement
+{
+    /// <inheritdoc />
+    protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, TRequirement requirement)
+    {
+        if (httpContextAccessor.HttpContext?.Request.RouteValues.TryGetValue(requirement.Name, out var value) == true
+            && value is not null
+            && TryConvert(value, out var typedValue)
+            && await IsAuthorised(typedValue))
+        {
+            context.Succeed(requirement);
+            return;
+        }
+
+        context.Fail();
+    }
+
+    /// <summary>
+    /// Performs authorisation based on the strongly-typed route parameter value.
+    /// </summary>
+    /// <param name="value">The converted route parameter value.</param>
+    /// <returns><c>true</c> to grant access; otherwise <c>false</c>.</returns>
+    protected abstract ValueTask<bool> IsAuthorised(TValue value);
+
+    /// <summary>
+    /// Converts the raw route value to <typeparamref name="TValue"/>. Route values are typically
+    /// strings; override to supply custom conversion.
+    /// </summary>
+    /// <param name="value">The raw route value.</param>
+    /// <param name="result">The converted value when conversion succeeds.</param>
+    /// <returns><c>true</c> if conversion succeeded; otherwise <c>false</c>.</returns>
+    protected virtual bool TryConvert(object value, [MaybeNullWhen(false)] out TValue result)
+    {
+        if (value is TValue typed)
+        {
+            result = typed;
+            return true;
+        }
+
+        try
+        {
+            var converter = TypeDescriptor.GetConverter(typeof(TValue));
+            var stringValue = value as string ?? value.ToString();
+
+            if (stringValue is not null && converter.CanConvertFrom(typeof(string)))
+            {
+                result = (TValue?)converter.ConvertFromString(null, CultureInfo.InvariantCulture, stringValue);
+                return result is not null;
+            }
+        }
+        catch (Exception ex) when (ex is NotSupportedException or FormatException or ArgumentException)
+        {
+            // Conversion failed; treat as unauthorised.
+        }
+
+        result = default;
+        return false;
+    }
 }

--- a/src/Asm.AspNetCore/Builder/RouteHandlerBuilderExtensions.cs
+++ b/src/Asm.AspNetCore/Builder/RouteHandlerBuilderExtensions.cs
@@ -9,13 +9,25 @@ namespace Microsoft.AspNetCore.Builder;
 public static class RouteHandlerBuilderExtensions
 {
     /// <summary>
-    /// Adds a validation filter to the route handler.
+    /// Adds a validation filter to the route handler that locates the parameter to validate by its type.
+    /// </summary>
+    /// <typeparam name="T">The type of parameter to be validated.</typeparam>
+    /// <param name="builder">The <see cref="RouteHandlerBuilder" /> object that this method extends.</param>
+    /// <returns>The <see cref="RouteHandlerBuilder"/> instance so that calls can be chained.</returns>
+    public static RouteHandlerBuilder WithValidation<T>(this RouteHandlerBuilder builder)
+    {
+        return builder.AddEndpointFilter(new ValidatorFilter<T>());
+    }
+
+    /// <summary>
+    /// Adds a validation filter to the route handler for the parameter at the given index.
     /// </summary>
     /// <typeparam name="T">The type of parameter to be validated.</typeparam>
     /// <param name="builder">The <see cref="RouteHandlerBuilder" /> object that this method extends.</param>
     /// <param name="parameterIndex">The index of the parameter to be validated.</param>
     /// <returns>The <see cref="RouteHandlerBuilder"/> instance so that calls can be chained.</returns>
-    public static RouteHandlerBuilder WithValidation<T>(this RouteHandlerBuilder builder, int parameterIndex = 0)
+    [Obsolete("Locate the parameter by type using WithValidation<T>() instead. This overload will be removed in a future version.")]
+    public static RouteHandlerBuilder WithValidation<T>(this RouteHandlerBuilder builder, int parameterIndex)
     {
         return builder.AddEndpointFilter(new ValidatorFilter<T>(parameterIndex));
     }

--- a/src/Asm.AspNetCore/Http/ValidatorFilter.cs
+++ b/src/Asm.AspNetCore/Http/ValidatorFilter.cs
@@ -4,11 +4,15 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Asm.AspNetCore.Http;
 
-internal class ValidatorFilter<T>(int parameterIndex) : IEndpointFilter
+internal class ValidatorFilter<T>(int? parameterIndex = null) : IEndpointFilter
 {
     public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
     {
-        T? arg = context.GetArgument<T>(parameterIndex);
+        // Locate the argument by type when no explicit index is given; fall back to the index for
+        // the legacy positional overload.
+        T? arg = parameterIndex is int index
+            ? context.GetArgument<T>(index)
+            : context.Arguments.OfType<T>().FirstOrDefault();
 
         // A missing/unbindable body is a client error, not a 500 — ValidateAndThrowAsync(null)
         // would otherwise throw ArgumentNullException.

--- a/src/Asm.AspNetCore/WebApplicationStart.cs
+++ b/src/Asm.AspNetCore/WebApplicationStart.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using Asm.AspNetCore.Extensions;
 using Asm.AspNetCore.HealthChecks;
 using Asm.Serilog;
@@ -16,7 +17,7 @@ namespace Asm.AspNetCore;
 /// Bootstraps and runs a web application.
 /// </summary>
 [ExcludeFromCodeCoverage]
-public class WebApplicationStart
+public static class WebApplicationStart
 {
     /// <summary>
     /// Builds and runs the web application.
@@ -27,42 +28,36 @@ public class WebApplicationStart
     /// <param name="addApp">Set up custom middleware.</param>
     /// <param name="addHealthChecks">A method to add health checks.</param>
     /// <returns>An integer return code.</returns>
-    public static int Run(string[] args, string appName, Action<WebApplicationBuilder> addServices, Action<WebApplication> addApp, Action<IHealthChecksBuilder, WebApplicationBuilder> addHealthChecks)
+    public static int Run(string[] args, string appName, Action<WebApplicationBuilder> addServices, Action<WebApplication> addApp, Action<IHealthChecksBuilder, WebApplicationBuilder> addHealthChecks) =>
+        RunCore(args, appName, addServices, addApp, addHealthChecks, Assembly.GetCallingAssembly(), application =>
+        {
+            application.Run();
+            return Task.CompletedTask;
+        }).AsTask().GetAwaiter().GetResult();
+
+    /// <summary>
+    /// Builds and runs the web application asynchronously.
+    /// </summary>
+    /// <param name="args">Command line arguments.</param>
+    /// <param name="appName">The friendly name of the application, used for logging and telemetry.</param>
+    /// <param name="addServices">A method to add service mappings.</param>
+    /// <param name="addApp">Set up custom middleware.</param>
+    /// <param name="addHealthChecks">A method to add health checks.</param>
+    /// <returns>An integer return code.</returns>
+    public static async ValueTask<int> RunAsync(string[] args, string appName, Action<WebApplicationBuilder> addServices, Action<WebApplication> addApp, Action<IHealthChecksBuilder, WebApplicationBuilder> addHealthChecks) =>
+        await RunCore(args, appName, addServices, addApp, addHealthChecks, Assembly.GetCallingAssembly(), application => application.RunAsync());
+
+    private static async ValueTask<int> RunCore(string[] args, string appName, Action<WebApplicationBuilder> addServices, Action<WebApplication> addApp, Action<IHealthChecksBuilder, WebApplicationBuilder> addHealthChecks, Assembly callingAssembly, Func<WebApplication, Task> run)
     {
         Log.Logger = LoggingConfigurator.ConfigureLogging(new LoggerConfiguration(), appName).CreateBootstrapLogger();
-
 
         try
         {
             Log.Information($"{appName} Starting...");
 
-            var builder = WebApplication.CreateBuilder(args);
+            var application = BuildApplication(args, appName, addServices, addApp, addHealthChecks, callingAssembly);
 
-            if (builder.Environment.IsDevelopment())
-            {
-                builder.Configuration.AddUserSecrets(System.Reflection.Assembly.GetCallingAssembly(), true);
-                builder.Logging.AddDebug();
-                builder.Logging.AddConsole();
-            }
-
-            builder.Host.UseCustomSerilog(appName);
-            builder.AddStandardOpenTelemetry(appName);
-
-            addServices(builder);
-
-            addHealthChecks(builder.Services.AddHealthChecks(), builder);
-
-            var application = builder.Build();
-
-            addApp(application);
-
-            application.MapHealthChecks("/healthz", new HealthCheckOptions
-            {
-                Predicate = p => p.Tags.IsNullOrEmpty() || p.Tags.Contains("health"),
-                ResponseWriter = ResponseWriter.WriteResponse,
-            });
-
-            application.Run();
+            await run(application);
 
             Log.Information($"{appName} Stopping...");
 
@@ -77,5 +72,36 @@ public class WebApplicationStart
         {
             Log.CloseAndFlush();
         }
+    }
+
+    private static WebApplication BuildApplication(string[] args, string appName, Action<WebApplicationBuilder> addServices, Action<WebApplication> addApp, Action<IHealthChecksBuilder, WebApplicationBuilder> addHealthChecks, Assembly callingAssembly)
+    {
+        var builder = WebApplication.CreateBuilder(args);
+
+        if (builder.Environment.IsDevelopment())
+        {
+            builder.Configuration.AddUserSecrets(callingAssembly, true);
+            builder.Logging.AddDebug();
+            builder.Logging.AddConsole();
+        }
+
+        builder.Host.UseCustomSerilog(appName);
+        builder.AddStandardOpenTelemetry(appName);
+
+        addServices(builder);
+
+        addHealthChecks(builder.Services.AddHealthChecks(), builder);
+
+        var application = builder.Build();
+
+        addApp(application);
+
+        application.MapHealthChecks("/healthz", new HealthCheckOptions
+        {
+            Predicate = p => p.Tags.IsNullOrEmpty() || p.Tags.Contains("health"),
+            ResponseWriter = ResponseWriter.WriteResponse,
+        });
+
+        return application;
     }
 }

--- a/src/Asm.Hosting/AppStart.cs
+++ b/src/Asm.Hosting/AppStart.cs
@@ -1,4 +1,4 @@
-﻿using Asm.Serilog;
+using Asm.Serilog;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Serilog;
@@ -17,54 +17,22 @@ public static class AppStart
     /// <param name="appName">The application name.</param>
     /// <param name="configureServices">A method to configure services.</param>
     /// <returns>A return code.</returns>
-    public static int Run(string[] args, string appName, Action<HostBuilderContext, IServiceCollection> configureServices)
-    {
-        Log.Logger = LoggingConfigurator.ConfigureLogging(new LoggerConfiguration(), appName).CreateBootstrapLogger();
-
-        try
+    public static int Run(string[] args, string appName, Action<HostBuilderContext, IServiceCollection> configureServices) =>
+        RunCore(args, appName, configureServices, host =>
         {
-            Log.Information("Starting...");
-            CreateHostBuilder(args, appName, configureServices).Build().Run();
-            return 0;
-        }
-        catch (Exception ex)
-        {
-            Log.Fatal(ex, "Fatal host exception");
-            return 1;
-        }
-        finally
-        {
-            Log.CloseAndFlush();
-        }
-    }
+            host.Run();
+            return Task.CompletedTask;
+        }).AsTask().GetAwaiter().GetResult();
 
     /// <summary>
-    /// Run the hosted process synchronously.
+    /// Run the hosted process asynchronously.
     /// </summary>
     /// <param name="args">Command line arguments.</param>
     /// <param name="appName">The application name.</param>
     /// <param name="configureServices">A method to configure services.</param>
     /// <returns>A return code.</returns>
-    public static async ValueTask<int> RunAsync(string[] args, string appName, Action<HostBuilderContext, IServiceCollection> configureServices)
-    {
-        Log.Logger = LoggingConfigurator.ConfigureLogging(new LoggerConfiguration(), appName).CreateBootstrapLogger();
-
-        try
-        {
-            Log.Information("Starting...");
-            await CreateHostBuilder(args, appName, configureServices).Build().RunAsync();
-            return 0;
-        }
-        catch (Exception ex)
-        {
-            Log.Fatal(ex, "Fatal host exception");
-            return 1;
-        }
-        finally
-        {
-            Log.CloseAndFlush();
-        }
-    }
+    public static async ValueTask<int> RunAsync(string[] args, string appName, Action<HostBuilderContext, IServiceCollection> configureServices) =>
+        await RunCore(args, appName, configureServices, host => host.RunAsync());
 
     /// <summary>
     /// Creates a host builder to allow customization of the host.
@@ -82,4 +50,24 @@ public static class AppStart
         .UseCustomSerilog()
         .ConfigureServices(configureServices);
 
+    private static async ValueTask<int> RunCore(string[] args, string appName, Action<HostBuilderContext, IServiceCollection> configureServices, Func<IHost, Task> run)
+    {
+        Log.Logger = LoggingConfigurator.ConfigureLogging(new LoggerConfiguration(), appName).CreateBootstrapLogger();
+
+        try
+        {
+            Log.Information("Starting...");
+            await run(CreateHostBuilder(args, appName, configureServices).Build());
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Log.Fatal(ex, "Fatal host exception");
+            return 1;
+        }
+        finally
+        {
+            Log.CloseAndFlush();
+        }
+    }
 }

--- a/src/Asm.ModelContextProtocol/AsmModelContextProtocolMcpServerBuilderExtensions.cs
+++ b/src/Asm.ModelContextProtocol/AsmModelContextProtocolMcpServerBuilderExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.Extensions.DependencyInjection;
+﻿using System.Reflection;
+
+namespace Microsoft.Extensions.DependencyInjection;
 
 /// <summary>
 /// Extension for the <see cref="IMcpServerBuilder"/> interface.
@@ -6,18 +8,57 @@
 public static class AsmModelContextProtocolMcpServerBuilderExtensions
 {
     /// <summary>
-    /// Adds tools from all assemblies in the current app domain that match the specified pattern. 
+    /// Adds tools from all assemblies whose name contains the specified pattern.
     /// </summary>
+    /// <remarks>
+    /// Both the assemblies already loaded into the current <see cref="AppDomain"/> and any matching
+    /// referenced assemblies (which may not yet be loaded) are searched, so tools are discovered even
+    /// when their assembly has not been touched at start-up.
+    /// </remarks>
     /// <param name="builder">The <see cref="IMcpServerBuilder"/> instance that this method extends.</param>
     /// <param name="pattern">Only search assemblies where the name contains this pattern.</param>
     /// <returns>The <see cref="IMcpServerBuilder"/> so that calls can be chained.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="builder"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="pattern"/> is <c>null</c> or empty.</exception>
     public static IMcpServerBuilder WithToolsFromAssemblies(this IMcpServerBuilder builder, string pattern)
     {
-        var assemblies = AppDomain.CurrentDomain.GetAssemblies().Where(a => a.GetName().Name?.Contains(pattern) == true);
-        foreach (var assembly in assemblies)
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(pattern);
+
+        var matches = new Dictionary<string, Assembly>(StringComparer.Ordinal);
+
+        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            var name = assembly.GetName().Name;
+            if (name is not null && name.Contains(pattern, StringComparison.Ordinal))
+            {
+                matches[name] = assembly;
+            }
+
+            // Referenced assemblies may not be loaded yet; load any that match so their tools are discoverable.
+            foreach (var referenced in assembly.GetReferencedAssemblies())
+            {
+                if (referenced.Name is not string referencedName || matches.ContainsKey(referencedName) || !referencedName.Contains(pattern, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    matches[referencedName] = Assembly.Load(referenced);
+                }
+                catch (Exception ex) when (ex is FileNotFoundException or FileLoadException or BadImageFormatException)
+                {
+                    // Ignore assemblies that cannot be loaded.
+                }
+            }
+        }
+
+        foreach (var assembly in matches.Values)
         {
             builder.WithToolsFromAssembly(assembly);
         }
+
         return builder;
     }
 }

--- a/src/Asm.Net/AsmNetIPAddressExtensions.cs
+++ b/src/Asm.Net/AsmNetIPAddressExtensions.cs
@@ -84,6 +84,14 @@ public static class AsmNetIPAddressExtensions
     }
 
     /// <summary>
+    /// Converts a 32-bit unsigned integer to an <see cref="IPAddress"/>.
+    /// </summary>
+    /// <remarks>This is the inverse of <see cref="ToUInt32(IPAddress)"/>.</remarks>
+    /// <param name="address">The address as a 32-bit unsigned integer.</param>
+    /// <returns>The IPv4 <see cref="IPAddress"/>.</returns>
+    public static IPAddress ToIPAddress(this uint address) => FromUInt32(address);
+
+    /// <summary>
     /// Converts a 32-bit unsigned integer to an IP address.
     /// </summary>
     /// <param name="address">The address as a 32-bit unsigned integer.</param>

--- a/src/Asm.Reqnroll/StepArgumentTransformations.cs
+++ b/src/Asm.Reqnroll/StepArgumentTransformations.cs
@@ -30,6 +30,27 @@ public class StepArgumentTransformations
     public int? ToIntNull() => null;
 
     /// <summary>
+    /// Converts a string to a <c>null</c> long.
+    /// </summary>
+    /// <returns><c>null</c>.</returns>
+    [StepArgumentTransformation(NullString)]
+    public long? ToLongNull() => null;
+
+    /// <summary>
+    /// Converts a string to a <c>null</c> decimal.
+    /// </summary>
+    /// <returns><c>null</c>.</returns>
+    [StepArgumentTransformation(NullString)]
+    public decimal? ToDecimalNull() => null;
+
+    /// <summary>
+    /// Converts a string to a <c>null</c> double.
+    /// </summary>
+    /// <returns><c>null</c>.</returns>
+    [StepArgumentTransformation(NullString)]
+    public double? ToDoubleNull() => null;
+
+    /// <summary>
     /// Converts a string to <see cref="IPAddress"/>.
     /// </summary>
     /// <param name="input">The string to convert</param>

--- a/src/Asm.Reqnroll/StringExtensions.cs
+++ b/src/Asm.Reqnroll/StringExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace Asm.Reqnroll;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Asm.Reqnroll;
 
 /// <summary>
 /// Extensions for the <see cref="String" /> class.
@@ -12,8 +14,9 @@ public static class StringExtensions
     /// Supports '\r', '\n', and '\t'.
     /// </remarks>
     /// <param name="str">The string to decode.</param>
-    /// <returns>The decoded string.</returns>
-    public static string? DecodeWhitespace(this string str)
+    /// <returns>The decoded string, or <c>null</c> if <paramref name="str"/> is <c>null</c>.</returns>
+    [return: NotNullIfNotNull(nameof(str))]
+    public static string? DecodeWhitespace(this string? str)
     {
         if (str == null) return null;
 

--- a/src/Asm.Testing.Domain/MockDbSet.cs
+++ b/src/Asm.Testing.Domain/MockDbSet.cs
@@ -31,10 +31,6 @@ public class MockDbSet<T> : Mock<DbSet<T>> where T : Entity
     /// <param name="data">The data to return.</param>
     public MockDbSet(IQueryable<T> data)
     {
-        this.As<IQueryable<T>>().Setup(m => m.Provider).Returns(new TestAsyncQueryProvider<T>(data.Provider));
-        this.As<IQueryable<T>>().Setup(m => m.Expression).Returns(data.Expression);
-        this.As<IQueryable<T>>().Setup(m => m.ElementType).Returns(data.ElementType);
-        this.As<IQueryable<T>>().Setup(m => m.GetEnumerator()).Returns(() => data.GetEnumerator());
-        this.As<IAsyncEnumerable<T>>().Setup(m => m.GetAsyncEnumerator(It.IsAny<CancellationToken>())).Returns(() => new TestAsyncEnumerator<T>(data.GetEnumerator()));
+        MockDbSetFactory.Configure(this, data);
     }
 }

--- a/src/Asm.Testing.Domain/MockDbSetFactory.cs
+++ b/src/Asm.Testing.Domain/MockDbSetFactory.cs
@@ -29,12 +29,24 @@ public static class MockDbSetFactory
     public static Mock<DbSet<T>> Create<T>(IQueryable<T> data) where T : class
     {
         var mockSet = new Mock<DbSet<T>>();
+        Configure(mockSet, data);
+        return mockSet;
+    }
+
+    /// <summary>
+    /// Configures the supplied <see cref="DbSet{T}"/> mock to serve the given data with both
+    /// synchronous and asynchronous LINQ support.
+    /// </summary>
+    /// <typeparam name="T">The entity type.</typeparam>
+    /// <param name="mockSet">The mock to configure.</param>
+    /// <param name="data">The data to return.</param>
+    internal static void Configure<T>(Mock<DbSet<T>> mockSet, IQueryable<T> data) where T : class
+    {
         mockSet.As<IQueryable<T>>().Setup(m => m.Provider).Returns(new TestAsyncQueryProvider<T>(data.Provider));
         mockSet.As<IQueryable<T>>().Setup(m => m.Expression).Returns(data.Expression);
         mockSet.As<IQueryable<T>>().Setup(m => m.ElementType).Returns(data.ElementType);
         mockSet.As<IQueryable<T>>().Setup(m => m.GetEnumerator()).Returns(() => data.GetEnumerator());
         mockSet.As<IAsyncEnumerable<T>>().Setup(m => m.GetAsyncEnumerator(It.IsAny<CancellationToken>())).Returns(() => new TestAsyncEnumerator<T>(data.GetEnumerator()));
-        return mockSet;
     }
 
     /// <summary>

--- a/src/Asm.Umbraco.Authentication/EntraId/EntraIdBackOfficeOptions.cs
+++ b/src/Asm.Umbraco.Authentication/EntraId/EntraIdBackOfficeOptions.cs
@@ -22,7 +22,9 @@ internal sealed class EntraIdBackOfficeOptions(IOptions<EntraIdOptions> entraIdO
     public void Configure(MicrosoftAccountOptions options)
     {
         var entraId = entraIdOptions.Value;
-        options.CallbackPath = "/signin-oidc";
+        // Provider-specific callback path; must not collide with the OpenID Connect handler's
+        // default "/signin-oidc". The Entra app-registration redirect URI must match this path.
+        options.CallbackPath = "/signin-entraid";
         options.ClientId = entraId.ClientId;
         options.ClientSecret = entraId.ClientSecret;
         options.TokenEndpoint = $"https://login.microsoftonline.com/{entraId.TenantId}/oauth2/v2.0/token";

--- a/src/Asm.Umbraco.Authentication/EntraId/EntraIdLoginOptions.cs
+++ b/src/Asm.Umbraco.Authentication/EntraId/EntraIdLoginOptions.cs
@@ -12,7 +12,11 @@ internal sealed class EntraIdLoginOptions(IOptions<EntraIdOptions> options) : IC
     /// <summary>
     /// The scheme name (without Umbraco's back-office prefix) used for the Entra ID login provider.
     /// </summary>
-    public const string SchemeName = "OpenIdConnect";
+    /// <remarks>
+    /// This is a provider-specific value. The underlying handler is <c>AddMicrosoftAccount</c> (OAuth 2.0),
+    /// not an OpenID Connect handler, so the scheme is named after the provider rather than "OpenIdConnect".
+    /// </remarks>
+    public const string SchemeName = "EntraId";
 
     private readonly EntraIdOptions _options = options.Value;
 

--- a/src/Asm.Umbraco.Authentication/README.md
+++ b/src/Asm.Umbraco.Authentication/README.md
@@ -53,4 +53,6 @@ Harden this to suit your app:
 
 ### App registration
 
-Register the app in Entra ID with redirect URI `https://<your-host>/signin-oidc`. Grant `openid`, `profile`, and `email` delegated permissions.
+Register the app in Entra ID with redirect URI `https://<your-host>/signin-entraid`. Grant `openid`, `profile`, and `email` delegated permissions.
+
+> **v4 breaking change:** the callback path moved from `/signin-oidc` to `/signin-entraid` and the back-office scheme name changed from `OpenIdConnect` to `EntraId`. Update the Entra app-registration redirect URI accordingly. Existing back-office external logins keyed on the old scheme name may need to be re-linked.

--- a/src/Asm/AsmException.cs
+++ b/src/Asm/AsmException.cs
@@ -7,7 +7,7 @@ namespace Asm;
 /// </summary>
 [Serializable]
 [ExcludeFromCodeCoverage]
-public class AsmException : Exception
+public abstract class AsmException : Exception
 {
     #region Properties
     /// <summary>
@@ -33,7 +33,7 @@ public class AsmException : Exception
     /// <summary>
     /// Initializes a new instance of the <see cref="AsmException"/> class.
     /// </summary>
-    public AsmException() : base()
+    protected AsmException() : base()
     {
         Id = Guid.NewGuid();
     }
@@ -42,7 +42,7 @@ public class AsmException : Exception
     /// Initializes a new instance of the <see cref="AsmException"/> class with a specified error message.
     /// </summary>
     /// <param name="message">The error message that explains the reason for the exception.</param>
-    public AsmException(string message) : base(message)
+    protected AsmException(string message) : base(message)
     {
         Id = Guid.NewGuid();
     }
@@ -52,7 +52,7 @@ public class AsmException : Exception
     /// </summary>
     /// <param name="message">The error message that explains the reason for the exception.</param>
     /// <param name="innerException">The exception that is the cause of the current exception, or a null reference (Nothing in Visual Basic) if no inner exception is specified. </param>
-    public AsmException(string message, Exception innerException) : base(message, innerException)
+    protected AsmException(string message, Exception innerException) : base(message, innerException)
     {
         Id = Guid.NewGuid();
     }
@@ -61,7 +61,7 @@ public class AsmException : Exception
     /// Initializes a new instance of the <see cref="AsmException"/> class.
     /// </summary>
     /// <param name="errorId">The ID of the error.</param>
-    public AsmException(int errorId) : base()
+    protected AsmException(int errorId) : base()
     {
         Id = Guid.NewGuid();
         ErrorId = errorId;
@@ -72,7 +72,7 @@ public class AsmException : Exception
     /// </summary>
     /// <param name="message">The error message that explains the reason for the exception.</param>
     /// <param name="errorId">The ID of the error.</param>
-    public AsmException(string message, int errorId) : base(message)
+    protected AsmException(string message, int errorId) : base(message)
     {
         Id = Guid.NewGuid();
         ErrorId = errorId;
@@ -84,7 +84,7 @@ public class AsmException : Exception
     /// <param name="message">The error message that explains the reason for the exception.</param>
     /// <param name="errorId">The ID of the error.</param>
     /// <param name="innerException">The exception that is the cause of the current exception, or a null reference (Nothing in Visual Basic) if no inner exception is specified. </param>
-    public AsmException(string message, int errorId, Exception innerException) : base(message, innerException)
+    protected AsmException(string message, int errorId, Exception innerException) : base(message, innerException)
     {
         Id = Guid.NewGuid();
         ErrorId = errorId;

--- a/src/Asm/Extensions/AsmEnumerableExtensions.cs
+++ b/src/Asm/Extensions/AsmEnumerableExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace System.Collections.Generic;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace System.Collections.Generic;
 
 /// <summary>
 /// Extension methods for the <see cref="IEnumerable{T}"/> interface.
@@ -10,11 +12,17 @@ public static class AsmEnumerableExtensions
     /// </summary>
     /// <typeparam name="T">The type of elements in the enumerable.</typeparam>
     /// <param name="enumerable">The enumerable object that this method extends.</param>
-    /// <param name="pageSize">The number of elements in a page.</param>
-    /// <param name="pageNumber">The 1-based page number to return.</param>
+    /// <param name="pageSize">The number of elements in a page. Must be greater than zero.</param>
+    /// <param name="pageNumber">The 1-based page number to return. Must be greater than zero.</param>
     /// <returns>The elements at the given page.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="enumerable"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="pageSize"/> or <paramref name="pageNumber"/> is less than one.</exception>
     public static IEnumerable<T> Page<T>(this IEnumerable<T> enumerable, int pageSize, int pageNumber)
     {
+        ArgumentNullException.ThrowIfNull(enumerable);
+        ArgumentOutOfRangeException.ThrowIfLessThan(pageSize, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(pageNumber, 1);
+
         return enumerable.Skip((pageNumber - 1) * pageSize).Take(pageSize);
     }
 
@@ -33,7 +41,7 @@ public static class AsmEnumerableExtensions
     /// <typeparam name="T">The type of elements in the enumerable.</typeparam>
     /// <param name="enumerable">The enumerable to check.</param>
     /// <returns><c>true</c> if the enumerable is <c>null</c> or empty; otherwise, <c>false</c>.</returns>
-    public static bool IsNullOrEmpty<T>(this IEnumerable<T> enumerable) =>
+    public static bool IsNullOrEmpty<T>([NotNullWhen(false)] this IEnumerable<T>? enumerable) =>
         !enumerable?.Any() ?? true;
 
     /// <summary>

--- a/src/Asm/Extensions/AsmEnumeratorExtensions.cs
+++ b/src/Asm/Extensions/AsmEnumeratorExtensions.cs
@@ -11,11 +11,20 @@ public static class AsmEnumeratorExtensions
     /// <typeparam name="T">The type of the generic enumerator.</typeparam>
     /// <param name="iEnumerator">The <see cref="System.Collections.IEnumerator"/>.</param>
     /// <returns>An instance of <see cref="System.Collections.Generic.IEnumerator{T}"/>.</returns>
-    public static IEnumerator<T> GetEnumerator<T>(this IEnumerator iEnumerator)
+    public static IEnumerator<T> AsGeneric<T>(this IEnumerator iEnumerator)
     {
         while (iEnumerator.MoveNext())
         {
             yield return (T)iEnumerator.Current;
         }
     }
+
+    /// <summary>
+    /// Converts an <see cref="System.Collections.IEnumerator"/> instance to an <see cref="System.Collections.Generic.IEnumerator{T}"/> instance.
+    /// </summary>
+    /// <typeparam name="T">The type of the generic enumerator.</typeparam>
+    /// <param name="iEnumerator">The <see cref="System.Collections.IEnumerator"/>.</param>
+    /// <returns>An instance of <see cref="System.Collections.Generic.IEnumerator{T}"/>.</returns>
+    [Obsolete("Use AsGeneric<T>() instead. This method will be removed in a future version.")]
+    public static IEnumerator<T> GetEnumerator<T>(this IEnumerator iEnumerator) => iEnumerator.AsGeneric<T>();
 }

--- a/src/Asm/Extensions/AsmListExtensions.cs
+++ b/src/Asm/Extensions/AsmListExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace System.Collections.Generic;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace System.Collections.Generic;
 
 /// <summary>
 /// Extensions for the <see cref="IList{T}"/> interface.
@@ -36,7 +38,7 @@ public static class AsmListExtensions
     /// <typeparam name="T">The type of elements in the list.</typeparam>
     /// <param name="list">The list to check.</param>
     /// <returns><c>true</c> if the list is <c>null</c> or empty; otherwise, <c>false</c>.</returns>
-    public static bool IsNullOrEmpty<T>(this IList<T>? list) =>
+    public static bool IsNullOrEmpty<T>([NotNullWhen(false)] this IList<T>? list) =>
         (list?.Count ?? 0) == 0;
 
     /// <summary>

--- a/src/Asm/Extensions/AsmQueryableExtensions.cs
+++ b/src/Asm/Extensions/AsmQueryableExtensions.cs
@@ -18,8 +18,12 @@ public static class AsmQueryableExtensions
     /// An <see cref="IQueryable{T}"/> that contains the specified number of elements from
     /// the page.
     /// </returns>
-    public static IQueryable<TSource> Page<TSource>(this IQueryable<TSource> source, IPageable page) =>
-        source.Page(page.PageSize, page.PageNumber);
+    public static IQueryable<TSource> Page<TSource>(this IQueryable<TSource> source, IPageable page)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+
+        return source.Page(page.PageSize, page.PageNumber);
+    }
 
     /// <summary>
     /// Skip / takes a page of data.
@@ -32,8 +36,16 @@ public static class AsmQueryableExtensions
     /// An <see cref="IQueryable{T}"/> that contains the specified number of elements from
     /// the page.
     /// </returns>
-    public static IQueryable<TSource> Page<TSource>(this IQueryable<TSource> source, int pageSize, int pageNumber) =>
-        source.Skip((pageNumber - 1) * pageSize).Take(pageSize);
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="source"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="pageSize"/> or <paramref name="pageNumber"/> is less than one.</exception>
+    public static IQueryable<TSource> Page<TSource>(this IQueryable<TSource> source, int pageSize, int pageNumber)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentOutOfRangeException.ThrowIfLessThan(pageSize, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(pageNumber, 1);
+
+        return source.Skip((pageNumber - 1) * pageSize).Take(pageSize);
+    }
 
     /// <summary>
     /// Converts the supplied expressions into a single OR'd where expression.

--- a/src/Asm/Extensions/System.Array.cs
+++ b/src/Asm/Extensions/System.Array.cs
@@ -1,4 +1,6 @@
-﻿namespace System;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace System;
 
 /// <summary>
 /// Extensions for the <see cref="Array"/> class.
@@ -35,7 +37,7 @@ public static class ArrayExtensions
     /// <typeparam name="T">The type of elements in the array.</typeparam>
     /// <param name="array">The array to check.</param>
     /// <returns><c>true</c> if the array is <c>null</c> or empty; otherwise, <c>false</c>.</returns>
-    public static bool IsNullOrEmpty<T>(this T[]? array) =>
+    public static bool IsNullOrEmpty<T>([NotNullWhen(false)] this T[]? array) =>
         (array?.Length ?? 0) == 0;
 
     /// <summary>

--- a/tests/Asm.AspNetCore.Modules.Tests/Routing/EndpointGroupBase.feature
+++ b/tests/Asm.AspNetCore.Modules.Tests/Routing/EndpointGroupBase.feature
@@ -51,5 +51,17 @@ Scenario: Endpoint group base requires any authorization when policy is empty
     Then the route group builder should be returned
 
 @Unit
+Scenario: Endpoint group base has a null name by default
+    Given I have an anonymous endpoint group
+    Then the group name should be null
+
+@Unit
+Scenario: Endpoint group base supports an anonymous group opt-out
+    Given I have an anonymous endpoint group
+    And I have an endpoint route builder
+    When I map the endpoint group
+    Then the route group builder should be returned
+
+@Unit
 Scenario: Endpoint group base cannot be instantiated directly
     Then EndpointGroupBase cannot be instantiated directly

--- a/tests/Asm.AspNetCore.Modules.Tests/Routing/EndpointGroupBase.feature
+++ b/tests/Asm.AspNetCore.Modules.Tests/Routing/EndpointGroupBase.feature
@@ -4,10 +4,9 @@ Feature: EndpointGroupBase
     So that I can reduce boilerplate code for endpoint mapping
 
 @Unit
-Scenario: Endpoint group base defines name and path
+Scenario: Endpoint group base defines a path
     Given I have a simple endpoint group
-    Then the group name should be 'SimpleGroup'
-    And the group path should be '/api/simple'
+    Then the group path should be '/api/simple'
 
 @Unit
 Scenario: Endpoint group base has default empty tags
@@ -49,11 +48,6 @@ Scenario: Endpoint group base requires any authorization when policy is empty
     And I have an endpoint route builder
     When I map the endpoint group
     Then the route group builder should be returned
-
-@Unit
-Scenario: Endpoint group base has a null name by default
-    Given I have an anonymous endpoint group
-    Then the group name should be null
 
 @Unit
 Scenario: Endpoint group base supports an anonymous group opt-out

--- a/tests/Asm.AspNetCore.Modules.Tests/Routing/EndpointGroupBase.feature.cs
+++ b/tests/Asm.AspNetCore.Modules.Tests/Routing/EndpointGroupBase.feature.cs
@@ -106,7 +106,7 @@ namespace Asm.AspNetCore.Modules.Tests.Routing
         
         private static global::Reqnroll.Formatters.RuntimeSupport.FeatureLevelCucumberMessages InitializeCucumberMessages()
         {
-            return new global::Reqnroll.Formatters.RuntimeSupport.FeatureLevelCucumberMessages("Routing/EndpointGroupBase.feature.ndjson", 11);
+            return new global::Reqnroll.Formatters.RuntimeSupport.FeatureLevelCucumberMessages("Routing/EndpointGroupBase.feature.ndjson", 13);
         }
         
         async System.Threading.Tasks.ValueTask Xunit.IAsyncLifetime.InitializeAsync()
@@ -419,17 +419,17 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             await this.ScenarioCleanupAsync();
         }
         
-        [global::Xunit.FactAttribute(DisplayName="Endpoint group base cannot be instantiated directly")]
+        [global::Xunit.FactAttribute(DisplayName="Endpoint group base has a null name by default")]
         [global::Xunit.TraitAttribute("FeatureTitle", "EndpointGroupBase")]
-        [global::Xunit.TraitAttribute("Description", "Endpoint group base cannot be instantiated directly")]
+        [global::Xunit.TraitAttribute("Description", "Endpoint group base has a null name by default")]
         [global::Xunit.TraitAttribute("Category", "Unit")]
-        public async global::System.Threading.Tasks.Task EndpointGroupBaseCannotBeInstantiatedDirectly()
+        public async global::System.Threading.Tasks.Task EndpointGroupBaseHasANullNameByDefault()
         {
             string[] tagsOfScenario = new string[] {
                     "Unit"};
             global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
             string pickleIndex = "8";
-            global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Endpoint group base cannot be instantiated directly", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
+            global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Endpoint group base has a null name by default", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
 #line 54
@@ -443,6 +443,78 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             {
                 await this.ScenarioStartAsync();
 #line 55
+    await testRunner.GivenAsync("I have an anonymous endpoint group", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
+#line hidden
+#line 56
+    await testRunner.ThenAsync("the group name should be null", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
+#line hidden
+            }
+            await this.ScenarioCleanupAsync();
+        }
+        
+        [global::Xunit.FactAttribute(DisplayName="Endpoint group base supports an anonymous group opt-out")]
+        [global::Xunit.TraitAttribute("FeatureTitle", "EndpointGroupBase")]
+        [global::Xunit.TraitAttribute("Description", "Endpoint group base supports an anonymous group opt-out")]
+        [global::Xunit.TraitAttribute("Category", "Unit")]
+        public async global::System.Threading.Tasks.Task EndpointGroupBaseSupportsAnAnonymousGroupOpt_Out()
+        {
+            string[] tagsOfScenario = new string[] {
+                    "Unit"};
+            global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
+            string pickleIndex = "9";
+            global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Endpoint group base supports an anonymous group opt-out", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
+            string[] tagsOfRule = ((string[])(null));
+            global::Reqnroll.RuleInfo ruleInfo = null;
+#line 59
+this.ScenarioInitialize(scenarioInfo, ruleInfo);
+#line hidden
+            if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
+            {
+                await testRunner.SkipScenarioAsync();
+            }
+            else
+            {
+                await this.ScenarioStartAsync();
+#line 60
+    await testRunner.GivenAsync("I have an anonymous endpoint group", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
+#line hidden
+#line 61
+    await testRunner.AndAsync("I have an endpoint route builder", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
+#line hidden
+#line 62
+    await testRunner.WhenAsync("I map the endpoint group", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
+#line hidden
+#line 63
+    await testRunner.ThenAsync("the route group builder should be returned", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
+#line hidden
+            }
+            await this.ScenarioCleanupAsync();
+        }
+        
+        [global::Xunit.FactAttribute(DisplayName="Endpoint group base cannot be instantiated directly")]
+        [global::Xunit.TraitAttribute("FeatureTitle", "EndpointGroupBase")]
+        [global::Xunit.TraitAttribute("Description", "Endpoint group base cannot be instantiated directly")]
+        [global::Xunit.TraitAttribute("Category", "Unit")]
+        public async global::System.Threading.Tasks.Task EndpointGroupBaseCannotBeInstantiatedDirectly()
+        {
+            string[] tagsOfScenario = new string[] {
+                    "Unit"};
+            global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
+            string pickleIndex = "10";
+            global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Endpoint group base cannot be instantiated directly", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
+            string[] tagsOfRule = ((string[])(null));
+            global::Reqnroll.RuleInfo ruleInfo = null;
+#line 66
+this.ScenarioInitialize(scenarioInfo, ruleInfo);
+#line hidden
+            if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
+            {
+                await testRunner.SkipScenarioAsync();
+            }
+            else
+            {
+                await this.ScenarioStartAsync();
+#line 67
     await testRunner.ThenAsync("EndpointGroupBase cannot be instantiated directly", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }

--- a/tests/Asm.AspNetCore.Modules.Tests/Routing/EndpointGroupBase.feature.cs
+++ b/tests/Asm.AspNetCore.Modules.Tests/Routing/EndpointGroupBase.feature.cs
@@ -106,7 +106,7 @@ namespace Asm.AspNetCore.Modules.Tests.Routing
         
         private static global::Reqnroll.Formatters.RuntimeSupport.FeatureLevelCucumberMessages InitializeCucumberMessages()
         {
-            return new global::Reqnroll.Formatters.RuntimeSupport.FeatureLevelCucumberMessages("Routing/EndpointGroupBase.feature.ndjson", 13);
+            return new global::Reqnroll.Formatters.RuntimeSupport.FeatureLevelCucumberMessages("Routing/EndpointGroupBase.feature.ndjson", 12);
         }
         
         async System.Threading.Tasks.ValueTask Xunit.IAsyncLifetime.InitializeAsync()
@@ -134,17 +134,17 @@ namespace Asm.AspNetCore.Modules.Tests.Routing
             await this.TestTearDownAsync();
         }
         
-        [global::Xunit.FactAttribute(DisplayName="Endpoint group base defines name and path")]
+        [global::Xunit.FactAttribute(DisplayName="Endpoint group base defines a path")]
         [global::Xunit.TraitAttribute("FeatureTitle", "EndpointGroupBase")]
-        [global::Xunit.TraitAttribute("Description", "Endpoint group base defines name and path")]
+        [global::Xunit.TraitAttribute("Description", "Endpoint group base defines a path")]
         [global::Xunit.TraitAttribute("Category", "Unit")]
-        public async global::System.Threading.Tasks.Task EndpointGroupBaseDefinesNameAndPath()
+        public async global::System.Threading.Tasks.Task EndpointGroupBaseDefinesAPath()
         {
             string[] tagsOfScenario = new string[] {
                     "Unit"};
             global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
             string pickleIndex = "0";
-            global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Endpoint group base defines name and path", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
+            global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Endpoint group base defines a path", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
 #line 7
@@ -161,10 +161,7 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
     await testRunner.GivenAsync("I have a simple endpoint group", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
 #line 9
-    await testRunner.ThenAsync("the group name should be \'SimpleGroup\'", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
-#line hidden
-#line 10
-    await testRunner.AndAsync("the group path should be \'/api/simple\'", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
+    await testRunner.ThenAsync("the group path should be \'/api/simple\'", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }
             await this.ScenarioCleanupAsync();
@@ -183,7 +180,7 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Endpoint group base has default empty tags", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
-#line 13
+#line 12
 this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
             if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
@@ -193,10 +190,10 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-#line 14
+#line 13
     await testRunner.GivenAsync("I have a minimal endpoint group", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
-#line 15
+#line 14
     await testRunner.ThenAsync("the group tags should be empty", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }
@@ -216,7 +213,7 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Endpoint group base can have custom tags", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
-#line 18
+#line 17
 this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
             if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
@@ -226,10 +223,10 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-#line 19
+#line 18
     await testRunner.GivenAsync("I have a simple endpoint group", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
-#line 20
+#line 19
     await testRunner.ThenAsync("the group tags should be \'simple,test\'", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }
@@ -249,7 +246,7 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Endpoint group base has default empty authorization policy", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
-#line 23
+#line 22
 this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
             if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
@@ -259,10 +256,10 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-#line 24
+#line 23
     await testRunner.GivenAsync("I have a minimal endpoint group", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
-#line 25
+#line 24
     await testRunner.ThenAsync("the authorization policy should be empty", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }
@@ -282,7 +279,7 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Endpoint group base can have a specific authorization policy", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
-#line 28
+#line 27
 this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
             if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
@@ -292,10 +289,10 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-#line 29
+#line 28
     await testRunner.GivenAsync("I have a simple endpoint group", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
-#line 30
+#line 29
     await testRunner.ThenAsync("the authorization policy should be \'RequireAdmin\'", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }
@@ -315,7 +312,7 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Endpoint group base maps to a route group builder", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
-#line 33
+#line 32
 this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
             if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
@@ -325,16 +322,16 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-#line 34
+#line 33
     await testRunner.GivenAsync("I have a simple endpoint group", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
-#line 35
+#line 34
     await testRunner.AndAsync("I have an endpoint route builder", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
 #line hidden
-#line 36
+#line 35
     await testRunner.WhenAsync("I map the endpoint group", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
-#line 37
+#line 36
     await testRunner.ThenAsync("the route group builder should be returned", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }
@@ -354,7 +351,7 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Endpoint group base applies authorization when policy is specified", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
-#line 40
+#line 39
 this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
             if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
@@ -364,16 +361,16 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-#line 41
+#line 40
     await testRunner.GivenAsync("I have a simple endpoint group with policy \'TestPolicy\'", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
-#line 42
+#line 41
     await testRunner.AndAsync("I have an endpoint route builder", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
 #line hidden
-#line 43
+#line 42
     await testRunner.WhenAsync("I map the endpoint group", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
-#line 44
+#line 43
     await testRunner.ThenAsync("the route group builder should have the authorization policy applied", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }
@@ -393,7 +390,7 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Endpoint group base requires any authorization when policy is empty", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
-#line 47
+#line 46
 this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
             if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
@@ -403,50 +400,17 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-#line 48
+#line 47
     await testRunner.GivenAsync("I have a minimal endpoint group", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
-#line 49
+#line 48
     await testRunner.AndAsync("I have an endpoint route builder", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
 #line hidden
-#line 50
+#line 49
     await testRunner.WhenAsync("I map the endpoint group", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
-#line 51
+#line 50
     await testRunner.ThenAsync("the route group builder should be returned", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
-#line hidden
-            }
-            await this.ScenarioCleanupAsync();
-        }
-        
-        [global::Xunit.FactAttribute(DisplayName="Endpoint group base has a null name by default")]
-        [global::Xunit.TraitAttribute("FeatureTitle", "EndpointGroupBase")]
-        [global::Xunit.TraitAttribute("Description", "Endpoint group base has a null name by default")]
-        [global::Xunit.TraitAttribute("Category", "Unit")]
-        public async global::System.Threading.Tasks.Task EndpointGroupBaseHasANullNameByDefault()
-        {
-            string[] tagsOfScenario = new string[] {
-                    "Unit"};
-            global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
-            string pickleIndex = "8";
-            global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Endpoint group base has a null name by default", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
-            string[] tagsOfRule = ((string[])(null));
-            global::Reqnroll.RuleInfo ruleInfo = null;
-#line 54
-this.ScenarioInitialize(scenarioInfo, ruleInfo);
-#line hidden
-            if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
-            {
-                await testRunner.SkipScenarioAsync();
-            }
-            else
-            {
-                await this.ScenarioStartAsync();
-#line 55
-    await testRunner.GivenAsync("I have an anonymous endpoint group", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
-#line hidden
-#line 56
-    await testRunner.ThenAsync("the group name should be null", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }
             await this.ScenarioCleanupAsync();
@@ -461,11 +425,11 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             string[] tagsOfScenario = new string[] {
                     "Unit"};
             global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
-            string pickleIndex = "9";
+            string pickleIndex = "8";
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Endpoint group base supports an anonymous group opt-out", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
-#line 59
+#line 53
 this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
             if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
@@ -475,16 +439,16 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-#line 60
+#line 54
     await testRunner.GivenAsync("I have an anonymous endpoint group", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
-#line 61
+#line 55
     await testRunner.AndAsync("I have an endpoint route builder", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
 #line hidden
-#line 62
+#line 56
     await testRunner.WhenAsync("I map the endpoint group", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
-#line 63
+#line 57
     await testRunner.ThenAsync("the route group builder should be returned", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }
@@ -500,11 +464,11 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             string[] tagsOfScenario = new string[] {
                     "Unit"};
             global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
-            string pickleIndex = "10";
+            string pickleIndex = "9";
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Endpoint group base cannot be instantiated directly", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
-#line 66
+#line 60
 this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
             if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
@@ -514,7 +478,7 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-#line 67
+#line 61
     await testRunner.ThenAsync("EndpointGroupBase cannot be instantiated directly", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }

--- a/tests/Asm.AspNetCore.Modules.Tests/Routing/EndpointGroupBaseSteps.cs
+++ b/tests/Asm.AspNetCore.Modules.Tests/Routing/EndpointGroupBaseSteps.cs
@@ -13,7 +13,7 @@ public class EndpointGroupBaseSteps
     {
         public override string Name => "SimpleGroup";
         public override string Path => "/api/simple";
-        public override string Tags => "simple,test";
+        public override string[] Tags => ["simple", "test"];
         public override string AuthorisationPolicy => "RequireAdmin";
 
         protected override void MapEndpoints(IEndpointRouteBuilder builder)
@@ -54,9 +54,21 @@ public class EndpointGroupBaseSteps
         }
     }
 
+    private class AnonymousEndpointGroup : EndpointGroupBase
+    {
+        public override string Path => "/api/anon";
+        public override bool AllowAnonymous => true;
+
+        protected override void MapEndpoints(IEndpointRouteBuilder builder)
+        {
+            builder.MapGet("/", () => "Hello from anonymous group");
+        }
+    }
+
     private EndpointGroupBase _simpleEndpointGroup;
     private EndpointGroupBase _minimalEndpointGroup;
     private EndpointGroupBase _customAuthGroup;
+    private EndpointGroupBase _anonymousEndpointGroup;
     private IEndpointRouteBuilder _endpointRouteBuilder;
     private RouteGroupBuilder _routeGroupBuilder;
 
@@ -76,6 +88,12 @@ public class EndpointGroupBaseSteps
     public void GivenIHaveASimpleEndpointGroupWithPolicy(string policy)
     {
         _customAuthGroup = new CustomAuthEndpointGroup(policy);
+    }
+
+    [Given(@"I have an anonymous endpoint group")]
+    public void GivenIHaveAnAnonymousEndpointGroup()
+    {
+        _anonymousEndpointGroup = new AnonymousEndpointGroup();
     }
 
     [Given(@"I have an endpoint route builder")]
@@ -100,6 +118,16 @@ public class EndpointGroupBaseSteps
         {
             _routeGroupBuilder = _customAuthGroup.MapGroup(_endpointRouteBuilder);
         }
+        else if (_anonymousEndpointGroup != null)
+        {
+            _routeGroupBuilder = _anonymousEndpointGroup.MapGroup(_endpointRouteBuilder);
+        }
+    }
+
+    [Then(@"the group name should be null")]
+    public void ThenTheGroupNameShouldBeNull()
+    {
+        Assert.Null(_anonymousEndpointGroup.Name);
     }
 
     [Then(@"the group name should be '(.*)'")]
@@ -118,19 +146,20 @@ public class EndpointGroupBaseSteps
     [Then(@"the group tags should be empty")]
     public void ThenTheGroupTagsShouldBeEmpty()
     {
-        Assert.Empty(_minimalEndpointGroup.Tags);
+        Assert.True(_minimalEndpointGroup.Tags is null or { Length: 0 });
     }
 
     [Then(@"the group tags should be '(.*)'")]
     public void ThenTheGroupTagsShouldBe(string expectedTags)
     {
-        Assert.Equal(expectedTags, _simpleEndpointGroup.Tags);
+        Assert.NotNull(_simpleEndpointGroup.Tags);
+        Assert.Equal(expectedTags, String.Join(",", _simpleEndpointGroup.Tags));
     }
 
     [Then(@"the authorization policy should be empty")]
     public void ThenTheAuthorizationPolicyShouldBeEmpty()
     {
-        Assert.Empty(_minimalEndpointGroup.AuthorisationPolicy);
+        Assert.True(String.IsNullOrEmpty(_minimalEndpointGroup.AuthorisationPolicy));
     }
 
     [Then(@"the authorization policy should be '(.*)'")]

--- a/tests/Asm.AspNetCore.Modules.Tests/Routing/EndpointGroupBaseSteps.cs
+++ b/tests/Asm.AspNetCore.Modules.Tests/Routing/EndpointGroupBaseSteps.cs
@@ -11,7 +11,6 @@ public class EndpointGroupBaseSteps
 {
     private class SimpleEndpointGroup : EndpointGroupBase
     {
-        public override string Name => "SimpleGroup";
         public override string Path => "/api/simple";
         public override string[] Tags => ["simple", "test"];
         public override string AuthorisationPolicy => "RequireAdmin";
@@ -25,7 +24,6 @@ public class EndpointGroupBaseSteps
 
     private class MinimalEndpointGroup : EndpointGroupBase
     {
-        public override string Name => "MinimalGroup";
         public override string Path => "/api/minimal";
 
         protected override void MapEndpoints(IEndpointRouteBuilder builder)
@@ -44,7 +42,6 @@ public class EndpointGroupBaseSteps
             _policy = policy;
         }
 
-        public override string Name => "CustomAuthGroup";
         public override string Path => "/api/custom";
         public override string AuthorisationPolicy => _policy;
 
@@ -122,19 +119,6 @@ public class EndpointGroupBaseSteps
         {
             _routeGroupBuilder = _anonymousEndpointGroup.MapGroup(_endpointRouteBuilder);
         }
-    }
-
-    [Then(@"the group name should be null")]
-    public void ThenTheGroupNameShouldBeNull()
-    {
-        Assert.Null(_anonymousEndpointGroup.Name);
-    }
-
-    [Then(@"the group name should be '(.*)'")]
-    public void ThenTheGroupNameShouldBe(string expectedName)
-    {
-        var group = _simpleEndpointGroup ?? _minimalEndpointGroup ?? _customAuthGroup;
-        Assert.Equal(expectedName, group.Name);
     }
 
     [Then(@"the group path should be '(.*)'")]

--- a/tests/Asm.AspNetCore.Tests/Authorisation/OneOfAuthorisationRequirementHandlerTests.cs
+++ b/tests/Asm.AspNetCore.Tests/Authorisation/OneOfAuthorisationRequirementHandlerTests.cs
@@ -1,0 +1,111 @@
+using System.Security.Claims;
+using Asm.AspNetCore.Authorisation;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Asm.AspNetCore.Tests.Authorisation;
+
+public class OneOfAuthorisationRequirementHandlerTests
+{
+    private sealed class TestSubRequirement(bool shouldSucceed) : IAuthorizationRequirement
+    {
+        public bool ShouldSucceed { get; } = shouldSucceed;
+    }
+
+    // Grants success when the single sub-requirement it is asked about is a TestSubRequirement that
+    // should succeed. Records the resource it was passed.
+    private sealed class FakeAuthorizationService : IAuthorizationService
+    {
+        public object? LastResource { get; private set; }
+
+        public Task<AuthorizationResult> AuthorizeAsync(ClaimsPrincipal user, object? resource, IEnumerable<IAuthorizationRequirement> requirements)
+        {
+            LastResource = resource;
+
+            var succeeded = requirements.All(r => r is TestSubRequirement { ShouldSucceed: true });
+            return Task.FromResult(succeeded ? AuthorizationResult.Success() : AuthorizationResult.Failed());
+        }
+
+        public Task<AuthorizationResult> AuthorizeAsync(ClaimsPrincipal user, object? resource, string policyName) =>
+            AuthorizeAsync(user, resource, [new TestSubRequirement(false)]);
+    }
+
+    private sealed class TestHandler(IAuthorizationService authorisationService, bool isAuthorisedResult)
+        : OneOfAuthorisationRequirementHandler(authorisationService)
+    {
+        public bool IsAuthorisedInvoked { get; private set; }
+
+        public object? IsAuthorisedResource { get; private set; }
+
+        protected override ValueTask<bool> IsAuthorised(object? resource)
+        {
+            IsAuthorisedInvoked = true;
+            IsAuthorisedResource = resource;
+            return ValueTask.FromResult(isAuthorisedResult);
+        }
+    }
+
+    private static AuthorizationHandlerContext CreateContext(OneOfAuthorisationRequirement requirement, object? resource = null) =>
+        new([requirement], new ClaimsPrincipal(new ClaimsIdentity()), resource);
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_OneOptionSucceeds_Succeeds()
+    {
+        var service = new FakeAuthorizationService();
+        var handler = new TestHandler(service, isAuthorisedResult: false);
+        var requirement = new OneOfAuthorisationRequirement(new TestSubRequirement(false), new TestSubRequirement(true));
+        var context = CreateContext(requirement);
+
+        await handler.HandleAsync(context);
+
+        Assert.True(context.HasSucceeded);
+        Assert.False(context.HasFailed);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_AllOptionsFail_DoesNotFailTheRequirement()
+    {
+        var service = new FakeAuthorizationService();
+        var handler = new TestHandler(service, isAuthorisedResult: false);
+        var requirement = new OneOfAuthorisationRequirement(new TestSubRequirement(false), new TestSubRequirement(false));
+        var context = CreateContext(requirement);
+
+        await handler.HandleAsync(context);
+
+        // In an any-of handler a failing option must not veto the whole requirement.
+        Assert.False(context.HasSucceeded);
+        Assert.False(context.HasFailed);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_AllOptionsFail_IsAuthorisedInvokedAndCanGrant()
+    {
+        var service = new FakeAuthorizationService();
+        var handler = new TestHandler(service, isAuthorisedResult: true);
+        var requirement = new OneOfAuthorisationRequirement(new TestSubRequirement(false));
+        var context = CreateContext(requirement);
+
+        await handler.HandleAsync(context);
+
+        Assert.True(handler.IsAuthorisedInvoked);
+        Assert.True(context.HasSucceeded);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_PassesResourceThrough()
+    {
+        var resource = new object();
+        var service = new FakeAuthorizationService();
+        var handler = new TestHandler(service, isAuthorisedResult: false);
+        var requirement = new OneOfAuthorisationRequirement(new TestSubRequirement(false));
+        var context = CreateContext(requirement, resource);
+
+        await handler.HandleAsync(context);
+
+        Assert.Same(resource, service.LastResource);
+        Assert.Same(resource, handler.IsAuthorisedResource);
+    }
+}

--- a/tests/Asm.AspNetCore.Tests/Authorisation/RouteParamAuthorisationHandlerTypedTests.cs
+++ b/tests/Asm.AspNetCore.Tests/Authorisation/RouteParamAuthorisationHandlerTypedTests.cs
@@ -1,0 +1,84 @@
+using System.Security.Claims;
+using Asm.AspNetCore.Authorisation;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Asm.AspNetCore.Tests.Authorisation;
+
+public class RouteParamAuthorisationHandlerTypedTests
+{
+    private sealed class TestHttpContextAccessor(HttpContext httpContext) : IHttpContextAccessor
+    {
+        public HttpContext? HttpContext { get; set; } = httpContext;
+    }
+
+    private sealed class TestRequirement(string name) : RouteParamAuthorisationRequirement(name);
+
+    // Strongly-typed handler: extracts the route value as a Guid before authorising.
+    private sealed class GuidRouteParamHandler(IHttpContextAccessor accessor, Guid allowed)
+        : RouteParamAuthorisationHandler<TestRequirement, Guid>(accessor)
+    {
+        public Guid? ReceivedValue { get; private set; }
+
+        protected override ValueTask<bool> IsAuthorised(Guid value)
+        {
+            ReceivedValue = value;
+            return ValueTask.FromResult(value == allowed);
+        }
+    }
+
+    private static (GuidRouteParamHandler handler, AuthorizationHandlerContext context, TestRequirement requirement) Setup(string routeValue, Guid allowed)
+    {
+        var httpContext = new DefaultHttpContext
+        {
+            Request = { RouteValues = new RouteValueDictionary { { "id", routeValue } } },
+        };
+
+        var accessor = new TestHttpContextAccessor(httpContext);
+        var requirement = new TestRequirement("id");
+        var handler = new GuidRouteParamHandler(accessor, allowed);
+        var context = new AuthorizationHandlerContext([requirement], new ClaimsPrincipal(new ClaimsIdentity()), null);
+        return (handler, context, requirement);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_ConvertsRouteValueAndAuthorises()
+    {
+        var allowed = Guid.NewGuid();
+        var (handler, context, _) = Setup(allowed.ToString(), allowed);
+
+        await handler.HandleAsync(context);
+
+        Assert.Equal(allowed, handler.ReceivedValue);
+        Assert.True(context.HasSucceeded);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_UnauthorisedTypedValue_Fails()
+    {
+        var allowed = Guid.NewGuid();
+        var other = Guid.NewGuid();
+        var (handler, context, _) = Setup(other.ToString(), allowed);
+
+        await handler.HandleAsync(context);
+
+        Assert.Equal(other, handler.ReceivedValue);
+        Assert.True(context.HasFailed);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task HandleAsync_UnconvertibleRouteValue_Fails()
+    {
+        var allowed = Guid.NewGuid();
+        var (handler, context, _) = Setup("not-a-guid", allowed);
+
+        await handler.HandleAsync(context);
+
+        Assert.Null(handler.ReceivedValue);
+        Assert.True(context.HasFailed);
+    }
+}

--- a/tests/Asm.AspNetCore.Tests/Extensions/HttpContextExtensions.feature.cs
+++ b/tests/Asm.AspNetCore.Tests/Extensions/HttpContextExtensions.feature.cs
@@ -156,17 +156,17 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-                global::Reqnroll.Table table1 = new global::Reqnroll.Table(new string[] {
+                global::Reqnroll.Table table3 = new global::Reqnroll.Table(new string[] {
                             "Type",
                             "Value"});
-                table1.AddRow(new string[] {
+                table3.AddRow(new string[] {
                             "name",
                             "John Doe"});
-                table1.AddRow(new string[] {
+                table3.AddRow(new string[] {
                             "preferred_username",
                             "john.doe@test.com"});
 #line 5
-    await testRunner.GivenAsync("I have an HttpContext with user claims", ((string)(null)), table1, "Given ");
+    await testRunner.GivenAsync("I have an HttpContext with user claims", ((string)(null)), table3, "Given ");
 #line hidden
 #line 9
     await testRunner.WhenAsync("I call GetUserName", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
@@ -273,14 +273,14 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-                global::Reqnroll.Table table2 = new global::Reqnroll.Table(new string[] {
+                global::Reqnroll.Table table4 = new global::Reqnroll.Table(new string[] {
                             "Type",
                             "Value"});
-                table2.AddRow(new string[] {
+                table4.AddRow(new string[] {
                             "preferred_username",
                             "john.doe@test.com"});
 #line 26
-    await testRunner.GivenAsync("I have an HttpContext with user claims", ((string)(null)), table2, "Given ");
+    await testRunner.GivenAsync("I have an HttpContext with user claims", ((string)(null)), table4, "Given ");
 #line hidden
 #line 29
     await testRunner.WhenAsync("I call GetUserName", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
@@ -351,20 +351,20 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-                global::Reqnroll.Table table3 = new global::Reqnroll.Table(new string[] {
+                global::Reqnroll.Table table5 = new global::Reqnroll.Table(new string[] {
                             "Type",
                             "Value"});
-                table3.AddRow(new string[] {
+                table5.AddRow(new string[] {
                             "name",
                             "John Doe"});
-                table3.AddRow(new string[] {
+                table5.AddRow(new string[] {
                             "name",
                             "Jane Doe"});
-                table3.AddRow(new string[] {
+                table5.AddRow(new string[] {
                             "preferred_username",
                             "john.doe@test.com"});
 #line 40
-    await testRunner.GivenAsync("I have an HttpContext with user claims", ((string)(null)), table3, "Given ");
+    await testRunner.GivenAsync("I have an HttpContext with user claims", ((string)(null)), table5, "Given ");
 #line hidden
 #line 45
     await testRunner.WhenAsync("I call GetUserName", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");

--- a/tests/Asm.AspNetCore.Tests/Http/ValidatorFilterTypeLocationTests.cs
+++ b/tests/Asm.AspNetCore.Tests/Http/ValidatorFilterTypeLocationTests.cs
@@ -1,0 +1,57 @@
+using Asm.AspNetCore.Http;
+using FluentValidation;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Asm.AspNetCore.Tests.Http;
+
+public class ValidatorFilterTypeLocationTests
+{
+    public sealed class Model
+    {
+        public string Name { get; init; } = "";
+    }
+
+    private sealed class ModelValidator : AbstractValidator<Model>
+    {
+        public ModelValidator() => RuleFor(m => m.Name).NotEmpty();
+    }
+
+    private static EndpointFilterInvocationContext CreateContext(params object?[] arguments)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IValidator<Model>, ModelValidator>();
+
+        var httpContext = new DefaultHttpContext { RequestServices = services.BuildServiceProvider() };
+        return new DefaultEndpointFilterInvocationContext(httpContext, arguments);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task InvokeAsync_LocatesArgumentByType_RegardlessOfPosition()
+    {
+        // The Model is the second argument; the type-based filter must still find it.
+        var context = CreateContext("some-string", new Model { Name = "valid" });
+        var filter = new ValidatorFilter<Model>();
+        var nextCalled = false;
+
+        await filter.InvokeAsync(context, _ =>
+        {
+            nextCalled = true;
+            return ValueTask.FromResult<object?>("ok");
+        });
+
+        Assert.True(nextCalled);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task InvokeAsync_InvalidArgumentLocatedByType_Throws()
+    {
+        var context = CreateContext(42, new Model { Name = "" });
+        var filter = new ValidatorFilter<Model>();
+
+        await Assert.ThrowsAsync<ValidationException>(async () =>
+            await filter.InvokeAsync(context, _ => ValueTask.FromResult<object?>("ok")));
+    }
+}

--- a/tests/Asm.AspNetCore.Tests/Infrastructure/ProblemDetailsFactorySteps.cs
+++ b/tests/Asm.AspNetCore.Tests/Infrastructure/ProblemDetailsFactorySteps.cs
@@ -11,6 +11,9 @@ namespace Asm.AspNetCore.Tests.Infrastructure;
 [Binding]
 public class ProblemDetailsFactorySteps
 {
+    // AsmException is abstract; use a concrete subclass to exercise its ProblemDetails handling.
+    private sealed class TestAsmException(string message, int errorId) : AsmException(message, errorId);
+
     private Mock<IHostEnvironment> _hostEnvironmentMock;
     private ProblemDetailsFactory _factory;
     private DefaultHttpContext _httpContext;
@@ -73,7 +76,7 @@ public class ProblemDetailsFactorySteps
     [Given(@"I have an HttpContext with an AsmException '(.*)' and error id (.*)")]
     public void GivenIHaveAnHttpContextWithAnAsmExceptionAndErrorId(string message, int errorId)
     {
-        _httpContext = CreateHttpContextWithException(new AsmException(message, errorId));
+        _httpContext = CreateHttpContextWithException(new TestAsmException(message, errorId));
     }
 
     [Given(@"I have an HttpContext with an unknown exception '(.*)'")]

--- a/tests/Asm.AspNetCore.Tests/Routing/EndpointGroupBaseSteps.cs
+++ b/tests/Asm.AspNetCore.Tests/Routing/EndpointGroupBaseSteps.cs
@@ -73,7 +73,6 @@ public class TestEndpointGroupWithPolicy : EndpointGroupBase
 
     public bool EndpointsMapped { get; private set; }
 
-    public override string Name => "TestGroup";
     public override string Path => "/test";
     public override string[] Tags => ["Test"];
     public override string AuthorisationPolicy => _authorisationPolicy;

--- a/tests/Asm.AspNetCore.Tests/Routing/EndpointGroupBaseSteps.cs
+++ b/tests/Asm.AspNetCore.Tests/Routing/EndpointGroupBaseSteps.cs
@@ -75,7 +75,7 @@ public class TestEndpointGroupWithPolicy : EndpointGroupBase
 
     public override string Name => "TestGroup";
     public override string Path => "/test";
-    public override string Tags => "Test";
+    public override string[] Tags => ["Test"];
     public override string AuthorisationPolicy => _authorisationPolicy;
 
     protected override void MapEndpoints(IEndpointRouteBuilder builder)

--- a/tests/Asm.Net.Tests/IPAddressExtensions.feature
+++ b/tests/Asm.Net.Tests/IPAddressExtensions.feature
@@ -97,3 +97,23 @@ Scenario: Get IP address as an unsigned 32 bit integer with invalid input
     Then an exception of type 'System.ArgumentException' is thrown
     And the exception message is 'Not an IPv4 address (Parameter 'ipAddress')'
     And the exception parameter name is 'ipAddress'
+
+@Unit
+Scenario: Create an IP address from an unsigned 32 bit integer using ToIPAddress
+    Given I have an unsigned 32 bit integer 3435973836
+    When I call ToIPAddress
+    Then the IP Address 204.204.204.204 is returned
+
+@Unit
+Scenario Outline: Round trip an IP address through ToUInt32 and ToIPAddress
+    Given I have an IP Address '<IP Address>'
+    When I call ToUInt32
+    And I call ToIPAddress
+    Then the IP Address <IP Address> is returned
+
+    Examples:
+    | IP Address      |
+    | 0.0.0.0         |
+    | 192.168.1.1     |
+    | 204.204.204.204 |
+    | 255.255.255.255 |

--- a/tests/Asm.Net.Tests/IPAddressExtensions.feature.cs
+++ b/tests/Asm.Net.Tests/IPAddressExtensions.feature.cs
@@ -109,7 +109,7 @@ namespace Asm.Net.Tests
         
         private static global::Reqnroll.Formatters.RuntimeSupport.FeatureLevelCucumberMessages InitializeCucumberMessages()
         {
-            return new global::Reqnroll.Formatters.RuntimeSupport.FeatureLevelCucumberMessages("IPAddressExtensions.feature.ndjson", 42);
+            return new global::Reqnroll.Formatters.RuntimeSupport.FeatureLevelCucumberMessages("IPAddressExtensions.feature.ndjson", 47);
         }
         
         async System.Threading.Tasks.ValueTask Xunit.IAsyncLifetime.InitializeAsync()
@@ -442,6 +442,91 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
 #line 99
     await testRunner.AndAsync("the exception parameter name is \'ipAddress\'", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
+#line hidden
+            }
+            await this.ScenarioCleanupAsync();
+        }
+        
+        [global::Xunit.FactAttribute(DisplayName="Create an IP address from an unsigned 32 bit integer using ToIPAddress")]
+        [global::Xunit.TraitAttribute("FeatureTitle", "IPAddress Extensions")]
+        [global::Xunit.TraitAttribute("Description", "Create an IP address from an unsigned 32 bit integer using ToIPAddress")]
+        [global::Xunit.TraitAttribute("Category", "Unit")]
+        public async global::System.Threading.Tasks.Task CreateAnIPAddressFromAnUnsigned32BitIntegerUsingToIPAddress()
+        {
+            string[] tagsOfScenario = new string[] {
+                    "Unit"};
+            global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
+            string pickleIndex = "40";
+            global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Create an IP address from an unsigned 32 bit integer using ToIPAddress", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
+            string[] tagsOfRule = ((string[])(null));
+            global::Reqnroll.RuleInfo ruleInfo = null;
+#line 102
+this.ScenarioInitialize(scenarioInfo, ruleInfo);
+#line hidden
+            if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
+            {
+                await testRunner.SkipScenarioAsync();
+            }
+            else
+            {
+                await this.ScenarioStartAsync();
+#line 103
+    await testRunner.GivenAsync("I have an unsigned 32 bit integer 3435973836", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
+#line hidden
+#line 104
+    await testRunner.WhenAsync("I call ToIPAddress", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
+#line hidden
+#line 105
+    await testRunner.ThenAsync("the IP Address 204.204.204.204 is returned", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
+#line hidden
+            }
+            await this.ScenarioCleanupAsync();
+        }
+        
+        [global::Xunit.TheoryAttribute(DisplayName="Round trip an IP address through ToUInt32 and ToIPAddress")]
+        [global::Xunit.TraitAttribute("FeatureTitle", "IPAddress Extensions")]
+        [global::Xunit.TraitAttribute("Description", "Round trip an IP address through ToUInt32 and ToIPAddress")]
+        [global::Xunit.TraitAttribute("Category", "Unit")]
+        [global::Xunit.InlineDataAttribute("0.0.0.0", "41", new string[0])]
+        [global::Xunit.InlineDataAttribute("192.168.1.1", "42", new string[0])]
+        [global::Xunit.InlineDataAttribute("204.204.204.204", "43", new string[0])]
+        [global::Xunit.InlineDataAttribute("255.255.255.255", "44", new string[0])]
+        public async global::System.Threading.Tasks.Task RoundTripAnIPAddressThroughToUInt32AndToIPAddress(string iPAddress, string @__pickleIndex, string[] exampleTags)
+        {
+            string[] @__tags = new string[] {
+                    "Unit"};
+            if ((exampleTags != null))
+            {
+                @__tags = System.Linq.Enumerable.ToArray(System.Linq.Enumerable.Concat(@__tags, exampleTags));
+            }
+            string[] tagsOfScenario = @__tags;
+            global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
+            argumentsOfScenario.Add("IP Address", iPAddress);
+            string pickleIndex = @__pickleIndex;
+            global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Round trip an IP address through ToUInt32 and ToIPAddress", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
+            string[] tagsOfRule = ((string[])(null));
+            global::Reqnroll.RuleInfo ruleInfo = null;
+#line 108
+this.ScenarioInitialize(scenarioInfo, ruleInfo);
+#line hidden
+            if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
+            {
+                await testRunner.SkipScenarioAsync();
+            }
+            else
+            {
+                await this.ScenarioStartAsync();
+#line 109
+    await testRunner.GivenAsync(string.Format("I have an IP Address \'{0}\'", iPAddress), ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
+#line hidden
+#line 110
+    await testRunner.WhenAsync("I call ToUInt32", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
+#line hidden
+#line 111
+    await testRunner.AndAsync("I call ToIPAddress", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
+#line hidden
+#line 112
+    await testRunner.ThenAsync(string.Format("the IP Address {0} is returned", iPAddress), ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }
             await this.ScenarioCleanupAsync();

--- a/tests/Asm.Net.Tests/IPAddressExtensionsSteps.cs
+++ b/tests/Asm.Net.Tests/IPAddressExtensionsSteps.cs
@@ -67,6 +67,12 @@ public class IPAddressExtensionsSteps(ScenarioContext context, ScenarioData scen
         scenarioData.IPAddress = AsmNetIPAddressExtensions.FromUInt32(scenarioData.IPAddressAsUInt32);
     }
 
+    [When(@"I call ToIPAddress")]
+    public void WhenICallToIPAddress()
+    {
+        scenarioData.IPAddress = scenarioData.IPAddressAsUInt32.ToIPAddress();
+    }
+
     [Then(@"the string value '(.*)' will be returned")]
     public void ThenTheStringValue_WillBeReturned(string expected)
     {

--- a/tests/Asm.Tests/Exceptions.feature
+++ b/tests/Asm.Tests/Exceptions.feature
@@ -45,6 +45,10 @@ Scenario: Create AsmException with message, error id and inner exception
     And the AsmException has an inner exception with message 'Inner error'
 
 @Unit
+Scenario: AsmException is abstract
+    Then AsmException is abstract
+
+@Unit
 Scenario: An Asm library exception type resolves by its full name
     When I catch an Asm NotFoundException
     Then an exception of type 'Asm.NotFoundException' is thrown

--- a/tests/Asm.Tests/Exceptions.feature.cs
+++ b/tests/Asm.Tests/Exceptions.feature.cs
@@ -105,7 +105,7 @@ namespace Asm.Tests
         
         private static global::Reqnroll.Formatters.RuntimeSupport.FeatureLevelCucumberMessages InitializeCucumberMessages()
         {
-            return new global::Reqnroll.Formatters.RuntimeSupport.FeatureLevelCucumberMessages("Exceptions.feature.ndjson", 10);
+            return new global::Reqnroll.Formatters.RuntimeSupport.FeatureLevelCucumberMessages("Exceptions.feature.ndjson", 11);
         }
         
         async System.Threading.Tasks.ValueTask Xunit.IAsyncLifetime.InitializeAsync()
@@ -374,17 +374,17 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             await this.ScenarioCleanupAsync();
         }
         
-        [global::Xunit.FactAttribute(DisplayName="An Asm library exception type resolves by its full name")]
+        [global::Xunit.FactAttribute(DisplayName="AsmException is abstract")]
         [global::Xunit.TraitAttribute("FeatureTitle", "Exceptions")]
-        [global::Xunit.TraitAttribute("Description", "An Asm library exception type resolves by its full name")]
+        [global::Xunit.TraitAttribute("Description", "AsmException is abstract")]
         [global::Xunit.TraitAttribute("Category", "Unit")]
-        public async global::System.Threading.Tasks.Task AnAsmLibraryExceptionTypeResolvesByItsFullName()
+        public async global::System.Threading.Tasks.Task AsmExceptionIsAbstract()
         {
             string[] tagsOfScenario = new string[] {
                     "Unit"};
             global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
             string pickleIndex = "6";
-            global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("An Asm library exception type resolves by its full name", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
+            global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("AsmException is abstract", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
 #line 48
@@ -398,9 +398,39 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             {
                 await this.ScenarioStartAsync();
 #line 49
+    await testRunner.ThenAsync("AsmException is abstract", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
+#line hidden
+            }
+            await this.ScenarioCleanupAsync();
+        }
+        
+        [global::Xunit.FactAttribute(DisplayName="An Asm library exception type resolves by its full name")]
+        [global::Xunit.TraitAttribute("FeatureTitle", "Exceptions")]
+        [global::Xunit.TraitAttribute("Description", "An Asm library exception type resolves by its full name")]
+        [global::Xunit.TraitAttribute("Category", "Unit")]
+        public async global::System.Threading.Tasks.Task AnAsmLibraryExceptionTypeResolvesByItsFullName()
+        {
+            string[] tagsOfScenario = new string[] {
+                    "Unit"};
+            global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
+            string pickleIndex = "7";
+            global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("An Asm library exception type resolves by its full name", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
+            string[] tagsOfRule = ((string[])(null));
+            global::Reqnroll.RuleInfo ruleInfo = null;
+#line 52
+this.ScenarioInitialize(scenarioInfo, ruleInfo);
+#line hidden
+            if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
+            {
+                await testRunner.SkipScenarioAsync();
+            }
+            else
+            {
+                await this.ScenarioStartAsync();
+#line 53
     await testRunner.WhenAsync("I catch an Asm NotFoundException", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
-#line 50
+#line 54
     await testRunner.ThenAsync("an exception of type \'Asm.NotFoundException\' is thrown", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }
@@ -416,11 +446,11 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             string[] tagsOfScenario = new string[] {
                     "Unit"};
             global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
-            string pickleIndex = "7";
+            string pickleIndex = "8";
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("CatchException can be called more than once in a scenario", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
-#line 53
+#line 57
 this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
             if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
@@ -430,10 +460,10 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-#line 54
+#line 58
     await testRunner.WhenAsync("I catch an exception then catch another", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
-#line 55
+#line 59
     await testRunner.ThenAsync("an exception of type \'System.InvalidOperationException\' is thrown", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }

--- a/tests/Asm.Tests/ExceptionsSteps.cs
+++ b/tests/Asm.Tests/ExceptionsSteps.cs
@@ -3,6 +3,17 @@ namespace Asm.Tests;
 [Binding]
 public class ExceptionsSteps
 {
+    // AsmException is abstract; exercise its behaviour through a minimal concrete subclass.
+    private sealed class TestAsmException : AsmException
+    {
+        public TestAsmException() : base() { }
+        public TestAsmException(string message) : base(message) { }
+        public TestAsmException(string message, Exception innerException) : base(message, innerException) { }
+        public TestAsmException(int errorId) : base(errorId) { }
+        public TestAsmException(string message, int errorId) : base(message, errorId) { }
+        public TestAsmException(string message, int errorId, Exception innerException) : base(message, errorId, innerException) { }
+    }
+
     private AsmException _asmException = null!;
     private Exception _innerException = null!;
 
@@ -15,37 +26,43 @@ public class ExceptionsSteps
     [When(@"I create an AsmException with the default constructor")]
     public void WhenICreateAnAsmExceptionWithTheDefaultConstructor()
     {
-        _asmException = new AsmException();
+        _asmException = new TestAsmException();
     }
 
     [When(@"I create an AsmException with message '(.*)'")]
     public void WhenICreateAnAsmExceptionWithMessage(string message)
     {
-        _asmException = new AsmException(message);
+        _asmException = new TestAsmException(message);
     }
 
     [When(@"I create an AsmException with message '(.*)' and the inner exception")]
     public void WhenICreateAnAsmExceptionWithMessageAndInnerException(string message)
     {
-        _asmException = new AsmException(message, _innerException);
+        _asmException = new TestAsmException(message, _innerException);
     }
 
     [When(@"I create an AsmException with error id (.*)")]
     public void WhenICreateAnAsmExceptionWithErrorId(int errorId)
     {
-        _asmException = new AsmException(errorId);
+        _asmException = new TestAsmException(errorId);
     }
 
     [When(@"I create an AsmException with message '(.*)' and error id (.*)")]
     public void WhenICreateAnAsmExceptionWithMessageAndErrorId(string message, int errorId)
     {
-        _asmException = new AsmException(message, errorId);
+        _asmException = new TestAsmException(message, errorId);
     }
 
     [When(@"I create an AsmException with message '(.*)', error id (.*) and the inner exception")]
     public void WhenICreateAnAsmExceptionWithMessageErrorIdAndInnerException(string message, int errorId)
     {
-        _asmException = new AsmException(message, errorId, _innerException);
+        _asmException = new TestAsmException(message, errorId, _innerException);
+    }
+
+    [Then(@"AsmException is abstract")]
+    public void ThenAsmExceptionIsAbstract()
+    {
+        Assert.True(typeof(AsmException).IsAbstract);
     }
 
     [Then(@"the AsmException has a unique Id")]

--- a/tests/Asm.Tests/Extensions/IEnumerableExtensions.feature
+++ b/tests/Asm.Tests/Extensions/IEnumerableExtensions.feature
@@ -24,6 +24,19 @@ Scenario: Page enumerable with page beyond range returns empty
     Then the result should be empty
 
 @Unit
+Scenario Outline: Page enumerable with invalid arguments throws
+    Given I have an enumerable with values [1, 2, 3]
+    When I call Page with page size <PageSize> and page number <PageNumber> expecting an exception
+    Then an ArgumentOutOfRangeException is thrown
+
+Examples:
+    | PageSize | PageNumber |
+    | 0        | 1          |
+    | -1       | 1          |
+    | 3        | 0          |
+    | 3        | -1         |
+
+@Unit
 Scenario: Shuffle enumerable returns same elements
     Given I have an enumerable with values [1, 2, 3, 4, 5]
     When I call Shuffle on the enumerable

--- a/tests/Asm.Tests/Extensions/IEnumerableExtensions.feature.cs
+++ b/tests/Asm.Tests/Extensions/IEnumerableExtensions.feature.cs
@@ -105,7 +105,7 @@ namespace Asm.Tests.Extensions
         
         private static global::Reqnroll.Formatters.RuntimeSupport.FeatureLevelCucumberMessages InitializeCucumberMessages()
         {
-            return new global::Reqnroll.Formatters.RuntimeSupport.FeatureLevelCucumberMessages("Extensions/IEnumerableExtensions.feature.ndjson", 17);
+            return new global::Reqnroll.Formatters.RuntimeSupport.FeatureLevelCucumberMessages("Extensions/IEnumerableExtensions.feature.ndjson", 21);
         }
         
         async System.Threading.Tasks.ValueTask Xunit.IAsyncLifetime.InitializeAsync()
@@ -221,17 +221,28 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             await this.ScenarioCleanupAsync();
         }
         
-        [global::Xunit.FactAttribute(DisplayName="Shuffle enumerable returns same elements")]
+        [global::Xunit.TheoryAttribute(DisplayName="Page enumerable with invalid arguments throws")]
         [global::Xunit.TraitAttribute("FeatureTitle", "IEnumerable Extensions")]
-        [global::Xunit.TraitAttribute("Description", "Shuffle enumerable returns same elements")]
+        [global::Xunit.TraitAttribute("Description", "Page enumerable with invalid arguments throws")]
         [global::Xunit.TraitAttribute("Category", "Unit")]
-        public async global::System.Threading.Tasks.Task ShuffleEnumerableReturnsSameElements()
+        [global::Xunit.InlineDataAttribute("0", "1", "9", new string[0])]
+        [global::Xunit.InlineDataAttribute("-1", "1", "10", new string[0])]
+        [global::Xunit.InlineDataAttribute("3", "0", "11", new string[0])]
+        [global::Xunit.InlineDataAttribute("3", "-1", "12", new string[0])]
+        public async global::System.Threading.Tasks.Task PageEnumerableWithInvalidArgumentsThrows(string pageSize, string pageNumber, string @__pickleIndex, string[] exampleTags)
         {
-            string[] tagsOfScenario = new string[] {
+            string[] @__tags = new string[] {
                     "Unit"};
+            if ((exampleTags != null))
+            {
+                @__tags = System.Linq.Enumerable.ToArray(System.Linq.Enumerable.Concat(@__tags, exampleTags));
+            }
+            string[] tagsOfScenario = @__tags;
             global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
-            string pickleIndex = "9";
-            global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Shuffle enumerable returns same elements", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
+            argumentsOfScenario.Add("PageSize", pageSize);
+            argumentsOfScenario.Add("PageNumber", pageNumber);
+            string pickleIndex = @__pickleIndex;
+            global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Page enumerable with invalid arguments throws", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
 #line 27
@@ -245,15 +256,51 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             {
                 await this.ScenarioStartAsync();
 #line 28
-    await testRunner.GivenAsync("I have an enumerable with values [1, 2, 3, 4, 5]", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
+    await testRunner.GivenAsync("I have an enumerable with values [1, 2, 3]", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
 #line 29
-    await testRunner.WhenAsync("I call Shuffle on the enumerable", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
+    await testRunner.WhenAsync(string.Format("I call Page with page size {0} and page number {1} expecting an exception", pageSize, pageNumber), ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
 #line 30
+    await testRunner.ThenAsync("an ArgumentOutOfRangeException is thrown", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
+#line hidden
+            }
+            await this.ScenarioCleanupAsync();
+        }
+        
+        [global::Xunit.FactAttribute(DisplayName="Shuffle enumerable returns same elements")]
+        [global::Xunit.TraitAttribute("FeatureTitle", "IEnumerable Extensions")]
+        [global::Xunit.TraitAttribute("Description", "Shuffle enumerable returns same elements")]
+        [global::Xunit.TraitAttribute("Category", "Unit")]
+        public async global::System.Threading.Tasks.Task ShuffleEnumerableReturnsSameElements()
+        {
+            string[] tagsOfScenario = new string[] {
+                    "Unit"};
+            global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
+            string pickleIndex = "13";
+            global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Shuffle enumerable returns same elements", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
+            string[] tagsOfRule = ((string[])(null));
+            global::Reqnroll.RuleInfo ruleInfo = null;
+#line 40
+this.ScenarioInitialize(scenarioInfo, ruleInfo);
+#line hidden
+            if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
+            {
+                await testRunner.SkipScenarioAsync();
+            }
+            else
+            {
+                await this.ScenarioStartAsync();
+#line 41
+    await testRunner.GivenAsync("I have an enumerable with values [1, 2, 3, 4, 5]", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
+#line hidden
+#line 42
+    await testRunner.WhenAsync("I call Shuffle on the enumerable", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
+#line hidden
+#line 43
     await testRunner.ThenAsync("the result should contain all original elements", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
-#line 31
+#line 44
     await testRunner.AndAsync("the result should have 5 elements", ((string)(null)), ((global::Reqnroll.Table)(null)), "And ");
 #line hidden
             }
@@ -269,11 +316,11 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             string[] tagsOfScenario = new string[] {
                     "Unit"};
             global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
-            string pickleIndex = "10";
+            string pickleIndex = "14";
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("IsNullOrEmpty returns true for null enumerable", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
-#line 34
+#line 47
 this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
             if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
@@ -283,13 +330,13 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-#line 35
+#line 48
     await testRunner.GivenAsync("I have a null enumerable", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
-#line 36
+#line 49
     await testRunner.WhenAsync("I call IsNullOrEmpty on the enumerable", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
-#line 37
+#line 50
     await testRunner.ThenAsync("the boolean value true is returned", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }
@@ -305,11 +352,11 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             string[] tagsOfScenario = new string[] {
                     "Unit"};
             global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
-            string pickleIndex = "11";
+            string pickleIndex = "15";
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("IsNullOrEmpty returns true for empty enumerable", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
-#line 40
+#line 53
 this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
             if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
@@ -319,13 +366,13 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-#line 41
+#line 54
     await testRunner.GivenAsync("I have an empty enumerable", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
-#line 42
+#line 55
     await testRunner.WhenAsync("I call IsNullOrEmpty on the enumerable", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
-#line 43
+#line 56
     await testRunner.ThenAsync("the boolean value true is returned", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }
@@ -341,11 +388,11 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             string[] tagsOfScenario = new string[] {
                     "Unit"};
             global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
-            string pickleIndex = "12";
+            string pickleIndex = "16";
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("IsNullOrEmpty returns false for non-empty enumerable", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
-#line 46
+#line 59
 this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
             if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
@@ -355,13 +402,13 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-#line 47
+#line 60
     await testRunner.GivenAsync("I have an enumerable with values [1, 2, 3]", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
-#line 48
+#line 61
     await testRunner.WhenAsync("I call IsNullOrEmpty on the enumerable", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
-#line 49
+#line 62
     await testRunner.ThenAsync("the boolean value false is returned", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }
@@ -377,11 +424,11 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             string[] tagsOfScenario = new string[] {
                     "Unit"};
             global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
-            string pickleIndex = "13";
+            string pickleIndex = "17";
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Empty returns true for empty enumerable", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
-#line 52
+#line 65
 this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
             if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
@@ -391,13 +438,13 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-#line 53
+#line 66
     await testRunner.GivenAsync("I have an empty enumerable", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
-#line 54
+#line 67
     await testRunner.WhenAsync("I call Empty on the enumerable", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
-#line 55
+#line 68
     await testRunner.ThenAsync("the boolean value true is returned", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }
@@ -413,11 +460,11 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             string[] tagsOfScenario = new string[] {
                     "Unit"};
             global::System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new global::System.Collections.Specialized.OrderedDictionary();
-            string pickleIndex = "14";
+            string pickleIndex = "18";
             global::Reqnroll.ScenarioInfo scenarioInfo = new global::Reqnroll.ScenarioInfo("Empty returns false for non-empty enumerable", null, tagsOfScenario, argumentsOfScenario, featureTags, pickleIndex);
             string[] tagsOfRule = ((string[])(null));
             global::Reqnroll.RuleInfo ruleInfo = null;
-#line 58
+#line 71
 this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line hidden
             if ((global::Reqnroll.TagHelper.ContainsIgnoreTag(scenarioInfo.CombinedTags) || global::Reqnroll.TagHelper.ContainsIgnoreTag(featureTags)))
@@ -427,13 +474,13 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
             else
             {
                 await this.ScenarioStartAsync();
-#line 59
+#line 72
     await testRunner.GivenAsync("I have an enumerable with values [1, 2, 3]", ((string)(null)), ((global::Reqnroll.Table)(null)), "Given ");
 #line hidden
-#line 60
+#line 73
     await testRunner.WhenAsync("I call Empty on the enumerable", ((string)(null)), ((global::Reqnroll.Table)(null)), "When ");
 #line hidden
-#line 61
+#line 74
     await testRunner.ThenAsync("the boolean value false is returned", ((string)(null)), ((global::Reqnroll.Table)(null)), "Then ");
 #line hidden
             }

--- a/tests/Asm.Tests/Extensions/IEnumerableExtensionsSteps.cs
+++ b/tests/Asm.Tests/Extensions/IEnumerableExtensionsSteps.cs
@@ -6,6 +6,7 @@ public class IEnumerableExtensionsSteps(ScenarioContext context)
     private IEnumerable<int> _enumerable;
     private IEnumerable<int> _result;
     private bool _boolResult;
+    private Exception _exception;
 
     [Given(@"I have an enumerable with values \[(.*)\]")]
     public void GivenIHaveAnEnumerableWithValues(string values)
@@ -36,6 +37,12 @@ public class IEnumerableExtensionsSteps(ScenarioContext context)
     public void WhenICallPageWithPageSizeAndPageNumber(int pageSize, int pageNumber)
     {
         _result = _enumerable!.Page(pageSize, pageNumber);
+    }
+
+    [When(@"I call Page with page size (.*) and page number (.*) expecting an exception")]
+    public void WhenICallPageExpectingAnException(int pageSize, int pageNumber)
+    {
+        _exception = Record.Exception(() => _enumerable!.Page(pageSize, pageNumber))!;
     }
 
     [When(@"I call Shuffle on the enumerable")]
@@ -76,6 +83,12 @@ public class IEnumerableExtensionsSteps(ScenarioContext context)
     public void ThenTheResultShouldBeEmpty()
     {
         Assert.Empty(_result!);
+    }
+
+    [Then(@"an ArgumentOutOfRangeException is thrown")]
+    public void ThenAnArgumentOutOfRangeExceptionIsThrown()
+    {
+        Assert.IsType<ArgumentOutOfRangeException>(_exception);
     }
 
     [Then(@"the result should contain all original elements")]

--- a/tests/Asm.Tests/Extensions/IEnumeratorExtensionsSteps.cs
+++ b/tests/Asm.Tests/Extensions/IEnumeratorExtensionsSteps.cs
@@ -29,7 +29,7 @@ public class IEnumeratorExtensionsSteps(ScenarioContext scenarioContext)
     public void WhenICallGetEnumeratorToConvertToIEnumeratorOfInt()
     {
         var enumerator = _arrayList.GetEnumerator();
-        var genericEnumerator = enumerator.GetEnumerator<int>();
+        var genericEnumerator = enumerator.AsGeneric<int>();
         var results = new List<int>();
         while (genericEnumerator.MoveNext())
         {
@@ -42,7 +42,7 @@ public class IEnumeratorExtensionsSteps(ScenarioContext scenarioContext)
     public void WhenICallGetEnumeratorToConvertToIEnumeratorOfString()
     {
         var enumerator = _arrayList.GetEnumerator();
-        var genericEnumerator = enumerator.GetEnumerator<string>();
+        var genericEnumerator = enumerator.AsGeneric<string>();
         var results = new List<string>();
         while (genericEnumerator.MoveNext())
         {

--- a/tests/Asm.Umbraco.Authentication.Tests/EntraId/EntraIdBackOfficeOptionsTests.cs
+++ b/tests/Asm.Umbraco.Authentication.Tests/EntraId/EntraIdBackOfficeOptionsTests.cs
@@ -59,7 +59,7 @@ public class EntraIdBackOfficeOptionsTests
 
         sut.Configure(MatchingName, options);
 
-        Assert.Equal("/signin-oidc", options.CallbackPath);
+        Assert.Equal("/signin-entraid", options.CallbackPath);
     }
 
     [Fact]
@@ -153,7 +153,7 @@ public class EntraIdBackOfficeOptionsTests
 
         sut.Configure(options);
 
-        Assert.Equal("/signin-oidc", options.CallbackPath);
+        Assert.Equal("/signin-entraid", options.CallbackPath);
     }
 
     [Fact]

--- a/tests/Asm.Umbraco.Authentication.Tests/EntraId/EntraIdLoginOptionsTests.cs
+++ b/tests/Asm.Umbraco.Authentication.Tests/EntraId/EntraIdLoginOptionsTests.cs
@@ -21,6 +21,14 @@ public class EntraIdLoginOptionsTests
             ClientSecret = "secret",
         }));
 
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void SchemeName_IsProviderSpecific()
+    {
+        // v4: renamed from "OpenIdConnect" so it does not masquerade as an OIDC handler.
+        Assert.Equal("EntraId", EntraIdLoginOptions.SchemeName);
+    }
+
     // -----------------------------------------------------------------------
     // Configure(string?, BackOfficeExternalLoginProviderOptions)
     // -----------------------------------------------------------------------

--- a/tests/Asm.Umbraco.Authentication.Tests/EntraId/EntraIdManifestReaderTests.cs
+++ b/tests/Asm.Umbraco.Authentication.Tests/EntraId/EntraIdManifestReaderTests.cs
@@ -69,7 +69,7 @@ public class EntraIdManifestReaderTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task ReadPackageManifestsAsync_ExtensionForProviderNameContainsOpenIdConnect()
+    public async Task ReadPackageManifestsAsync_ExtensionForProviderNameMatchesSchemeName()
     {
         var expectedProviderName =
             Constants.Security.BackOfficeExternalAuthenticationTypePrefix + EntraIdLoginOptions.SchemeName;


### PR DESCRIPTION
Phase 5 Batch 9 of the v4.0 API redesign (#411): consistency and correctness fixes across the ASM libraries. Targets `release/v4.0`.

All 14 items done. Full solution: **949 tests passing, zero failures, zero new warnings** (`dotnet test Asm.slnx -c Release`). Renames ship with `[Obsolete]` forwarders (except the EntraId `const`, documented as breaking). Migration notes appended to `docs/migration-v4.md`.

## Items

1. **WebApplicationStart** — now a `static` class; added `RunAsync`; `Run`/`RunAsync` (both here and in `Asm.Hosting.AppStart`) now share one `RunCore` implementation. The calling assembly is captured at the public entry point and passed down so `AddUserSecrets(GetCallingAssembly())` still resolves the consumer assembly.
2. **`uint.ToIPAddress()`** added to `AsmNetIPAddressExtensions` (inverse of `ToUInt32`), with round-trip tests.
3. **`AsmException` is now `abstract`** with `protected` constructors. Existing concrete ASM exception types already derive from the appropriate framework bases (not `AsmException`), so they're unaffected. Tests that instantiated `AsmException` directly now use concrete subclasses.
4. **`GetEnumerator<T>()` → `AsGeneric<T>()`** on `IEnumerator`, with an `[Obsolete]` forwarder.
5. **Nullability** — `[NotNullWhen(false)]` on all three `IsNullOrEmpty` extensions (enumerable/list/array); `DecodeWhitespace` now `string?` with `[return: NotNullIfNotNull]`. `GetUserName` was already correctly annotated (non-null return, nullable `HttpContext?`) — left as-is.
6. **`Page`** (enumerable + queryable) guards `pageSize`/`pageNumber < 1` with `ArgumentOutOfRangeException` and null source/`IPageable` with `ArgumentNullException`.
7. **`Asm.Reqnroll`** — added `<NULL>` transforms for `long?`, `decimal?`, `double?` mirroring the existing `int?` one. (Kept to the null variants; Reqnroll already converts non-null numerics natively, and overlapping non-null regexes would be ambiguous.)
8. **`MockDbSet<T>`** delegates its Moq setup to a shared `MockDbSetFactory.Configure`.
9. **`WithValidation<T>`** locates the parameter by type; positional `WithValidation<T>(int)` overload retained but `[Obsolete]`.
10. **`WithToolsFromAssemblies`** guards null/empty inputs and now also loads matching *referenced* assemblies not yet loaded.
11. **`EndpointGroupBase`** — `string?` sentinels instead of `String.Empty`; `Name` is now `virtual string?` (per-endpoint names when null); `Tags` is now `string[]?` (multiple tags); added `AllowAnonymous` opt-out.
12. **EntraId** — `SchemeName` `"OpenIdConnect"` → `"EntraId"`, `CallbackPath` `/signin-oidc` → `/signin-entraid`. OAuth `AddMicrosoftAccount` handler retained (not switched to OIDC). **Breaking** (`const`, no shim): app-registration redirect URI must be updated and existing back-office logins may need re-linking — documented in the migration doc and package README.
13. **`OneOfAuthorisationRequirementHandler`** — passes `context.Resource` through; no longer calls `context.Fail()` (one failing option must not veto an any-of requirement); wires the previously-dead `IsAuthorised` hook into evaluation (signature `object? resource`). Test-first: added a test asserting one-of succeeds when any option passes, and that `IsAuthorised` is invoked and can grant.
14. **`RouteParamAuthorisationHandler<TRequirement, TValue>`** — new strongly-typed variant that converts the route value via `TypeConverter` (overridable `TryConvert`) before calling `IsAuthorised(TValue)`. Original stringly-typed handler unchanged.

## Key decisions
- **#3:** did not re-parent `NotFoundException`/`NotAuthorisedException`/etc. onto `AsmException` — they deliberately derive from framework bases (`SecurityException`, etc.); the instruction was to keep them "deriving appropriately".
- **#11:** `Tags` changed to `string[]` (clear reading of "multiple tags"); derived overrides in both test projects updated. Groups overriding only `Path`/`MapEndpoints` are unaffected.
- **#13:** `IsAuthorised` kept `abstract` (per instructions) and made functional; returning `false` preserves pure any-of behaviour.

## Tests
Behavioural changes covered by new/updated tests: OneOf handler (4 xUnit tests incl. the failing-first any-of case + resource pass-through + IsAuthorised invocation), typed RouteParam handler (3), type-based ValidatorFilter (2), ToIPAddress round-trip (Reqnroll scenarios), Page validation (Reqnroll outline), `AsmException` abstract, EntraId scheme/callback assertions, EndpointGroupBase anonymous/null-name/multi-tag.
