### PR TITLE
Release versioning: branch-name/anchor-tag model, publish from release/**

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,10 +3,8 @@ name: Build and Publish
 on:
   push:
     branches:
-      - "main"
+      - "release/**"
   pull_request:
-    branches:
-      - "main"
   workflow_dispatch:
 
 permissions:
@@ -38,21 +36,28 @@ jobs:
     - name: Set version
       id: set-version-number
       run: |
-        if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-          echo "version=${{ steps.gitversion.outputs.major }}.${{ steps.gitversion.outputs.minor }}.${{ steps.gitversion.outputs.commitsSinceVersionSource }}" >> "$GITHUB_OUTPUT"
+        MAJOR="${{ steps.gitversion.outputs.major }}"
+        MINOR="${{ steps.gitversion.outputs.minor }}"
+        COUNT="${{ steps.gitversion.outputs.commitsSinceVersionSource }}"
+        # Patch (stable) / beta counter comes from the commit count since the line's anchor tag.
+        if [[ "${{ github.ref_name }}" == *-beta ]]; then
+          VERSION="$MAJOR.$MINOR.0-beta.$COUNT"
         else
-          echo "version=${{ steps.gitversion.outputs.semVer }}" >> "$GITHUB_OUTPUT"
+          VERSION="$MAJOR.$MINOR.$COUNT"
         fi
-    - run: echo "::notice::Version ${{ steps.set-version-number.outputs.version }}"
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        echo "assemblyVersion=${{ steps.gitversion.outputs.assemblySemVer }}" >> "$GITHUB_OUTPUT"
+        echo "fileVersion=$MAJOR.$MINOR.$COUNT.0" >> "$GITHUB_OUTPUT"
+    - run: echo "::notice::Version ${{ steps.set-version-number.outputs.version }} (assembly ${{ steps.set-version-number.outputs.assemblyVersion }})"
 
     - name: Restore
       run: dotnet restore Asm.slnx
 
     - name: Build
-      run: dotnet build Asm.slnx --no-restore --configuration Release
+      run: dotnet build Asm.slnx --no-restore --configuration Release --p:Version=${{ steps.set-version-number.outputs.version }} --p:AssemblyVersion=${{ steps.set-version-number.outputs.assemblyVersion }} --p:FileVersion=${{ steps.set-version-number.outputs.fileVersion }} --p:InformationalVersion=${{ steps.set-version-number.outputs.version }}
 
     - name: Package
-      run: dotnet pack Asm.slnx --no-restore --no-build -o ${{ github.workspace }}/publish --configuration Release --p:Version=${{ steps.set-version-number.outputs.version }} --p:FileVersion=${{ steps.set-version-number.outputs.version }}
+      run: dotnet pack Asm.slnx --no-restore --no-build -o ${{ github.workspace }}/publish --configuration Release --p:Version=${{ steps.set-version-number.outputs.version }}
 
     - name: Upload build artifacts
       uses: actions/upload-artifact@v7.0.1
@@ -158,7 +163,7 @@ jobs:
     permissions:
       packages: write
       contents: read
-    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && startsWith(github.ref, 'refs/heads/release/')
     steps:
     - name: Download packages
       uses: actions/download-artifact@v8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,71 @@
+name: Release
+
+# Deliberately starts or graduates a version line. Everything else (patches) is automatic:
+# a push to a release branch publishes the next patch (see build.yml).
+#
+# Each line is anchored by an empty "Start X.Y" commit on its own branch, tagged X.Y.0. Because the
+# tag lives on a commit unique to that branch, other lines never see it, so lines are fully isolated
+# (a 5.0 beta can run alongside the 4.x stable line without disturbing it). GitVersion then reads
+# Major.Minor from the tag and CommitsSinceVersionSource as the patch/beta counter.
+#
+#   start-beta   -> branch release/X.Y-beta + anchor -> publishes X.Y.0-beta.N (default unchanged)
+#   start-stable -> branch release/X.Y + anchor + make default -> publishes X.Y.x (a new minor line)
+#   graduate     -> rename release/X.Y-beta -> release/X.Y + make default (anchor already on the branch)
+#
+# Requires a repo secret RELEASE_TOKEN: a PAT (or GitHub App token) with admin, because the stock
+# GITHUB_TOKEN cannot rename a branch or change the repository default branch.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Major.Minor to act on, e.g. 5.0"
+        required: true
+        type: string
+      action:
+        description: "Operation"
+        required: true
+        type: choice
+        options:
+          - start-beta
+          - start-stable
+          - graduate
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+      REPO: ${{ github.repository }}
+      V: ${{ inputs.version }}
+    steps:
+      - uses: actions/checkout@v7.0.0
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Start a new line (branch + anchor commit + tag)
+        if: inputs.action == 'start-beta' || inputs.action == 'start-stable'
+        run: |
+          if [ "${{ inputs.action }}" = "start-beta" ]; then BRANCH="release/$V-beta"; else BRANCH="release/$V"; fi
+          git checkout -b "$BRANCH"
+          git commit --allow-empty -m "Start $V"
+          git tag "$V.0"
+          git push origin "$BRANCH" "$V.0"
+          echo "::notice::Created $BRANCH anchored at $V.0."
+
+      - name: Make the new stable line the default
+        if: inputs.action == 'start-stable'
+        run: gh api -X PATCH "repos/$REPO" -f default_branch="release/$V"
+
+      - name: Graduate beta to stable and make default
+        if: inputs.action == 'graduate'
+        run: |
+          gh api -X POST "repos/$REPO/branches/release%2F$V-beta/rename" -f new_name="release/$V"
+          gh api -X PATCH "repos/$REPO" -f default_branch="release/$V"
+          echo "::notice::Renamed release/$V-beta -> release/$V and set it as the default branch."

--- a/.gitignore
+++ b/.gitignore
@@ -331,3 +331,6 @@ ASALocalRun/
 
 *.ignore/
 /.claude/settings.local.json
+
+# Agent worktrees
+.claude/worktrees/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,8 @@
     <Authors>Andrew McLachlan</Authors>
     <Company />
     <Copyright>© 2011-$([System.DateTime]::Now.Year) Andrew McLachlan</Copyright>
-    <AssemblyVersion>3.0.0.0</AssemblyVersion>
+    <!-- Version, AssemblyVersion (pinned to Major.0.0.0) and FileVersion are supplied by CI
+         from GitVersion (see .github/workflows/build.yml). Local builds default to 0.0.0/1.0.0. -->
   </PropertyGroup>
 
 

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,8 +1,25 @@
+# Versions are anchored by a per-line tag X.Y.0 that the Release workflow creates when it cuts a
+# release line (see .github/workflows/release.yml). GitVersion then gives Major.Minor from that tag
+# and CommitsSinceVersionSource as the patch/beta counter (which resets per line, because each line
+# gets its own anchor tag). build.yml assembles the final version:
+#   release/X.Y       -> X.Y.<commits>            stable, published
+#   release/X.Y-beta  -> X.Y.0-beta.<commits>     prerelease, published
+#   main / feature/*  -> prerelease, never published (publishing is gated to release/** in CI)
+#
+# AssemblyVersion is pinned to <Major>.0.0.0 (Major scheme) so there are no binding redirects
+# within a major line.
 workflow: GitHubFlow/v1
-next-version: 4.0.0
+
+assembly-versioning-scheme: Major
+
 branches:
-  main:
-    is-main-branch: true
+  release:
+    regex: ^releases?[/-]v?\d+\.\d+(-beta)?$
+    label: ''
+    increment: Patch
     mode: ContinuousDeployment
+    is-release-branch: true
+  main:
+    label: ci
   feature:
-    label: beta
+    label: alpha

--- a/docs/release-branching-strategy.md
+++ b/docs/release-branching-strategy.md
@@ -1,0 +1,154 @@
+# Release Branching & Versioning Strategy (Proposal)
+
+> **Status:** agreed design for **ASM**, not yet implemented. Intended to also form the
+> basis of the equivalent overhaul for **MooApp**, so the two share one strategy.
+
+## Context
+
+ASM publishes NuGet packages to GitHub Packages from CI. Today the workflow **publishes on
+every push to `main`** (`build.yml` publish job `if: … github.ref == 'refs/heads/main'`), and
+the version is *inferred from timing* — `major.minor.commitsSinceVersionSource`, with
+`major.minor` floored by a hardcoded `next-version` in `GitVersion.yml`. GitVersion has **no
+`release` branch type** configured.
+
+Problems this causes:
+
+- A routine merge to `main` can publish a **mislabelled** version (e.g. a breaking change
+  shipping as `3.7.x`), because nothing ties the version to intent.
+- Cutting a new major/minor requires fragile manual tag/bump choreography (a tag must exist on
+  `main`'s HEAD *before* the triggering push, or a wrong version ships).
+- `AssemblyVersion` is hardcoded and stale (`3.0.0.0`), independent of the package version.
+
+### Goals
+
+- Semantic Versioning (`Major.Minor.Patch`).
+- **Major/Minor chosen deliberately** by the developer (by creating a release branch).
+- **Patch increments automatically** for every change.
+- No ever-increasing build numbers; no "empty" version-bump publishes.
+- The correct major/minor exists **before** new functionality is published.
+- **One supported version at a time** (older lines are not maintained) — which lets the model
+  collapse to a single trunk.
+- Routine flow (patches, Dependabot) is **fully automatic with zero config to maintain**.
+
+## Target model — the release branch *is* the trunk
+
+- The **current release branch `release/X.Y`** (no `v` prefix) is the **repository default
+  branch** and the trunk: PRs and Dependabot land there (default → zero Dependabot config), CI
+  runs there, and each push publishes stable `X.Y.<patch>`. **There is no separate long-lived
+  `main`.**
+- **Each release line is anchored by a tag `X.Y.0`** on an empty "Start X.Y" commit *unique to its
+  branch* (created by the Release workflow). GitVersion reads **Major.Minor from that anchor tag**
+  and the **patch/beta counter from the commit count since it** (`CommitsSinceVersionSource`), which
+  resets per line. Because the anchor commit exists only on its own branch, **lines are isolated** —
+  a `5.0` beta never affects the live `4.x` line, even while both receive commits. (GitVersion cannot
+  derive a rolling version from a two-part `release/X.Y` name; only a tag / `next-version` / full
+  `X.Y.Z` name seeds it — verified against the GitVersion docs and locally.)
+- **Only `release/**` branches publish.** PRs run CI (build + test) but never publish.
+
+| Branch | Version produced | Publishes | Default branch |
+|---|---|---|---|
+| `release/4.0` | `4.0.x` stable | ✅ | ✅ (current) |
+| `release/5.0-beta` | `5.0.0-beta.N` (prerelease) | ✅ (prerelease) | ❌ |
+| `release/5.0` (after graduation) | `5.0.x` stable | ✅ | ✅ (new) |
+| `feature/*`, PRs | CI prerelease (unpublished) | ❌ | ❌ |
+
+**Cutting a new minor** (non-breaking, e.g. 5.1): create `release/5.1`, flip the default branch
+→ publishes `5.1.x`.
+
+**Cutting a new major** (breaking, e.g. 5.0): create `release/5.0-beta` → publishes
+`5.0.0-beta.N` while you iterate (stable `4.0` consumers unaffected). When ready, a **"Release"
+workflow** renames `release/5.0-beta` → `release/5.0` (GitHub rename-branch API, which
+auto-retargets open PRs) **and sets it as the default branch** → publishes stable `5.0.0`;
+`release/4.0` retired.
+
+The only deliberate acts are **creating the next branch and flipping the default** — i.e. the
+"choose major/minor deliberately" step, which is rare. Everything routine is automatic.
+
+## Changes
+
+### 1. `GitVersion.yml` — anchor-tag versioning
+
+- A single `release` branch type matching `release/X.Y` and `release/X.Y-beta`
+  (`^releases?[/-]v?\d+\.\d+(-beta)?$`), `mode: ContinuousDeployment`, `is-release-branch: true`,
+  `increment: Patch`, `label: ''`. Major.Minor comes from the per-line anchor tag, not the name.
+- `assembly-versioning-scheme: Major` → `AssemblyVersion` = `X.0.0.0`.
+- **No `next-version`** (anchor tags supersede it).
+- Verified locally with `dotnet-gitversion` across `release/4.0`, `release/5.0-beta`, `feature/*`.
+
+### 2. `.github/workflows/build.yml`
+
+- **Triggers:** `push: branches: ['release/**']` (the publish path) + `pull_request` (CI only) +
+  `workflow_dispatch`. Drop the `main`-only push trigger.
+- **Version step:** derive from GitVersion (`majorMinorPatch`, or `semVer` for prerelease
+  branches) instead of the `main`-conditional formatting.
+- **Publish job `if:`** → `startsWith(github.ref, 'refs/heads/release/')`. Publishes stable from
+  `release/X.Y` and prereleases from `release/X.Y-beta`; PRs never publish.
+- **Pack step:** add `--p:AssemblyVersion=<major>.0.0.0` (from the GitVersion `major` output) —
+  pins the binding version per major line.
+
+### 3. `.github/dependabot.yml`
+
+- **No change.** Leave `target-branch` unset so it follows the repo default branch — which,
+  after the transition, is `release/4.0`, and moves automatically whenever the "Release"
+  workflow flips the default.
+
+### 4. `Directory.Build.props`
+
+- Remove the hardcoded `<AssemblyVersion>3.0.0.0</AssemblyVersion>` (now supplied at pack time
+  as `<major>.0.0.0`); optionally keep a local-dev fallback.
+
+### 5. New `.github/workflows/release.yml` (workflow_dispatch)
+
+A one-click "start/graduate a version" workflow so there is **no manual git**. Inputs: `version`
+(e.g. `5.0`) and `action`:
+
+- **`start-beta`:** branch `release/X.Y-beta` from the current default, add an empty `Start X.Y`
+  commit, tag it `X.Y.0`, push both → publishes `X.Y.0-beta.N`. Default **unchanged** (the beta runs
+  alongside the current stable line).
+- **`start-stable`:** same, on `release/X.Y`, and set it as the default branch (a new minor line).
+- **`graduate`:** rename `release/X.Y-beta` → `release/X.Y` (GitHub rename-branch API) and set it as
+  the default branch. The anchor tag is already on the branch, so versioning continues as `X.Y.N`.
+- **Auth:** rename + default-branch change need a **PAT or GitHub App token** in a `RELEASE_TOKEN`
+  secret (the stock `GITHUB_TOKEN` cannot do either).
+
+## Transition (current ASM state → new model)
+
+Current state: `main` is behind; all v4 work **and the open v4 PRs** live on `release/v4.0`.
+
+1. Merge the open v4 PRs into `release/v4.0` (done — #417/#420/#421 merged).
+2. Land the config changes above on `release/v4.0` (this PR).
+3. **Rename `release/v4.0` → `release/4.0`** (drop the `v`; GitHub rename-branch API retargets any
+   PRs).
+4. **Anchor the 4.0 line:** add an empty `Start 4.0` commit at the tip of `release/4.0` and tag it
+   `4.0.0`, so the line versions from `4.0.0` (the first push publishes `4.0.1`, etc.). This is the
+   one-off manual equivalent of what `release.yml`'s `start-*` does for future lines.
+5. **Set `release/4.0` as the repository default branch.**
+6. Add the `RELEASE_TOKEN` secret (PAT/App token) used by `release.yml`.
+7. **Retire `main`** — delete it (recommended; `release/4.0` is a strict superset), or keep it as a
+   non-default, unused branch.
+8. Thereafter, pushes to `release/4.0` publish the **`4.0.x` stable line**; new majors/minors use
+   the `release.yml` workflow.
+
+## Verification
+
+- Run `dotnet-gitversion` locally on `release/4.0` and a throwaway `release/5.0-beta`; confirm
+  `4.0.x` stable and `5.0.0-beta.N`, and that `feature/*` produces an unpublished prerelease.
+- On a scratch branch, dry-run `build.yml`: a **PR builds+tests but does not publish**; a **push
+  to `release/**` publishes**; a push to `release/5.0-beta` publishes a **prerelease**.
+- Confirm Dependabot raises PRs against the default branch after the flip (no `target-branch`).
+- Confirm the `release.yml` token can change `default_branch` and rename a branch.
+- Confirm packed `AssemblyVersion` = `<major>.0.0.0`.
+
+## Open decisions
+
+- **`main`:** delete it (recommended) vs keep a vestigial, unused branch.
+- **Prerelease label wording:** `-beta` (recommended) vs `-preview` / `-rc`.
+- **Graduation mechanism:** GitHub rename-branch API (recommended — atomic, retargets PRs) vs
+  create-new + delete-old.
+
+## Applicability to MooApp
+
+MooApp is a separate repo but shares the same publish-from-CI shape. The same strategy applies
+directly; the MooApp-specific work is: the transition steps against its current branches, its
+`GitVersion.yml`/workflow files, and confirming its Dependabot/default-branch setup. Design this
+ASM version first as the proving ground, then mirror it.


### PR DESCRIPTION
Implements the release-branch versioning overhaul (`docs/release-branching-strategy.md`). **Config only — do not merge until the go-live sequence below is followed**, or it will publish a wrong version.

## What this does
- **`GitVersion.yml`** — anchor-tag model: `Major.Minor` from a per-line tag `X.Y.0`, patch/beta counter from `CommitsSinceVersionSource` (resets per line). `AssemblyVersion` pinned to `X.0.0.0`. No `next-version`.
- **`build.yml`** — triggers on `release/**` pushes; **publishes only from `release/**`** (never `main`); PRs run CI without publishing. Version assembled as `X.Y.<count>` (stable) or `X.Y.0-beta.<count>` (beta, detected from branch name); `AssemblyVersion`/`FileVersion` stamped at build time.
- **`release.yml`** (new) — `workflow_dispatch` to `start-beta` / `start-stable` / `graduate` a line. Each `start` makes an empty `Start X.Y` commit on the new branch, tags it `X.Y.0` (so lines are isolated), and pushes. Needs a `RELEASE_TOKEN` secret (PAT/App token with admin).
- **`Directory.Build.props`** — drops the stale hardcoded `AssemblyVersion 3.0.0.0`.

## Verified
GitVersion 6.5.1 locally (clean clone), confirming: `release/4.0` → `4.0.x`, `release/5.0-beta` → `5.0.0-beta.N`, graduate → `5.0.N`, and that a beta line's anchor tag does **not** poison the live `4.x` line (anchor sits on a branch-unique commit). Also confirmed against the GitVersion docs that a two-part `release/X.Y` name alone cannot seed the version — hence the anchor tag.

## ⚠️ Go-live ordering (critical)
Merging this activates the new `build.yml`; a push to a `release/**` branch with **no `X.Y.0` anchor tag** would compute `3.7.x` from the old `v3.7.0` tag and publish it. So:
1. On `release/v4.0` (old `build.yml`, won't publish): add an empty `Start 4.0` commit and tag it `4.0.0`.
2. Rename `release/v4.0` → `release/4.0`.
3. Merge this PR into `release/4.0` → first publish is `4.0.1` (correct).
4. Set `release/4.0` as the default branch; add the `RELEASE_TOKEN` secret; retire `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
