### PR TITLE
Chore: test naming (PascalCase + Given/When/Then summaries)

### DIFF
--- a/tests/Asm.AspNetCore.Mvc.Tests/ModelBinding/DataTypeValidatorTests.cs
+++ b/tests/Asm.AspNetCore.Mvc.Tests/ModelBinding/DataTypeValidatorTests.cs
@@ -12,22 +12,32 @@ public class DataTypeValidatorTests
         return attribute.GetValidationResult(value, context);
     }
 
+    /// <summary>
+    /// Given a DataType.EmailAddress validator and a well-formed email address in any casing
+    /// When the value is validated
+    /// Then validation succeeds
+    /// </summary>
     [Theory]
     [InlineData("user@example.com")]
     [InlineData("USER@EXAMPLE.COM")]        // uppercase must be accepted
     [InlineData("John.Doe@Example.Co.Uk")]  // mixed case
-    public void ValidEmail_PassesValidation(string email)
+    public void ValidEmailPassesValidation(string email)
     {
         Assert.Equal(ValidationResult.Success, Validate(email));
     }
 
+    /// <summary>
+    /// Given a DataType.EmailAddress validator and a malformed email value
+    /// When the value is validated
+    /// Then validation does not succeed
+    /// </summary>
     [Theory]
     [InlineData("<script>x</script> a@b.co")] // embedded valid substring must be rejected
     [InlineData("a@b.co and more")]
     [InlineData("not-an-email")]
     [InlineData("@example.com")]
     [InlineData("user@")]
-    public void InvalidEmail_FailsValidation(string email)
+    public void InvalidEmailFailsValidation(string email)
     {
         Assert.NotEqual(ValidationResult.Success, Validate(email));
     }

--- a/tests/Asm.Cqrs.Tests/Commands/CommandTests.cs
+++ b/tests/Asm.Cqrs.Tests/Commands/CommandTests.cs
@@ -5,9 +5,14 @@ namespace Asm.Cqrs.Tests.Commands;
 
 public class CommandTests
 {
+    /// <summary>
+    /// Given a command dispatcher with registered command handlers
+    /// When a TestCommand with mixed-case input "Abc" is dispatched
+    /// Then the handler returns false
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task NegaTest()
+    public async Task DispatchCommandWithMixedCaseInputReturnsFalse()
     {
         ServiceCollection services = new();
 
@@ -22,9 +27,14 @@ public class CommandTests
         Assert.False(result);
     }
 
+    /// <summary>
+    /// Given a command dispatcher with registered command handlers
+    /// When a TestCommand with uppercase input "ABC" is dispatched
+    /// Then the handler returns true
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task PosiTest()
+    public async Task DispatchCommandWithUppercaseInputReturnsTrue()
     {
         ServiceCollection services = new();
 
@@ -39,9 +49,14 @@ public class CommandTests
         Assert.True(result);
     }
 
+    /// <summary>
+    /// Given a command whose handler throws synchronously
+    /// When the command is executed through the dispatcher
+    /// Then the handler's original InvalidOperationException surfaces, not a TargetInvocationException
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task SynchronousHandlerThrow_SurfacesOriginalExceptionType()
+    public async Task SynchronousHandlerThrowSurfacesOriginalExceptionType()
     {
         ServiceCollection services = new();
         services.AddCommandHandlers(GetType().Assembly);
@@ -53,9 +68,14 @@ public class CommandTests
             async () => await commandDispatcher.Execute(new ThrowingCommand(), TestContext.Current.CancellationToken));
     }
 
+    /// <summary>
+    /// Given a response-returning command referenced through the non-generic ICommand interface
+    /// When it is executed via the void Execute method that cannot resolve a handler
+    /// Then an InvalidOperationException is thrown whose message points to Dispatch&lt;TResponse&gt;
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task ResponseCommand_DispatchedAsVoidCommand_ThrowsHelpfulError()
+    public async Task ResponseCommandDispatchedAsVoidCommandThrowsHelpfulError()
     {
         ServiceCollection services = new();
         services.AddCommandHandlers(GetType().Assembly);

--- a/tests/Asm.Cqrs.Tests/Queries/QueryTests.cs
+++ b/tests/Asm.Cqrs.Tests/Queries/QueryTests.cs
@@ -5,10 +5,15 @@ namespace Asm.Cqrs.Tests.Queries;
 
 public class QueryTests
 {
+    /// <summary>
+    /// Given a query dispatcher with registered query handlers
+    /// When a TestQuery with input "Abc" is dispatched
+    /// Then the handler returns the uppercased result "ABC"
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
     [Trait("Description", "Tests a Generic Query")]
-    public async Task TestGenericQuery()
+    public async Task DispatchGenericQueryReturnsUppercasedResult()
     {
         ServiceCollection services = new();
 

--- a/tests/Asm.OAuth.Tests/OAuthOptionsRegistrationTests.cs
+++ b/tests/Asm.OAuth.Tests/OAuthOptionsRegistrationTests.cs
@@ -29,9 +29,14 @@ public class OAuthOptionsRegistrationTests
         ("AzureOAuth:TenantId", "11111111-1111-1111-1111-111111111111"),
     ];
 
+    /// <summary>
+    /// Given Azure OAuth options registered from valid configuration
+    /// When base OAuthOptions are resolved via IOptions, IOptionsMonitor and IOptionsSnapshot
+    /// Then each returns the polymorphic Azure options with the correct Authority and Audience
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void AddAzureOAuthOptions_BridgesBaseOAuthOptions_AcrossAllOptionsInterfaces()
+    public void AddAzureOAuthOptionsBridgesBaseOAuthOptionsAcrossAllOptionsInterfaces()
     {
         using var provider = BuildAzure(ValidAzureSettings());
 
@@ -50,9 +55,14 @@ public class OAuthOptionsRegistrationTests
         Assert.Equal("api://my-api", fromOptions.Audience);
     }
 
+    /// <summary>
+    /// Given Azure OAuth options bound from configuration that does not set ValidateAudience
+    /// When the AzureOAuthOptions are resolved
+    /// Then ValidateAudience defaults to true
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void AddAzureOAuthOptions_ValidateAudience_DefaultsToTrueThroughBinding()
+    public void AddAzureOAuthOptionsValidateAudienceDefaultsToTrueThroughBinding()
     {
         using var provider = BuildAzure(ValidAzureSettings());
 
@@ -61,9 +71,14 @@ public class OAuthOptionsRegistrationTests
         Assert.True(options.ValidateAudience);
     }
 
+    /// <summary>
+    /// Given Azure OAuth configuration that omits the TenantId
+    /// When the AzureOAuthOptions are resolved
+    /// Then an OptionsValidationException is thrown whose message mentions TenantId
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void AddAzureOAuthOptions_MissingTenantId_FailsValidation()
+    public void AddAzureOAuthOptionsMissingTenantIdFailsValidation()
     {
         using var provider = BuildAzure(
             ("AzureOAuth:Domain", "https://login.microsoftonline.com"),
@@ -76,9 +91,14 @@ public class OAuthOptionsRegistrationTests
         Assert.Contains("TenantId", exception.Message);
     }
 
+    /// <summary>
+    /// Given Azure OAuth configuration whose Domain has a trailing slash
+    /// When the AzureOAuthOptions are resolved
+    /// Then an OptionsValidationException is thrown
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void AddAzureOAuthOptions_TrailingSlashDomain_FailsValidation()
+    public void AddAzureOAuthOptionsTrailingSlashDomainFailsValidation()
     {
         using var provider = BuildAzure(
             ("AzureOAuth:Domain", "https://login.microsoftonline.com/"),
@@ -90,9 +110,14 @@ public class OAuthOptionsRegistrationTests
             () => _ = provider.GetRequiredService<IOptions<AzureOAuthOptions>>().Value);
     }
 
+    /// <summary>
+    /// Given plain OAuth options registered from empty configuration missing required fields
+    /// When the OAuthOptions are resolved
+    /// Then an OptionsValidationException is thrown
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void AddOAuthOptions_MissingRequiredFields_FailsValidation()
+    public void AddOAuthOptionsMissingRequiredFieldsFailsValidation()
     {
         var config = new ConfigurationBuilder().AddInMemoryCollection([]).Build();
         var services = new ServiceCollection();

--- a/tests/Asm.Testing.Domain.Tests/MockDbSetTests.cs
+++ b/tests/Asm.Testing.Domain.Tests/MockDbSetTests.cs
@@ -18,9 +18,14 @@ public class MockDbSetTests
         new() { Name = "Third" },
     ];
 
+    /// <summary>
+    /// Given a DbSet created from MockDbSetFactory over three entities
+    /// When ToListAsync is awaited twice
+    /// Then both calls return all three items and the two results are equal
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task MockDbSetFactory_ToListAsyncTwice_ReturnsAllItemsBothTimes()
+    public async Task MockDbSetFactoryToListAsyncTwiceReturnsAllItemsBothTimes()
     {
         DbSet<TestEntity> set = MockDbSetFactory.Create(CreateData()).Object;
 
@@ -32,9 +37,14 @@ public class MockDbSetTests
         Assert.Equal(first, second);
     }
 
+    /// <summary>
+    /// Given a DbSet created directly from a MockDbSet over three entities
+    /// When ToListAsync is awaited twice
+    /// Then both calls return all three items and the two results are equal
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task MockDbSet_ToListAsyncTwice_ReturnsAllItemsBothTimes()
+    public async Task MockDbSetToListAsyncTwiceReturnsAllItemsBothTimes()
     {
         DbSet<TestEntity> set = new MockDbSet<TestEntity>(CreateData()).Object;
 
@@ -46,9 +56,14 @@ public class MockDbSetTests
         Assert.Equal(first, second);
     }
 
+    /// <summary>
+    /// Given an async-enumerable DbSet created from MockDbSetFactory over three entities
+    /// When it is iterated with await foreach twice
+    /// Then each iteration enumerates all three items
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task MockDbSetFactory_AwaitForeachTwice_EnumeratesAllItemsBothTimes()
+    public async Task MockDbSetFactoryAwaitForeachTwiceEnumeratesAllItemsBothTimes()
     {
         IAsyncEnumerable<TestEntity> set = (IAsyncEnumerable<TestEntity>)MockDbSetFactory.Create(CreateData()).Object;
 
@@ -62,9 +77,14 @@ public class MockDbSetTests
         Assert.Equal(3, secondCount);
     }
 
+    /// <summary>
+    /// Given a queryable created from MockDbSetFactory over three entities
+    /// When Count is evaluated twice
+    /// Then both evaluations return three
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void MockDbSetFactory_EnumerateTwice_ReturnsAllItemsBothTimes()
+    public void MockDbSetFactoryEnumerateTwiceReturnsAllItemsBothTimes()
     {
         IQueryable<TestEntity> set = MockDbSetFactory.CreateQueryable(CreateData());
 
@@ -72,9 +92,14 @@ public class MockDbSetTests
         Assert.Equal(3, set.Count());
     }
 
+    /// <summary>
+    /// Given a queryable created from MockDbSetFactory over three entities
+    /// When the entities are projected to their names and awaited with ToListAsync
+    /// Then the projected names are returned in order
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task MockDbSetFactory_ProjectionWithToListAsync_Works()
+    public async Task MockDbSetFactoryProjectionWithToListAsyncWorks()
     {
         IQueryable<TestEntity> set = MockDbSetFactory.CreateQueryable(CreateData());
 

--- a/tests/Asm.Tests/BoundedTests.cs
+++ b/tests/Asm.Tests/BoundedTests.cs
@@ -6,9 +6,14 @@ public class BoundedTests
 {
     // ── Iterator form ─────────────────────────────────────────────────────────
 
+    /// <summary>
+    /// Given a Bounded.While iterator with a high limit that is broken out of early.
+    /// When the loop breaks after three iterations.
+    /// Then it runs exactly three times and does not throw.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Iterator_BreaksEarly_RunsUntilBreakAndDoesNotThrow()
+    public void IteratorBreaksEarlyRunsUntilBreakAndDoesNotThrow()
     {
         int runs = 0;
         foreach (var _ in Bounded.While(100))
@@ -20,9 +25,14 @@ public class BoundedTests
         Assert.Equal(3, runs);
     }
 
+    /// <summary>
+    /// Given a Bounded.While iterator with a limit of five that is never broken out of.
+    /// When the loop runs to the limit.
+    /// Then it runs five times and throws a BoundExceededException reporting MaxIterations of five.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Iterator_NeverBreaks_ThrowsAfterMaxIterations()
+    public void IteratorNeverBreaksThrowsAfterMaxIterations()
     {
         int runs = 0;
 
@@ -38,9 +48,14 @@ public class BoundedTests
         Assert.Equal(5, exception.MaxIterations);
     }
 
+    /// <summary>
+    /// Given a Bounded.While iterator with a limit of five and BoundExceeded.Stop.
+    /// When the loop is never broken out of and reaches the limit.
+    /// Then it runs five times and does not throw.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Iterator_NeverBreaks_Stop_DoesNotThrow()
+    public void IteratorNeverBreaksStopDoesNotThrow()
     {
         int runs = 0;
         foreach (var _ in Bounded.While(5, BoundExceeded.Stop))
@@ -51,25 +66,40 @@ public class BoundedTests
         Assert.Equal(5, runs);
     }
 
+    /// <summary>
+    /// Given a Bounded.While iterator over four items with BoundExceeded.Stop.
+    /// When it is enumerated.
+    /// Then it yields the sequential indices 0, 1, 2, 3.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Iterator_YieldsSequentialIndices()
+    public void IteratorYieldsSequentialIndices()
     {
         Assert.Equal([0, 1, 2, 3], Bounded.While(4, BoundExceeded.Stop));
     }
 
+    /// <summary>
+    /// Given a Bounded.While iterator constructed with a negative maximum.
+    /// When enumeration is started.
+    /// Then an ArgumentOutOfRangeException is thrown.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Iterator_NegativeMax_Throws()
+    public void IteratorNegativeMaxThrows()
     {
         Assert.Throws<ArgumentOutOfRangeException>(() => Bounded.While(-1).GetEnumerator().MoveNext());
     }
 
     // ── Condition form (sync) ─────────────────────────────────────────────────
 
+    /// <summary>
+    /// Given a Bounded.While condition form whose condition becomes false after three iterations.
+    /// When it is run with a high maximum.
+    /// Then it returns three and the body ran three times.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Condition_StopsWhenConditionBecomesFalse_ReturnsIterationCount()
+    public void ConditionStopsWhenConditionBecomesFalseReturnsIterationCount()
     {
         int counter = 0;
         int ran = Bounded.While(() => counter < 3, () => counter++, maxIterations: 100);
@@ -78,9 +108,14 @@ public class BoundedTests
         Assert.Equal(3, counter);
     }
 
+    /// <summary>
+    /// Given a Bounded.While condition form whose condition is always true with a maximum of ten.
+    /// When it is run.
+    /// Then it throws a BoundExceededException after ten iterations, reporting MaxIterations of ten.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Condition_AlwaysTrue_ThrowsAfterMaxIterations()
+    public void ConditionAlwaysTrueThrowsAfterMaxIterations()
     {
         int ran = 0;
 
@@ -91,9 +126,14 @@ public class BoundedTests
         Assert.Equal(10, exception.MaxIterations);
     }
 
+    /// <summary>
+    /// Given a Bounded.While condition form whose condition is always true with a maximum of ten and BoundExceeded.Stop.
+    /// When it is run.
+    /// Then it returns ten and the body ran ten times without throwing.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Condition_AlwaysTrue_Stop_ReturnsMax()
+    public void ConditionAlwaysTrueStopReturnsMax()
     {
         int ran = 0;
         int result = Bounded.While(() => true, () => ran++, maxIterations: 10, BoundExceeded.Stop);
@@ -102,9 +142,14 @@ public class BoundedTests
         Assert.Equal(10, ran);
     }
 
+    /// <summary>
+    /// Given a Bounded.While condition form called with a null condition or a null body.
+    /// When either invocation runs.
+    /// Then an ArgumentNullException is thrown.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Condition_NullArguments_Throw()
+    public void ConditionNullArgumentsThrow()
     {
         Assert.Throws<ArgumentNullException>(() => Bounded.While(null!, () => { }, 10));
         Assert.Throws<ArgumentNullException>(() => Bounded.While(() => true, null!, 10));
@@ -112,9 +157,14 @@ public class BoundedTests
 
     // ── Condition form (async) ────────────────────────────────────────────────
 
+    /// <summary>
+    /// Given a Bounded.WhileAsync condition form whose condition becomes false after three iterations.
+    /// When it is awaited with a high maximum.
+    /// Then it returns three.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task ConditionAsync_StopsWhenConditionBecomesFalse_ReturnsIterationCount()
+    public async Task ConditionAsyncStopsWhenConditionBecomesFalseReturnsIterationCount()
     {
         int counter = 0;
         int ran = await Bounded.WhileAsync(
@@ -126,17 +176,27 @@ public class BoundedTests
         Assert.Equal(3, ran);
     }
 
+    /// <summary>
+    /// Given a Bounded.WhileAsync condition form whose condition is always true with a maximum of ten.
+    /// When it is awaited.
+    /// Then it throws a BoundExceededException after reaching the maximum.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task ConditionAsync_AlwaysTrue_ThrowsAfterMaxIterations()
+    public async Task ConditionAsyncAlwaysTrueThrowsAfterMaxIterations()
     {
         await Assert.ThrowsAsync<BoundExceededException>(
             () => Bounded.WhileAsync(() => true, _ => Task.CompletedTask, maxIterations: 10));
     }
 
+    /// <summary>
+    /// Given a Bounded.WhileAsync condition form passed an already-cancelled cancellation token.
+    /// When it is awaited.
+    /// Then an OperationCanceledException is thrown.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task ConditionAsync_Cancellation_Throws()
+    public async Task ConditionAsyncCancellationThrows()
     {
         using var cts = new CancellationTokenSource();
         cts.Cancel();

--- a/tests/Asm.Tests/CoreFixesTests.cs
+++ b/tests/Asm.Tests/CoreFixesTests.cs
@@ -9,9 +9,14 @@ namespace Asm.Tests;
 /// </summary>
 public class CoreFixesTests
 {
+    /// <summary>
+    /// Given two ByteArray instances with the same bytes and endianness.
+    /// When they are compared and their hash codes taken.
+    /// Then they are equal and produce equal hash codes.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void ByteArray_EqualInstances_HaveEqualHashCodes()
+    public void ByteArrayEqualInstancesHaveEqualHashCodes()
     {
         var a = new ByteArray([1, 2, 3, 4], Endian.BigEndian);
         var b = new ByteArray([1, 2, 3, 4], Endian.BigEndian);
@@ -20,9 +25,14 @@ public class CoreFixesTests
         Assert.Equal(a.GetHashCode(), b.GetHashCode());
     }
 
+    /// <summary>
+    /// Given two ByteArray instances with the same bytes but different endianness.
+    /// When their hash codes are taken.
+    /// Then the hash codes differ.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void ByteArray_DifferentEndian_HaveDifferentHashCodes()
+    public void ByteArrayDifferentEndianHaveDifferentHashCodes()
     {
         var big = new ByteArray([1, 2, 3, 4], Endian.BigEndian);
         var little = new ByteArray([1, 2, 3, 4], Endian.LittleEndian);
@@ -30,39 +40,64 @@ public class CoreFixesTests
         Assert.NotEqual(big.GetHashCode(), little.GetHashCode());
     }
 
+    /// <summary>
+    /// Given an empty array of nybbles.
+    /// When Nybble.ToUInt32 is called.
+    /// Then an ArgumentException is thrown.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Nybble_ToUInt32_EmptyArray_Throws()
+    public void NybbleToUInt32EmptyArrayThrows()
     {
         Assert.Throws<ArgumentException>(() => Nybble.ToUInt32([]));
     }
 
+    /// <summary>
+    /// Given an array of nine nybbles, more than fit in a UInt32.
+    /// When Nybble.ToUInt32 is called.
+    /// Then an ArgumentOutOfRangeException is thrown.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Nybble_ToUInt32_MoreThanEightNybbles_Throws()
+    public void NybbleToUInt32MoreThanEightNybblesThrows()
     {
         var nybbles = Enumerable.Range(0, 9).Select(_ => new Nybble(1)).ToArray();
 
         Assert.Throws<ArgumentOutOfRangeException>(() => Nybble.ToUInt32(nybbles));
     }
 
+    /// <summary>
+    /// Given a JSON string that is not a valid hex colour ("#GGGGGG").
+    /// When it is deserialized to a HexColour.
+    /// Then a JsonException is thrown.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void HexColour_DeserializeInvalidString_ThrowsJsonException()
+    public void HexColourDeserializeInvalidStringThrowsJsonException()
     {
         Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<HexColour>("\"#GGGGGG\""));
     }
 
+    /// <summary>
+    /// Given a JSON number token ("123") rather than a string.
+    /// When it is deserialized to a HexColour.
+    /// Then a JsonException is thrown.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void HexColour_DeserializeNumberToken_ThrowsJsonException()
+    public void HexColourDeserializeNumberTokenThrowsJsonException()
     {
         Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<HexColour>("123"));
     }
 
+    /// <summary>
+    /// Given a call to Squish with a fromEnd value larger than the string.
+    /// When the out-of-range ArgumentOutOfRangeException is thrown.
+    /// Then its ParamName reports the "fromEnd" parameter.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Squish_FromEndOutOfRange_ReportsFromEndParameter()
+    public void SquishFromEndOutOfRangeReportsFromEndParameter()
     {
         var exception = Assert.Throws<ArgumentOutOfRangeException>(() => "abc".Squish(fromEnd: 10));
 

--- a/tests/Asm.Tests/ExtendedBitArrayExtraTests.cs
+++ b/tests/Asm.Tests/ExtendedBitArrayExtraTests.cs
@@ -8,9 +8,14 @@ namespace Asm.Tests;
 /// </summary>
 public class ExtendedBitArrayExtraTests
 {
+    /// <summary>
+    /// Given a 16-bit little-endian ExtendedBitArray whose two bytes are 5 and 1.
+    /// When GetBytes is called.
+    /// Then every byte is packed, returning [5, 1] rather than only the first byte.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void GetBytes_MultiByte_PacksEveryByte()
+    public void GetBytesMultiBytePacksEveryByte()
     {
         // 16 bits: byte 0 = 5, byte 1 = 1. The old stride bug only wrote byte 0.
         bool[] bits = [true, false, true, false, false, false, false, false, true, false, false, false, false, false, false, false];
@@ -19,18 +24,28 @@ public class ExtendedBitArrayExtraTests
         Assert.Equal([(byte)5, (byte)1], eba.GetBytes());
     }
 
+    /// <summary>
+    /// Given an ExtendedBitArray constructed from the bytes [5, 1, 200].
+    /// When GetBytes is called.
+    /// Then it round-trips the original bytes unchanged.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void GetBytes_RoundTripsFromBytes()
+    public void GetBytesRoundTripsFromBytes()
     {
         var eba = new ExtendedBitArray(new byte[] { 5, 1, 200 }, Endian.LittleEndian);
 
         Assert.Equal([(byte)5, (byte)1, (byte)200], eba.GetBytes());
     }
 
+    /// <summary>
+    /// Given an ExtendedBitArray of four bits and a destination bool array.
+    /// When CopyTo is called with offset 0.
+    /// Then it does not throw and copies every bit into the destination.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void CopyTo_Array_DoesNotThrowAndCopies()
+    public void CopyToArrayDoesNotThrowAndCopies()
     {
         var eba = new ExtendedBitArray([true, false, true, false], Endian.LittleEndian);
         var dest = new bool[4];
@@ -40,9 +55,14 @@ public class ExtendedBitArrayExtraTests
         Assert.Equal([true, false, true, false], dest);
     }
 
+    /// <summary>
+    /// Given an eight-bit ExtendedBitArray.
+    /// When it is indexed with a from-end range (^4..^1).
+    /// Then it returns the bits at indices 4, 5 and 6.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void RangeIndexer_HonoursFromEndIndices()
+    public void RangeIndexerHonoursFromEndIndices()
     {
         var eba = new ExtendedBitArray([true, false, true, false, true, true, false, false], Endian.LittleEndian);
 
@@ -50,9 +70,14 @@ public class ExtendedBitArrayExtraTests
         Assert.Equal([true, true, false], eba[^4..^1]);
     }
 
+    /// <summary>
+    /// Given a four-bit ExtendedBitArray.
+    /// When it is indexed with a full from-end range (..^0).
+    /// Then it returns all four bits unchanged.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void RangeIndexer_FullFromEndRange()
+    public void RangeIndexerFullFromEndRange()
     {
         var eba = new ExtendedBitArray([true, false, true, false], Endian.LittleEndian);
 
@@ -60,18 +85,28 @@ public class ExtendedBitArrayExtraTests
     }
 
     // BigEndian value semantics: bit 0 is the most-significant bit, so [t,f,t,f] reads as 1010b = 10.
+    /// <summary>
+    /// Given a big-endian ExtendedBitArray of bits [true, false, true, false].
+    /// When ToByte is called.
+    /// Then bit 0 is treated as the most-significant bit, yielding 1010b = 10.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void BigEndian_ToByte_IsMostSignificantBitFirst()
+    public void BigEndianToByteIsMostSignificantBitFirst()
     {
         var eba = new ExtendedBitArray([true, false, true, false], Endian.BigEndian);
 
         Assert.Equal((byte)10, eba.ToByte());
     }
 
+    /// <summary>
+    /// Given a big-endian ExtendedBitArray with only the most-significant bit set.
+    /// When ToSByte is called.
+    /// Then the sign bit is honoured, yielding -128 in two's complement.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void BigEndian_ToSByte_HandlesSignBit()
+    public void BigEndianToSByteHandlesSignBit()
     {
         // MSB set, rest clear -> -128 in two's complement.
         var eba = new ExtendedBitArray([true, false, false, false, false, false, false, false], Endian.BigEndian);
@@ -79,9 +114,14 @@ public class ExtendedBitArrayExtraTests
         Assert.Equal((sbyte)-128, eba.ToSByte());
     }
 
+    /// <summary>
+    /// Given a little-endian ExtendedBitArray with all 16 bits set.
+    /// When ToInt16 is called.
+    /// Then it returns -1.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void LittleEndian_ToInt16_NegativeValue()
+    public void LittleEndianToInt16NegativeValue()
     {
         // All 16 bits set -> -1.
         var bits = Enumerable.Repeat(true, 16).ToArray();
@@ -90,9 +130,14 @@ public class ExtendedBitArrayExtraTests
         Assert.Equal((short)-1, eba.ToInt16());
     }
 
+    /// <summary>
+    /// Given a 16-bit little-endian ExtendedBitArray whose low byte is 5.
+    /// When ToByte converts it to an 8-bit target.
+    /// Then only the low 8 bits are kept, yielding 5 instead of throwing an OverflowException.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void ToUnsigned_ArrayLongerThanTarget_TruncatesToLowBits()
+    public void ToUnsignedArrayLongerThanTargetTruncatesToLowBits()
     {
         // 16-bit array converted to a byte keeps only the low 8 bits (was OverflowException).
         bool[] bits = [true, false, true, false, false, false, false, false, true, true, true, true, true, true, true, true];

--- a/tests/Asm.Tests/IO/StringWriterWithEncodingTests.cs
+++ b/tests/Asm.Tests/IO/StringWriterWithEncodingTests.cs
@@ -11,9 +11,14 @@ public class StringWriterWithEncodingTests
 {
     public static readonly List<object[]> encodings = [new Encoding[] { Encoding.UTF8 }, new Encoding[] { Encoding.ASCII }, new Encoding[] { Encoding.Latin1 }];
 
+    /// <summary>
+    /// Given a StringWriterWithEncoding constructed with a specific encoding.
+    /// When the Encoding property is read.
+    /// Then it returns the encoding supplied to the constructor.
+    /// </summary>
     [Theory]
     [MemberData(nameof(encodings))]
-    public void EncodingTest(Encoding encoding)
+    public void EncodingReturnsConstructorEncoding(Encoding encoding)
     {
         // Arrange
         var writer = new StringWriterWithEncoding(encoding);

--- a/tests/Asm.Tests/NameValueCollectionExtensionsTests.cs
+++ b/tests/Asm.Tests/NameValueCollectionExtensionsTests.cs
@@ -5,9 +5,14 @@ namespace Asm.Tests;
 
 public class NameValueCollectionExtensionsTests
 {
+    /// <summary>
+    /// Given a NameValueCollection containing a key with a parseable value and a missing key.
+    /// When GetValue is called with a default for each.
+    /// Then the present key returns its parsed value and the missing key returns the supplied default.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void GetValueTest()
+    public void GetValueReturnsParsedValueOrDefault()
     {
         NameValueCollection collection = new NameValueCollection();
 

--- a/tests/Asm.Umbraco.Authentication.Tests/EntraId/EntraIdBackOfficeOptionsTests.cs
+++ b/tests/Asm.Umbraco.Authentication.Tests/EntraId/EntraIdBackOfficeOptionsTests.cs
@@ -26,9 +26,14 @@ public class EntraIdBackOfficeOptionsTests
     // Configure(string?, MicrosoftAccountOptions)
     // -----------------------------------------------------------------------
 
+    /// <summary>
+    /// Given EntraIdBackOfficeOptions and MicrosoftAccountOptions.
+    /// When Configure is called with the matching scheme name.
+    /// Then the MicrosoftAccountOptions ClientId is set from the EntraId options.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Configure_WithMatchingName_SetsClientId()
+    public void ConfigureWithMatchingNameSetsClientId()
     {
         var sut = CreateSut();
         var options = new MicrosoftAccountOptions();
@@ -38,9 +43,14 @@ public class EntraIdBackOfficeOptionsTests
         Assert.Equal(ClientId, options.ClientId);
     }
 
+    /// <summary>
+    /// Given EntraIdBackOfficeOptions and MicrosoftAccountOptions.
+    /// When Configure is called with the matching scheme name.
+    /// Then the MicrosoftAccountOptions ClientSecret is set from the EntraId options.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Configure_WithMatchingName_SetsClientSecret()
+    public void ConfigureWithMatchingNameSetsClientSecret()
     {
         var sut = CreateSut();
         var options = new MicrosoftAccountOptions();
@@ -50,9 +60,14 @@ public class EntraIdBackOfficeOptionsTests
         Assert.Equal(ClientSecret, options.ClientSecret);
     }
 
+    /// <summary>
+    /// Given EntraIdBackOfficeOptions and MicrosoftAccountOptions.
+    /// When Configure is called with the matching scheme name.
+    /// Then the MicrosoftAccountOptions CallbackPath is "/signin-entraid".
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Configure_WithMatchingName_SetsCallbackPath()
+    public void ConfigureWithMatchingNameSetsCallbackPath()
     {
         var sut = CreateSut();
         var options = new MicrosoftAccountOptions();
@@ -62,9 +77,14 @@ public class EntraIdBackOfficeOptionsTests
         Assert.Equal("/signin-entraid", options.CallbackPath);
     }
 
+    /// <summary>
+    /// Given EntraIdBackOfficeOptions and MicrosoftAccountOptions.
+    /// When Configure is called with the matching scheme name.
+    /// Then the MicrosoftAccountOptions TokenEndpoint is the tenant-specific token URL.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Configure_WithMatchingName_SetsTokenEndpoint()
+    public void ConfigureWithMatchingNameSetsTokenEndpoint()
     {
         var sut = CreateSut();
         var options = new MicrosoftAccountOptions();
@@ -76,9 +96,14 @@ public class EntraIdBackOfficeOptionsTests
             options.TokenEndpoint);
     }
 
+    /// <summary>
+    /// Given EntraIdBackOfficeOptions and MicrosoftAccountOptions.
+    /// When Configure is called with the matching scheme name.
+    /// Then the MicrosoftAccountOptions AuthorizationEndpoint is the tenant-specific authorize URL.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Configure_WithMatchingName_SetsAuthorizationEndpoint()
+    public void ConfigureWithMatchingNameSetsAuthorizationEndpoint()
     {
         var sut = CreateSut();
         var options = new MicrosoftAccountOptions();
@@ -90,9 +115,14 @@ public class EntraIdBackOfficeOptionsTests
             options.AuthorizationEndpoint);
     }
 
+    /// <summary>
+    /// Given EntraIdBackOfficeOptions and MicrosoftAccountOptions.
+    /// When Configure is called with a non-matching scheme name.
+    /// Then the MicrosoftAccountOptions ClientId is left unchanged.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Configure_WithNonMatchingName_LeavesClientIdUnchanged()
+    public void ConfigureWithNonMatchingNameLeavesClientIdUnchanged()
     {
         var sut = CreateSut();
         var options = new MicrosoftAccountOptions();
@@ -103,9 +133,14 @@ public class EntraIdBackOfficeOptionsTests
         Assert.Equal(originalClientId, options.ClientId);
     }
 
+    /// <summary>
+    /// Given EntraIdBackOfficeOptions and MicrosoftAccountOptions.
+    /// When Configure is called with a non-matching scheme name.
+    /// Then the MicrosoftAccountOptions ClientSecret is left unchanged.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Configure_WithNonMatchingName_LeavesClientSecretUnchanged()
+    public void ConfigureWithNonMatchingNameLeavesClientSecretUnchanged()
     {
         var sut = CreateSut();
         var options = new MicrosoftAccountOptions();
@@ -120,9 +155,14 @@ public class EntraIdBackOfficeOptionsTests
     // Configure(MicrosoftAccountOptions) — no-name overload
     // -----------------------------------------------------------------------
 
+    /// <summary>
+    /// Given EntraIdBackOfficeOptions and MicrosoftAccountOptions.
+    /// When the no-name Configure overload is called.
+    /// Then the MicrosoftAccountOptions ClientId is set from the EntraId options.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Configure_WithoutName_SetsClientId()
+    public void ConfigureWithoutNameSetsClientId()
     {
         var sut = CreateSut();
         var options = new MicrosoftAccountOptions();
@@ -132,9 +172,14 @@ public class EntraIdBackOfficeOptionsTests
         Assert.Equal(ClientId, options.ClientId);
     }
 
+    /// <summary>
+    /// Given EntraIdBackOfficeOptions and MicrosoftAccountOptions.
+    /// When the no-name Configure overload is called.
+    /// Then the MicrosoftAccountOptions ClientSecret is set from the EntraId options.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Configure_WithoutName_SetsClientSecret()
+    public void ConfigureWithoutNameSetsClientSecret()
     {
         var sut = CreateSut();
         var options = new MicrosoftAccountOptions();
@@ -144,9 +189,14 @@ public class EntraIdBackOfficeOptionsTests
         Assert.Equal(ClientSecret, options.ClientSecret);
     }
 
+    /// <summary>
+    /// Given EntraIdBackOfficeOptions and MicrosoftAccountOptions.
+    /// When the no-name Configure overload is called.
+    /// Then the MicrosoftAccountOptions CallbackPath is "/signin-entraid".
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Configure_WithoutName_SetsCallbackPath()
+    public void ConfigureWithoutNameSetsCallbackPath()
     {
         var sut = CreateSut();
         var options = new MicrosoftAccountOptions();
@@ -156,9 +206,14 @@ public class EntraIdBackOfficeOptionsTests
         Assert.Equal("/signin-entraid", options.CallbackPath);
     }
 
+    /// <summary>
+    /// Given EntraIdBackOfficeOptions and MicrosoftAccountOptions.
+    /// When the no-name Configure overload is called.
+    /// Then the MicrosoftAccountOptions TokenEndpoint is the tenant-specific token URL.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Configure_WithoutName_SetsTokenEndpoint()
+    public void ConfigureWithoutNameSetsTokenEndpoint()
     {
         var sut = CreateSut();
         var options = new MicrosoftAccountOptions();
@@ -170,9 +225,14 @@ public class EntraIdBackOfficeOptionsTests
             options.TokenEndpoint);
     }
 
+    /// <summary>
+    /// Given EntraIdBackOfficeOptions and MicrosoftAccountOptions.
+    /// When the no-name Configure overload is called.
+    /// Then the MicrosoftAccountOptions AuthorizationEndpoint is the tenant-specific authorize URL.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Configure_WithoutName_SetsAuthorizationEndpoint()
+    public void ConfigureWithoutNameSetsAuthorizationEndpoint()
     {
         var sut = CreateSut();
         var options = new MicrosoftAccountOptions();

--- a/tests/Asm.Umbraco.Authentication.Tests/EntraId/EntraIdLoginOptionsTests.cs
+++ b/tests/Asm.Umbraco.Authentication.Tests/EntraId/EntraIdLoginOptionsTests.cs
@@ -21,9 +21,14 @@ public class EntraIdLoginOptionsTests
             ClientSecret = "secret",
         }));
 
+    /// <summary>
+    /// Given the EntraIdLoginOptions type.
+    /// When its SchemeName constant is read.
+    /// Then it is the provider-specific value "EntraId".
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void SchemeName_IsProviderSpecific()
+    public void SchemeNameIsProviderSpecific()
     {
         // v4: renamed from "OpenIdConnect" so it does not masquerade as an OIDC handler.
         Assert.Equal("EntraId", EntraIdLoginOptions.SchemeName);
@@ -33,9 +38,14 @@ public class EntraIdLoginOptionsTests
     // Configure(string?, BackOfficeExternalLoginProviderOptions)
     // -----------------------------------------------------------------------
 
+    /// <summary>
+    /// Given EntraIdLoginOptions and BackOfficeExternalLoginProviderOptions.
+    /// When Configure is called with the matching scheme name.
+    /// Then the AutoLinkOptions are not null.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Configure_WithMatchingName_SetsAutoLinkOptionsNotNull()
+    public void ConfigureWithMatchingNameSetsAutoLinkOptionsNotNull()
     {
         var sut = CreateSut();
         var options = new BackOfficeExternalLoginProviderOptions();
@@ -45,9 +55,14 @@ public class EntraIdLoginOptionsTests
         Assert.NotNull(options.AutoLinkOptions);
     }
 
+    /// <summary>
+    /// Given EntraIdLoginOptions and BackOfficeExternalLoginProviderOptions.
+    /// When Configure is called with the matching scheme name.
+    /// Then AutoLinkExternalAccount is enabled.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Configure_WithMatchingName_AutoLinksExternalAccount()
+    public void ConfigureWithMatchingNameAutoLinksExternalAccount()
     {
         var sut = CreateSut();
         var options = new BackOfficeExternalLoginProviderOptions();
@@ -57,9 +72,14 @@ public class EntraIdLoginOptionsTests
         Assert.True(options.AutoLinkOptions.AutoLinkExternalAccount);
     }
 
+    /// <summary>
+    /// Given EntraIdLoginOptions and BackOfficeExternalLoginProviderOptions.
+    /// When Configure is called with the matching scheme name.
+    /// Then DenyLocalLogin is false.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Configure_WithMatchingName_SetsDenyLocalLoginFalse()
+    public void ConfigureWithMatchingNameSetsDenyLocalLoginFalse()
     {
         var sut = CreateSut();
         var options = new BackOfficeExternalLoginProviderOptions();
@@ -69,9 +89,14 @@ public class EntraIdLoginOptionsTests
         Assert.False(options.DenyLocalLogin);
     }
 
+    /// <summary>
+    /// Given EntraIdLoginOptions and BackOfficeExternalLoginProviderOptions.
+    /// When Configure is called with a non-matching scheme name.
+    /// Then AutoLinkExternalAccount is unchanged and remains disabled.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Configure_WithNonMatchingName_LeavesAutoLinkOptionsUnchanged()
+    public void ConfigureWithNonMatchingNameLeavesAutoLinkOptionsUnchanged()
     {
         var sut = CreateSut();
         var options = new BackOfficeExternalLoginProviderOptions();
@@ -91,9 +116,14 @@ public class EntraIdLoginOptionsTests
     // Configure(BackOfficeExternalLoginProviderOptions) — no-name overload
     // -----------------------------------------------------------------------
 
+    /// <summary>
+    /// Given EntraIdLoginOptions and BackOfficeExternalLoginProviderOptions.
+    /// When the no-name Configure overload is called.
+    /// Then the AutoLinkOptions are not null.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Configure_WithoutName_SetsAutoLinkOptionsNotNull()
+    public void ConfigureWithoutNameSetsAutoLinkOptionsNotNull()
     {
         var sut = CreateSut();
         var options = new BackOfficeExternalLoginProviderOptions();
@@ -103,9 +133,14 @@ public class EntraIdLoginOptionsTests
         Assert.NotNull(options.AutoLinkOptions);
     }
 
+    /// <summary>
+    /// Given EntraIdLoginOptions and BackOfficeExternalLoginProviderOptions.
+    /// When the no-name Configure overload is called.
+    /// Then AutoLinkExternalAccount is enabled.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Configure_WithoutName_AutoLinksExternalAccount()
+    public void ConfigureWithoutNameAutoLinksExternalAccount()
     {
         var sut = CreateSut();
         var options = new BackOfficeExternalLoginProviderOptions();
@@ -115,9 +150,14 @@ public class EntraIdLoginOptionsTests
         Assert.True(options.AutoLinkOptions.AutoLinkExternalAccount);
     }
 
+    /// <summary>
+    /// Given EntraIdLoginOptions and BackOfficeExternalLoginProviderOptions.
+    /// When the no-name Configure overload is called.
+    /// Then DenyLocalLogin is false.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Configure_WithoutName_SetsDenyLocalLoginFalse()
+    public void ConfigureWithoutNameSetsDenyLocalLoginFalse()
     {
         var sut = CreateSut();
         var options = new BackOfficeExternalLoginProviderOptions();
@@ -131,9 +171,14 @@ public class EntraIdLoginOptionsTests
     // OnAutoLinking callback
     // -----------------------------------------------------------------------
 
+    /// <summary>
+    /// Given configured EntraIdLoginOptions and a back-office identity user with external login info.
+    /// When the AutoLinkOptions OnAutoLinking callback is invoked.
+    /// Then the user's IsApproved is set to true.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void OnAutoLinking_SetsIsApprovedTrue()
+    public void OnAutoLinkingSetsIsApprovedTrue()
     {
         var sut = CreateSut();
         var options = new BackOfficeExternalLoginProviderOptions();
@@ -151,9 +196,14 @@ public class EntraIdLoginOptionsTests
     // OnExternalLogin callback
     // -----------------------------------------------------------------------
 
+    /// <summary>
+    /// Given configured EntraIdLoginOptions and a back-office identity user with external login info.
+    /// When the AutoLinkOptions OnExternalLogin callback is invoked.
+    /// Then it returns true.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void OnExternalLogin_ReturnsTrue()
+    public void OnExternalLoginReturnsTrue()
     {
         var sut = CreateSut();
         var options = new BackOfficeExternalLoginProviderOptions();
@@ -171,9 +221,14 @@ public class EntraIdLoginOptionsTests
     // Options flow through from EntraIdOptions
     // -----------------------------------------------------------------------
 
+    /// <summary>
+    /// Given EntraIdOptions with AutoLink set to false.
+    /// When Configure is called on the resulting login options.
+    /// Then AutoLinkExternalAccount is disabled.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Configure_HonoursAutoLinkFalse()
+    public void ConfigureHonoursAutoLinkFalse()
     {
         var sut = CreateSut(new EntraIdOptions { TenantId = "t", ClientId = "c", ClientSecret = "s", AutoLink = false });
         var options = new BackOfficeExternalLoginProviderOptions();
@@ -183,9 +238,14 @@ public class EntraIdLoginOptionsTests
         Assert.False(options.AutoLinkOptions.AutoLinkExternalAccount);
     }
 
+    /// <summary>
+    /// Given EntraIdOptions with DenyLocalLogin set to true.
+    /// When Configure is called on the resulting login options.
+    /// Then DenyLocalLogin is true.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Configure_HonoursDenyLocalLoginTrue()
+    public void ConfigureHonoursDenyLocalLoginTrue()
     {
         var sut = CreateSut(new EntraIdOptions { TenantId = "t", ClientId = "c", ClientSecret = "s", DenyLocalLogin = true });
         var options = new BackOfficeExternalLoginProviderOptions();
@@ -195,9 +255,14 @@ public class EntraIdLoginOptionsTests
         Assert.True(options.DenyLocalLogin);
     }
 
+    /// <summary>
+    /// Given EntraIdOptions with custom DefaultUserGroups.
+    /// When Configure is called on the resulting login options.
+    /// Then the AutoLinkOptions DefaultUserGroups match the configured groups.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Configure_HonoursCustomDefaultUserGroups()
+    public void ConfigureHonoursCustomDefaultUserGroups()
     {
         var sut = CreateSut(new EntraIdOptions { TenantId = "t", ClientId = "c", ClientSecret = "s", DefaultUserGroups = ["writer", "translator"] });
         var options = new BackOfficeExternalLoginProviderOptions();
@@ -207,9 +272,14 @@ public class EntraIdLoginOptionsTests
         Assert.Equal(["writer", "translator"], options.AutoLinkOptions.DefaultUserGroups);
     }
 
+    /// <summary>
+    /// Given EntraIdLoginOptions created with default EntraIdOptions.
+    /// When Configure is called.
+    /// Then the AutoLinkOptions DefaultUserGroups default to the editor group.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Configure_DefaultUserGroups_IsEditor()
+    public void ConfigureDefaultUserGroupsIsEditor()
     {
         var sut = CreateSut();
         var options = new BackOfficeExternalLoginProviderOptions();

--- a/tests/Asm.Umbraco.Authentication.Tests/EntraId/EntraIdManifestReaderTests.cs
+++ b/tests/Asm.Umbraco.Authentication.Tests/EntraId/EntraIdManifestReaderTests.cs
@@ -5,9 +5,14 @@ namespace Asm.Umbraco.Authentication.Tests.EntraId;
 
 public class EntraIdManifestReaderTests
 {
+    /// <summary>
+    /// Given an EntraIdManifestReader.
+    /// When ReadPackageManifestsAsync is called.
+    /// Then it returns exactly one manifest.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task ReadPackageManifestsAsync_ReturnsSingleManifest()
+    public async Task ReadPackageManifestsAsyncReturnsSingleManifest()
     {
         var sut = new EntraIdManifestReader();
 
@@ -16,9 +21,14 @@ public class EntraIdManifestReaderTests
         Assert.Single(manifests);
     }
 
+    /// <summary>
+    /// Given an EntraIdManifestReader.
+    /// When ReadPackageManifestsAsync is called and the single manifest is inspected.
+    /// Then its Name is "Asm.Umbraco.Authentication.EntraId".
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task ReadPackageManifestsAsync_ManifestNameIsCorrect()
+    public async Task ReadPackageManifestsAsyncManifestNameIsCorrect()
     {
         var sut = new EntraIdManifestReader();
 
@@ -28,9 +38,14 @@ public class EntraIdManifestReaderTests
         Assert.Equal("Asm.Umbraco.Authentication.EntraId", manifest.Name);
     }
 
+    /// <summary>
+    /// Given an EntraIdManifestReader.
+    /// When ReadPackageManifestsAsync is called and the single manifest is inspected.
+    /// Then its AllowPublicAccess is true.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task ReadPackageManifestsAsync_ManifestAllowsPublicAccess()
+    public async Task ReadPackageManifestsAsyncManifestAllowsPublicAccess()
     {
         var sut = new EntraIdManifestReader();
 
@@ -40,9 +55,14 @@ public class EntraIdManifestReaderTests
         Assert.True(manifest.AllowPublicAccess);
     }
 
+    /// <summary>
+    /// Given an EntraIdManifestReader.
+    /// When ReadPackageManifestsAsync is called and the single manifest is inspected.
+    /// Then its Extensions collection is non-null and contains exactly one extension.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task ReadPackageManifestsAsync_ManifestHasExactlyOneExtension()
+    public async Task ReadPackageManifestsAsyncManifestHasExactlyOneExtension()
     {
         var sut = new EntraIdManifestReader();
 
@@ -53,9 +73,14 @@ public class EntraIdManifestReaderTests
         Assert.Single(manifest.Extensions);
     }
 
+    /// <summary>
+    /// Given an EntraIdManifestReader.
+    /// When ReadPackageManifestsAsync is called and the single manifest's single extension is inspected.
+    /// Then the extension's type is "authProvider".
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task ReadPackageManifestsAsync_ExtensionTypeIsAuthProvider()
+    public async Task ReadPackageManifestsAsyncExtensionTypeIsAuthProvider()
     {
         var sut = new EntraIdManifestReader();
 
@@ -67,9 +92,14 @@ public class EntraIdManifestReaderTests
         Assert.Equal("authProvider", (string)ext.type);
     }
 
+    /// <summary>
+    /// Given an EntraIdManifestReader and the expected provider name derived from the scheme name.
+    /// When ReadPackageManifestsAsync is called and the single manifest's single extension is inspected.
+    /// Then the extension's forProviderName matches the expected provider name.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task ReadPackageManifestsAsync_ExtensionForProviderNameMatchesSchemeName()
+    public async Task ReadPackageManifestsAsyncExtensionForProviderNameMatchesSchemeName()
     {
         var expectedProviderName =
             Constants.Security.BackOfficeExternalAuthenticationTypePrefix + EntraIdLoginOptions.SchemeName;
@@ -83,9 +113,14 @@ public class EntraIdManifestReaderTests
         Assert.Equal(expectedProviderName, (string)ext.forProviderName);
     }
 
+    /// <summary>
+    /// Given an EntraIdManifestReader.
+    /// When ReadPackageManifestsAsync is called and the single manifest's single extension is inspected.
+    /// Then the extension's meta.label is "Microsoft".
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task ReadPackageManifestsAsync_ExtensionMetaLabelIsMicrosoft()
+    public async Task ReadPackageManifestsAsyncExtensionMetaLabelIsMicrosoft()
     {
         var sut = new EntraIdManifestReader();
 

--- a/tests/Asm.Umbraco.Authentication.Tests/EntraId/EntraIdOptionsTests.cs
+++ b/tests/Asm.Umbraco.Authentication.Tests/EntraId/EntraIdOptionsTests.cs
@@ -4,9 +4,14 @@ namespace Asm.Umbraco.Authentication.Tests.EntraId;
 
 public class EntraIdOptionsTests
 {
+    /// <summary>
+    /// Given an EntraIdOptions initialised with a TenantId.
+    /// When the TenantId property is read.
+    /// Then it returns the value that was set.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void TenantId_CanBeSetAndRead()
+    public void TenantIdCanBeSetAndRead()
     {
         var options = new EntraIdOptions
         {
@@ -18,9 +23,14 @@ public class EntraIdOptionsTests
         Assert.Equal("test-tenant-id", options.TenantId);
     }
 
+    /// <summary>
+    /// Given an EntraIdOptions initialised with a ClientId.
+    /// When the ClientId property is read.
+    /// Then it returns the value that was set.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void ClientId_CanBeSetAndRead()
+    public void ClientIdCanBeSetAndRead()
     {
         var options = new EntraIdOptions
         {
@@ -32,9 +42,14 @@ public class EntraIdOptionsTests
         Assert.Equal("test-client-id", options.ClientId);
     }
 
+    /// <summary>
+    /// Given an EntraIdOptions initialised with a ClientSecret.
+    /// When the ClientSecret property is read.
+    /// Then it returns the value that was set.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void ClientSecret_CanBeSetAndRead()
+    public void ClientSecretCanBeSetAndRead()
     {
         var options = new EntraIdOptions
         {
@@ -46,9 +61,14 @@ public class EntraIdOptionsTests
         Assert.Equal("test-client-secret", options.ClientSecret);
     }
 
+    /// <summary>
+    /// Given two EntraIdOptions records with identical values and a shared DefaultUserGroups instance.
+    /// When they are compared for equality.
+    /// Then they are considered equal.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Records_WithSameValues_AreEqual()
+    public void RecordsWithSameValuesAreEqual()
     {
         // DefaultUserGroups is a reference-type collection, so record equality requires the same
         // instance (C# records compare members by their own Equals). Share it to compare the rest.
@@ -72,9 +92,14 @@ public class EntraIdOptionsTests
         Assert.Equal(a, b);
     }
 
+    /// <summary>
+    /// Given two EntraIdOptions records that differ by TenantId.
+    /// When they are compared for equality.
+    /// Then they are considered not equal.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Records_WithDifferentValues_AreNotEqual()
+    public void RecordsWithDifferentValuesAreNotEqual()
     {
         var a = new EntraIdOptions
         {

--- a/tests/Asm.Umbraco.Authentication.Tests/EntraId/IUmbracoBuilderExtensionsTests.cs
+++ b/tests/Asm.Umbraco.Authentication.Tests/EntraId/IUmbracoBuilderExtensionsTests.cs
@@ -28,9 +28,14 @@ public class IUmbracoBuilderExtensionsTests
     // AddEntraIdAuthentication(Action<EntraIdOptions>)
     // -----------------------------------------------------------------------
 
+    /// <summary>
+    /// Given an Umbraco builder.
+    /// When AddEntraIdAuthentication is called with a configure action.
+    /// Then EntraIdLoginOptions is registered as IConfigureOptions of BackOfficeExternalLoginProviderOptions.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void AddEntraIdAuthentication_WithAction_RegistersEntraIdLoginOptions()
+    public void AddEntraIdAuthenticationWithActionRegistersEntraIdLoginOptions()
     {
         var (builder, services) = CreateBuilder();
 
@@ -46,9 +51,14 @@ public class IUmbracoBuilderExtensionsTests
             sd.ImplementationType == typeof(EntraIdLoginOptions));
     }
 
+    /// <summary>
+    /// Given an Umbraco builder.
+    /// When AddEntraIdAuthentication is called with a configure action.
+    /// Then EntraIdBackOfficeOptions is registered as IConfigureOptions of MicrosoftAccountOptions.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void AddEntraIdAuthentication_WithAction_RegistersEntraIdBackOfficeOptions()
+    public void AddEntraIdAuthenticationWithActionRegistersEntraIdBackOfficeOptions()
     {
         var (builder, services) = CreateBuilder();
 
@@ -64,9 +74,14 @@ public class IUmbracoBuilderExtensionsTests
             sd.ImplementationType == typeof(EntraIdBackOfficeOptions));
     }
 
+    /// <summary>
+    /// Given an Umbraco builder.
+    /// When AddEntraIdAuthentication is called with a configure action.
+    /// Then EntraIdManifestReader is registered as an IPackageManifestReader.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void AddEntraIdAuthentication_WithAction_RegistersPackageManifestReader()
+    public void AddEntraIdAuthenticationWithActionRegistersPackageManifestReader()
     {
         var (builder, services) = CreateBuilder();
 
@@ -82,9 +97,14 @@ public class IUmbracoBuilderExtensionsTests
             sd.ImplementationType == typeof(EntraIdManifestReader));
     }
 
+    /// <summary>
+    /// Given an Umbraco builder.
+    /// When AddEntraIdAuthentication is called with a configure action setting tenant, client and secret.
+    /// Then the resolved EntraIdOptions carry those bound values.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void AddEntraIdAuthentication_WithAction_BindsEntraIdOptions()
+    public void AddEntraIdAuthenticationWithActionBindsEntraIdOptions()
     {
         var (builder, services) = CreateBuilder();
 
@@ -103,9 +123,14 @@ public class IUmbracoBuilderExtensionsTests
         Assert.Equal("test-secret", options.Value.ClientSecret);
     }
 
+    /// <summary>
+    /// Given an Umbraco builder.
+    /// When AddEntraIdAuthentication is called with a configure action.
+    /// Then the same builder instance is returned.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void AddEntraIdAuthentication_WithAction_ReturnsBuilder()
+    public void AddEntraIdAuthenticationWithActionReturnsBuilder()
     {
         var (builder, _) = CreateBuilder();
 
@@ -119,9 +144,14 @@ public class IUmbracoBuilderExtensionsTests
         Assert.Same(builder, returned);
     }
 
+    /// <summary>
+    /// Given a null Umbraco builder.
+    /// When AddEntraIdAuthentication is called with a configure action.
+    /// Then an ArgumentNullException is thrown.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void AddEntraIdAuthentication_WithNullBuilder_ThrowsArgumentNullException()
+    public void AddEntraIdAuthenticationWithNullBuilderThrowsArgumentNullException()
     {
         IUmbracoBuilder nullBuilder = null;
 
@@ -134,9 +164,14 @@ public class IUmbracoBuilderExtensionsTests
             }));
     }
 
+    /// <summary>
+    /// Given an Umbraco builder.
+    /// When AddEntraIdAuthentication is called with a null configure action.
+    /// Then an ArgumentNullException is thrown.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void AddEntraIdAuthentication_WithNullAction_ThrowsArgumentNullException()
+    public void AddEntraIdAuthenticationWithNullActionThrowsArgumentNullException()
     {
         var (builder, _) = CreateBuilder();
 
@@ -148,9 +183,14 @@ public class IUmbracoBuilderExtensionsTests
     // AddEntraIdAuthentication(IConfigurationSection)
     // -----------------------------------------------------------------------
 
+    /// <summary>
+    /// Given an Umbraco builder and a configuration section.
+    /// When AddEntraIdAuthentication is called with that section.
+    /// Then EntraIdLoginOptions is registered as IConfigureOptions of BackOfficeExternalLoginProviderOptions.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void AddEntraIdAuthentication_WithConfigSection_RegistersEntraIdLoginOptions()
+    public void AddEntraIdAuthenticationWithConfigSectionRegistersEntraIdLoginOptions()
     {
         var (builder, services) = CreateBuilder();
 
@@ -161,9 +201,14 @@ public class IUmbracoBuilderExtensionsTests
             sd.ImplementationType == typeof(EntraIdLoginOptions));
     }
 
+    /// <summary>
+    /// Given an Umbraco builder and a configuration section.
+    /// When AddEntraIdAuthentication is called with that section.
+    /// Then EntraIdBackOfficeOptions is registered as IConfigureOptions of MicrosoftAccountOptions.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void AddEntraIdAuthentication_WithConfigSection_RegistersEntraIdBackOfficeOptions()
+    public void AddEntraIdAuthenticationWithConfigSectionRegistersEntraIdBackOfficeOptions()
     {
         var (builder, services) = CreateBuilder();
 
@@ -174,9 +219,14 @@ public class IUmbracoBuilderExtensionsTests
             sd.ImplementationType == typeof(EntraIdBackOfficeOptions));
     }
 
+    /// <summary>
+    /// Given an Umbraco builder and a configuration section.
+    /// When AddEntraIdAuthentication is called with that section.
+    /// Then EntraIdManifestReader is registered as an IPackageManifestReader.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void AddEntraIdAuthentication_WithConfigSection_RegistersPackageManifestReader()
+    public void AddEntraIdAuthenticationWithConfigSectionRegistersPackageManifestReader()
     {
         var (builder, services) = CreateBuilder();
 
@@ -187,9 +237,14 @@ public class IUmbracoBuilderExtensionsTests
             sd.ImplementationType == typeof(EntraIdManifestReader));
     }
 
+    /// <summary>
+    /// Given an Umbraco builder and a configuration section with tenant, client and secret values.
+    /// When AddEntraIdAuthentication is called with that section.
+    /// Then the resolved EntraIdOptions carry those bound values.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void AddEntraIdAuthentication_WithConfigSection_BindsEntraIdOptions()
+    public void AddEntraIdAuthenticationWithConfigSectionBindsEntraIdOptions()
     {
         var (builder, services) = CreateBuilder();
 
@@ -206,9 +261,14 @@ public class IUmbracoBuilderExtensionsTests
         Assert.Equal("section-secret", options.Value.ClientSecret);
     }
 
+    /// <summary>
+    /// Given an Umbraco builder and a configuration section.
+    /// When AddEntraIdAuthentication is called with that section.
+    /// Then the same builder instance is returned.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void AddEntraIdAuthentication_WithConfigSection_ReturnsBuilder()
+    public void AddEntraIdAuthenticationWithConfigSectionReturnsBuilder()
     {
         var (builder, _) = CreateBuilder();
 
@@ -217,9 +277,14 @@ public class IUmbracoBuilderExtensionsTests
         Assert.Same(builder, returned);
     }
 
+    /// <summary>
+    /// Given an Umbraco builder.
+    /// When AddEntraIdAuthentication is called with a null configuration section.
+    /// Then an ArgumentNullException is thrown.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void AddEntraIdAuthentication_WithNullConfigSection_ThrowsArgumentNullException()
+    public void AddEntraIdAuthenticationWithNullConfigSectionThrowsArgumentNullException()
     {
         var (builder, _) = CreateBuilder();
 
@@ -227,9 +292,14 @@ public class IUmbracoBuilderExtensionsTests
             builder.AddEntraIdAuthentication((IConfigurationSection)null));
     }
 
+    /// <summary>
+    /// Given a null Umbraco builder.
+    /// When AddEntraIdAuthentication is called with a configuration section.
+    /// Then an ArgumentNullException is thrown.
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void AddEntraIdAuthentication_WithConfigSection_NullBuilder_ThrowsArgumentNullException()
+    public void AddEntraIdAuthenticationWithConfigSectionNullBuilderThrowsArgumentNullException()
     {
         IUmbracoBuilder nullBuilder = null;
 

--- a/tests/Asm.Umbraco.Tests/Extensions/IPublishedContentExtensionsTests.cs
+++ b/tests/Asm.Umbraco.Tests/Extensions/IPublishedContentExtensionsTests.cs
@@ -9,9 +9,14 @@ public class IPublishedContentExtensionsTests
     // NameAsCssClass
     // -----------------------------------------------------------------------
 
+    /// <summary>
+    /// Given published content whose Name contains a space and mixed case
+    /// When NameAsCssClass is called
+    /// Then a lowercase, hyphen-separated CSS class name is returned
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void NameAsCssClass_ReturnsLowercaseHyphenSeparatedName()
+    public void NameAsCssClassReturnsLowercaseHyphenSeparatedName()
     {
         var contentMock = new Mock<IPublishedContent>();
         contentMock.Setup(c => c.Name).Returns("Hello World");
@@ -21,18 +26,28 @@ public class IPublishedContentExtensionsTests
         Assert.Equal("hello-world", result);
     }
 
+    /// <summary>
+    /// Given a null IPublishedContent reference
+    /// When NameAsCssClass is called
+    /// Then null is returned
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void NameAsCssClass_WhenNullContent_ReturnsNull()
+    public void NameAsCssClassReturnsNullWhenContentIsNull()
     {
         IPublishedContent content = null;
         var result = content.NameAsCssClass();
         Assert.Null(result);
     }
 
+    /// <summary>
+    /// Given published content whose Name contains multiple spaces
+    /// When NameAsCssClass is called
+    /// Then each space is replaced with a hyphen in the returned CSS class name
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void NameAsCssClass_MultipleSpaces_ReplacesEachWithHyphen()
+    public void NameAsCssClassReplacesMultipleSpacesEachWithHyphen()
     {
         var contentMock = new Mock<IPublishedContent>();
         contentMock.Setup(c => c.Name).Returns("One Two Three");
@@ -42,9 +57,14 @@ public class IPublishedContentExtensionsTests
         Assert.Equal("one-two-three", result);
     }
 
+    /// <summary>
+    /// Given published content whose Name is already lowercase but contains a space
+    /// When NameAsCssClass is called
+    /// Then the name is returned unchanged except that the space is replaced with a hyphen
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void NameAsCssClass_AlreadyLowercase_ReturnsUnchangedExceptSpaces()
+    public void NameAsCssClassLeavesAlreadyLowercaseUnchangedExceptSpaces()
     {
         var contentMock = new Mock<IPublishedContent>();
         contentMock.Setup(c => c.Name).Returns("already lower");

--- a/tests/Asm.Umbraco.Tests/MachineInfo/FixedMachineInfoFactoryOptionsTests.cs
+++ b/tests/Asm.Umbraco.Tests/MachineInfo/FixedMachineInfoFactoryOptionsTests.cs
@@ -4,25 +4,40 @@ namespace Asm.Umbraco.Tests.MachineInfo;
 
 public class FixedMachineInfoFactoryOptionsTests
 {
+    /// <summary>
+    /// Given options created without specifying an environment variable name
+    /// When EnvironmentVariableName is read
+    /// Then it defaults to "MACHINE_NAME"
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void EnvironmentVariableName_DefaultsToMachineName()
+    public void EnvironmentVariableNameDefaultsToMachineName()
     {
         var options = new FixedMachineInfoFactoryOptions { MachineName = "test-machine" };
         Assert.Equal("MACHINE_NAME", options.EnvironmentVariableName);
     }
 
+    /// <summary>
+    /// Given options with MachineName set to a value
+    /// When MachineName is read back
+    /// Then it returns the value that was assigned
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void MachineName_RoundTrip()
+    public void MachineNameRoundTrips()
     {
         var options = new FixedMachineInfoFactoryOptions { MachineName = "my-server" };
         Assert.Equal("my-server", options.MachineName);
     }
 
+    /// <summary>
+    /// Given options that explicitly set EnvironmentVariableName
+    /// When EnvironmentVariableName is read back
+    /// Then it returns the overridden value rather than the default
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void EnvironmentVariableName_CanBeOverridden()
+    public void EnvironmentVariableNameCanBeOverridden()
     {
         var options = new FixedMachineInfoFactoryOptions
         {

--- a/tests/Asm.Umbraco.Tests/MachineInfo/FixedMachineInfoFactoryTests.cs
+++ b/tests/Asm.Umbraco.Tests/MachineInfo/FixedMachineInfoFactoryTests.cs
@@ -28,9 +28,14 @@ public class FixedMachineInfoFactoryTests : IDisposable
         Environment.SetEnvironmentVariable(CustomEnvVar, null);
     }
 
+    /// <summary>
+    /// Given the configured environment variable is set
+    /// When GetMachineIdentifier is called
+    /// Then the environment variable value is returned in preference to the fallback machine name
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void GetMachineIdentifier_WhenEnvVarSet_ReturnsEnvVarValue()
+    public void GetMachineIdentifierReturnsEnvVarValueWhenEnvVarSet()
     {
         Environment.SetEnvironmentVariable(TestEnvVar, "env-machine-name");
 
@@ -40,9 +45,14 @@ public class FixedMachineInfoFactoryTests : IDisposable
         Assert.Equal("env-machine-name", factory.GetMachineIdentifier());
     }
 
+    /// <summary>
+    /// Given the configured environment variable is not set
+    /// When GetMachineIdentifier is called
+    /// Then the fallback machine name from options is returned
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void GetMachineIdentifier_WhenEnvVarNotSet_ReturnsFallbackMachineName()
+    public void GetMachineIdentifierReturnsFallbackMachineNameWhenEnvVarNotSet()
     {
         Environment.SetEnvironmentVariable(TestEnvVar, null);
 
@@ -52,9 +62,14 @@ public class FixedMachineInfoFactoryTests : IDisposable
         Assert.Equal("fallback-name", factory.GetMachineIdentifier());
     }
 
+    /// <summary>
+    /// Given options specify a custom environment variable name that is set
+    /// When GetMachineIdentifier is called
+    /// Then the value of the custom environment variable is returned
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void GetMachineIdentifier_WhenCustomEnvVarSet_ReturnsCustomEnvVarValue()
+    public void GetMachineIdentifierReturnsCustomEnvVarValueWhenCustomEnvVarSet()
     {
         Environment.SetEnvironmentVariable(CustomEnvVar, "custom-env-machine");
 
@@ -68,9 +83,14 @@ public class FixedMachineInfoFactoryTests : IDisposable
         Assert.Equal("custom-env-machine", factory.GetMachineIdentifier());
     }
 
+    /// <summary>
+    /// Given a factory built with a discriminator and machine name options
+    /// When GetLocalIdentity is called
+    /// Then the returned identity contains the discriminator, process id prefix, domain id prefix and a GUID segment
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void GetLocalIdentity_ContainsMachineNameDiscriminatorProcessIdDomainIdAndGuid()
+    public void GetLocalIdentityContainsDiscriminatorProcessIdDomainIdAndGuid()
     {
         var options = Options.Create(new FixedMachineInfoFactoryOptions { MachineName = "test-machine" });
         var factory = new FixedMachineInfoFactory(_discriminatorMock.Object, options);
@@ -83,9 +103,14 @@ public class FixedMachineInfoFactoryTests : IDisposable
         Assert.Matches(@"[0-9A-F]{32}", identity);              // GUID segment (N format, uppercased)
     }
 
+    /// <summary>
+    /// Given a single factory instance
+    /// When GetLocalIdentity is called more than once
+    /// Then the same identity value is returned on every call
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void GetLocalIdentity_ReturnsSameValueOnMultipleCalls()
+    public void GetLocalIdentityReturnsSameValueOnMultipleCalls()
     {
         var options = Options.Create(new FixedMachineInfoFactoryOptions { MachineName = "test-machine" });
         var factory = new FixedMachineInfoFactory(_discriminatorMock.Object, options);

--- a/tests/Asm.Umbraco.Tests/MachineInfo/IUmbracoBuilderExtensionsTests.cs
+++ b/tests/Asm.Umbraco.Tests/MachineInfo/IUmbracoBuilderExtensionsTests.cs
@@ -17,9 +17,14 @@ public class IUmbracoBuilderExtensionsTests
         return (builderMock.Object, services);
     }
 
+    /// <summary>
+    /// Given an Umbraco builder
+    /// When AddFixedMachineInfoFactory is called with a configuration action
+    /// Then a service descriptor mapping IMachineInfoFactory to FixedMachineInfoFactory is registered
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void AddFixedMachineInfoFactory_WithActionConfigure_RegistersIMachineInfoFactory()
+    public void AddFixedMachineInfoFactoryWithActionConfigureRegistersMachineInfoFactory()
     {
         var (builder, services) = CreateBuilder();
 
@@ -35,9 +40,14 @@ public class IUmbracoBuilderExtensionsTests
             sd.ImplementationType == typeof(FixedMachineInfoFactory));
     }
 
+    /// <summary>
+    /// Given an Umbraco builder
+    /// When AddFixedMachineInfoFactory is called with a configuration action that sets options
+    /// Then the resolved FixedMachineInfoFactoryOptions reflect the configured values
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void AddFixedMachineInfoFactory_WithActionConfigure_BindsOptions()
+    public void AddFixedMachineInfoFactoryWithActionConfigureBindsOptions()
     {
         var (builder, services) = CreateBuilder();
 
@@ -53,9 +63,14 @@ public class IUmbracoBuilderExtensionsTests
         Assert.Equal("CUSTOM_VAR", options.Value.EnvironmentVariableName);
     }
 
+    /// <summary>
+    /// Given an Umbraco builder
+    /// When AddFixedMachineInfoFactory is called with a configuration action
+    /// Then the same builder instance is returned to allow fluent chaining
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void AddFixedMachineInfoFactory_WithActionConfigure_ReturnsBuilder()
+    public void AddFixedMachineInfoFactoryWithActionConfigureReturnsBuilder()
     {
         var (builder, _) = CreateBuilder();
 
@@ -64,9 +79,14 @@ public class IUmbracoBuilderExtensionsTests
         Assert.Same(builder, returned);
     }
 
+    /// <summary>
+    /// Given an Umbraco builder
+    /// When AddFixedMachineInfoFactory is called with a configuration section
+    /// Then a service descriptor mapping IMachineInfoFactory to FixedMachineInfoFactory is registered
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void AddFixedMachineInfoFactory_WithConfigSection_RegistersIMachineInfoFactory()
+    public void AddFixedMachineInfoFactoryWithConfigSectionRegistersMachineInfoFactory()
     {
         var (builder, services) = CreateBuilder();
 
@@ -85,9 +105,14 @@ public class IUmbracoBuilderExtensionsTests
             sd.ImplementationType == typeof(FixedMachineInfoFactory));
     }
 
+    /// <summary>
+    /// Given an Umbraco builder and a configuration section with machine info values
+    /// When AddFixedMachineInfoFactory is called with that section
+    /// Then the resolved FixedMachineInfoFactoryOptions are bound from the section values
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void AddFixedMachineInfoFactory_WithConfigSection_BindsOptions()
+    public void AddFixedMachineInfoFactoryWithConfigSectionBindsOptions()
     {
         var (builder, services) = CreateBuilder();
 
@@ -107,9 +132,14 @@ public class IUmbracoBuilderExtensionsTests
         Assert.Equal("SECTION_VAR", options.Value.EnvironmentVariableName);
     }
 
+    /// <summary>
+    /// Given an Umbraco builder
+    /// When AddFixedMachineInfoFactory is called with a configuration section
+    /// Then the same builder instance is returned to allow fluent chaining
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void AddFixedMachineInfoFactory_WithConfigSection_ReturnsBuilder()
+    public void AddFixedMachineInfoFactoryWithConfigSectionReturnsBuilder()
     {
         var (builder, _) = CreateBuilder();
 
@@ -122,18 +152,28 @@ public class IUmbracoBuilderExtensionsTests
         Assert.Same(builder, returned);
     }
 
+    /// <summary>
+    /// Given a null Umbraco builder
+    /// When AddFixedMachineInfoFactory is called with a configuration action
+    /// Then an ArgumentNullException is thrown
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void AddFixedMachineInfoFactory_NullBuilder_ThrowsArgumentNullException()
+    public void AddFixedMachineInfoFactoryWithNullBuilderThrowsArgumentNullException()
     {
         IUmbracoBuilder nullBuilder = null;
         Assert.Throws<ArgumentNullException>(() =>
             nullBuilder.AddFixedMachineInfoFactory(opts => opts.MachineName = "x"));
     }
 
+    /// <summary>
+    /// Given a valid Umbraco builder but a null configuration action
+    /// When AddFixedMachineInfoFactory is called
+    /// Then an ArgumentNullException is thrown
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void AddFixedMachineInfoFactory_NullConfigure_ThrowsArgumentNullException()
+    public void AddFixedMachineInfoFactoryWithNullConfigureThrowsArgumentNullException()
     {
         var (builder, _) = CreateBuilder();
         Assert.Throws<ArgumentNullException>(() =>

--- a/tests/Asm.Umbraco.Tests/TagHelpers/ImgSetTagHelperHelpersTests.cs
+++ b/tests/Asm.Umbraco.Tests/TagHelpers/ImgSetTagHelperHelpersTests.cs
@@ -5,9 +5,14 @@ namespace Asm.Umbraco.Tests.TagHelpers;
 
 public class ImgSetTagHelperHelpersTests
 {
+    /// <summary>
+    /// Given the current culture uses a comma decimal separator (de-DE)
+    /// When FormatSrcsetEntry formats a fractional density descriptor
+    /// Then the density is rendered with a dot separator using the invariant culture ("1.5x")
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void FormatSrcsetEntry_UsesInvariantCulture()
+    public void FormatSrcsetEntryUsesInvariantCulture()
     {
         var previous = CultureInfo.CurrentCulture;
         try
@@ -25,9 +30,14 @@ public class ImgSetTagHelperHelpersTests
         }
     }
 
+    /// <summary>
+    /// Given a media URL that includes a query string
+    /// When ToPhysicalPath converts it to a physical path
+    /// Then the query string is removed and the path ends with the media file name
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void ToPhysicalPath_StripsQueryString()
+    public void ToPhysicalPathStripsQueryString()
     {
         var path = ImgSetTagHelper.ToPhysicalPath("/wwwroot", "/media/pic.jpg?width=100");
 
@@ -35,9 +45,14 @@ public class ImgSetTagHelperHelpersTests
         Assert.EndsWith($"media{Path.DirectorySeparatorChar}pic.jpg", path);
     }
 
+    /// <summary>
+    /// Given a root-relative media URL and a web root path
+    /// When ToPhysicalPath converts it to a physical path
+    /// Then the URL is combined under the web root rather than replacing it
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void ToPhysicalPath_RootRelativeUrl_CombinesUnderWebRoot()
+    public void ToPhysicalPathCombinesRootRelativeUrlUnderWebRoot()
     {
         // A rooted media URL must resolve under the web root, not replace it.
         var webRoot = Path.Combine("app", "wwwroot");
@@ -47,9 +62,14 @@ public class ImgSetTagHelperHelpersTests
         Assert.EndsWith($"media{Path.DirectorySeparatorChar}pic.jpg", path);
     }
 
+    /// <summary>
+    /// Given a URL consisting only of a query string
+    /// When ToPhysicalPath converts it to a physical path
+    /// Then the query string is stripped from the result
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void ToPhysicalPath_QueryAtStart_IsStripped()
+    public void ToPhysicalPathStripsQueryAtStart()
     {
         var path = ImgSetTagHelper.ToPhysicalPath("/wwwroot", "?x=1");
 

--- a/tests/Asm.Umbraco.Tests/TagHelpers/ImgSetTagHelperTests.cs
+++ b/tests/Asm.Umbraco.Tests/TagHelpers/ImgSetTagHelperTests.cs
@@ -48,9 +48,14 @@ public class ImgSetTagHelperTests
         return helper;
     }
 
+    /// <summary>
+    /// Given an ImgSetTagHelper whose Images collection is null
+    /// When Process is invoked
+    /// Then the output is suppressed (TagName is set to null)
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Process_WhenImagesIsNull_SuppressesOutput()
+    public void ProcessSuppressesOutputWhenImagesIsNull()
     {
         var helper = CreateTagHelper();
         helper.Images = null;
@@ -62,9 +67,14 @@ public class ImgSetTagHelperTests
         Assert.Null(output.TagName);
     }
 
+    /// <summary>
+    /// Given an ImgSetTagHelper whose Images collection is empty
+    /// When Process is invoked
+    /// Then FirstOrDefault returns null and the output is suppressed (TagName is set to null)
+    /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public void Process_WhenImagesIsEmpty_SuppressesOutput()
+    public void ProcessSuppressesOutputWhenImagesIsEmpty()
     {
         var helper = CreateTagHelper(images: []);
 


### PR DESCRIPTION
## Summary

Enforces the maintainer's xUnit test conventions across the in-scope test projects:

- **Method names** renamed from snake_case / `Method_Scenario_Expected` (underscore-separated) to idiomatic **underscore-free PascalCase**. Meaningless names (e.g. `NegaTest`/`PosiTest`, `EncodingTest`) were given descriptive PascalCase names reflecting what the body asserts.
- **Given/When/Then `<summary>`** added to every `[Fact]`/`[Theory]` test method, accurate to the assertions in the body.

## Scope

- **125 test methods** renamed and documented across 21 files in: `Asm.Tests` (30), `Asm.Umbraco.Authentication.Tests` (52), `Asm.Umbraco.Tests` (26), `Asm.Cqrs.Tests` (5), `Asm.OAuth.Tests` (5), `Asm.Testing.Domain.Tests` (5), `Asm.AspNetCore.Mvc.Tests` (2).
- **Excluded** (other work in flight): `Asm.Domain.Tests`, `Asm.Domain.Infrastructure.Tests`, `Asm.AspNetCore.Tests`.
- Reqnroll `[Binding]` step classes left untouched.

## Safety

Behaviour-preserving only: no assertions, test logic, attributes, or `[InlineData]`/`[MemberData]` values changed. `[MemberData]` data-source members and helpers were not renamed.

`dotnet test Asm.slnx -c Release` — all tests pass (unchanged counts), zero new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
