### PR TITLE
feat: promote reusable infrastructure from MooBank (Tier 1)

### DIFF
--- a/Asm.slnx
+++ b/Asm.slnx
@@ -32,6 +32,9 @@
   </Folder>
   <Folder Name="/Tests/">
     <File Path="tests/Directory.Build.props" />
+    <Project Path="tests/Asm.AspNetCore.Api.Tests/Asm.AspNetCore.Api.Tests.csproj">
+      <BuildType Solution="Release 64|*" Project="Debug" />
+    </Project>
     <Project Path="tests/Asm.AspNetCore.Modules.Tests/Asm.AspNetCore.Modules.Tests.csproj">
       <BuildType Solution="Release 64|*" Project="Release" />
     </Project>
@@ -52,6 +55,9 @@
     </Project>
     <Project Path="tests/Asm.Domain.Tests/Asm.Domain.Tests.csproj">
       <BuildType Solution="Release 64|*" Project="Release" />
+    </Project>
+    <Project Path="tests/Asm.Hosting.Tests/Asm.Hosting.Tests.csproj">
+      <BuildType Solution="Release 64|*" Project="Debug" />
     </Project>
     <Project Path="tests/Asm.Net.Tests/Asm.Net.Tests.csproj">
       <BuildType Solution="Release 64|*" Project="Release" />

--- a/docs/reusable-code-promotion.md
+++ b/docs/reusable-code-promotion.md
@@ -1,0 +1,107 @@
+# Promoting reusable code from MooBank
+
+Tracking the promotion of genuinely reusable infrastructure that the MooBank application had to
+build because ASM lacked it. Driven by MooBank issue
+[#886 "Promote Reusable code to ASM library"](https://github.com/AndrewMcLachlan/MooBank/issues/886).
+
+Each candidate below was cross-checked against ASM to confirm it is a real gap (not already provided).
+Anything coupled to MooBank's domain (accounts, transactions, budgets, instruments, families, tags) is
+deliberately excluded and stays in MooBank.
+
+## Promoted in this branch (Tier 1)
+
+Self-contained, low-risk extractions with no design decisions. All ship with tests.
+
+| Item | New API | Project |
+|------|---------|---------|
+| Nullable→`required` schema transformer | `OpenApiOptions.AddRequiredForNonNullableProperties()` (`RequiredForNonNullableSchemaTransformer`) | `Asm.AspNetCore.Api` |
+| `[DisplayName]` schema reference IDs | `OpenApiOptions.UseDisplayNameSchemaReferenceIds()` (`DisplayNameSchemaReferenceIds`) | `Asm.AspNetCore.Api` |
+| Relocate `/api` prefix to a relative server | `OpenApiOptions.RelocatePathPrefixToServer(prefix)` (`ServerPathPrefixDocumentTransformer`) | `Asm.AspNetCore.Api` |
+| Document title + version-from-assembly | `OpenApiOptions.AddDocumentInfo(title, assembly?)` (`DocumentInfoTransformer`) | `Asm.AspNetCore.Api` |
+| Generic background work queue | `IBackgroundWorkQueue<T>` / `BackgroundWorkQueue<T>` + `IServiceCollection.AddBackgroundWorkQueue<T>()` | `Asm.Hosting` |
+| Generic queued hosted worker | `QueuedHostedService<T>` (abstract; override `ProcessAsync`) | `Asm.Hosting` |
+| Month-boundary date extensions | `DateOnly`/`DateTime` `ToStartOfMonth()` / `ToEndOfMonth()` | `Asm` |
+| Sequential async projection | `IEnumerable<T>.SelectAsync(selector)` | `Asm` |
+
+New extension methods use the C# `extension { }` member syntax, matching the repo's existing style
+(`System.DateOnly.cs`).
+
+**Dropped from Tier 1 with cause:** MooBank's OpenAPI "sort tags" transformer was a **no-op** — it
+re-added already-present tags to a `HashSet`, which never reorders anything. Rather than promote a
+no-op (or a fragile sort over an unordered set), it was omitted. If tag ordering is wanted later, it
+needs the document's tag collection to be genuinely ordered first.
+
+### MooBank follow-up (issue #886 step 3)
+
+The MooBank-side duplicates (`src/MooBank.Api/Program.cs` OpenAPI block, `src/MooBank/Queues/*` +
+`Services/Background/*`, `src/MooBank/Extensions/DateExtensions.cs`,
+`src/MooBank/EnumerableAsyncExtensions.cs`) can be deleted and replaced with these APIs **once a new
+ASM version carrying this branch is published**. That bump + deletion is a separate MooBank PR.
+
+## Backlog — Tier 2 (high value, needs a small design decision)
+
+### Integration-test auth harness → new `Asm.Testing.AspNetCore` package
+- **From**: `tests/MooBank.Api.Tests/Infrastructure/{TestAuthHandler,MooBankWebApplicationFactory}.cs`
+- **What**: A header-driven fake `AuthenticationHandler` that mints a `ClaimsPrincipal` from `X-Test-*`
+  headers, plus a `WebApplicationFactory` that (a) swaps the SqlServer `DbContext` for in-memory —
+  crucially removing the `IDbContextOptionsConfiguration<T>` descriptor as well as `DbContextOptions`
+  — and (b) rebinds the JwtBearer scheme's `HandlerType` via `PostConfigure<AuthenticationOptions>`
+  so the **real** authorisation requirement handlers still run under test.
+- **Gap**: No `AuthenticationHandler`/`WebApplicationFactory` type anywhere in ASM. `Asm.Testing.Domain`
+  only mocks `DbSet`; `Asm.Testing` is an empty shell.
+- **To promote**: genericise the concrete `MooBankContext` to `TContext`; make the header→claim map and
+  claim-type names injectable; keep MooBank's concrete `TestUser` factories in MooBank.
+- **Effort/risk**: Medium; test-only code, low risk.
+
+### Auth cluster (all hinge on one small ASM addition)
+- **Denial-audit seam (do first)**: a minimal `IAuthorisationAuditor` (or similar) with a no-op default,
+  in `Asm.AspNetCore.Authorisation`. "Audit every authorisation denial once, in one shape" is the
+  cross-cutting concern; the only MooBank-specific part of the signature is the `User`, reducible to
+  `ClaimsPrincipal`/user-id. This seam is what lets the next two promote without dragging MooBank's
+  full `IAuditLogger` along. Note: MooBank's `IAuditLogger` login/import/mutation methods are
+  app-specific and must **not** move — only the denial hook is generic.
+- **Tolerant (non-vetoing) route handler** → `Asm.AspNetCore.Authorisation`. From
+  `src/MooBank.Security/Authorisation/TolerantRouteAuthorisationHandler.cs`. MooBank *forked* ASM's
+  `RouteParamAuthorisationHandler` precisely because it always calls `context.Fail()` on a missing
+  route value; the tolerant variant fails open on absence (letting resource-based handlers decide) and
+  closed on a present-but-invalid value — the same philosophy as ASM's already-generic
+  `OneOfAuthorisationRequirementHandler`. Break two couplings: `User?` → `IPrincipalProvider`/bool, and
+  `IAuditLogger` → the audit seam above.
+- **Auditable `RoleRequirement` + handler** → `Asm.AspNetCore.Authorisation`. From
+  `src/MooBank.Security/Authorisation/{RoleRequirement,RoleAuthorisationHandler}.cs`. "Like
+  `RequireRole` but denials are logged." Gated on the audit seam; without it, it degenerates into plain
+  `RequireRole` and isn't worth promoting. `AdminRequirement` (the concrete subclass) stays in MooBank.
+
+### `IUserIdProvider` + generic settable user provider → `Asm.Security` / `Asm.AspNetCore.Security`
+- **From**: `src/MooBank.Domain/Security/IUserIdProvider.cs`, `src/MooBank/Security/IUserDataProvider.cs`,
+  `src/MooBank.Security/SettableUserDataProvider.cs`.
+- **What**: The "explicitly-set value for background/job processing, else resolve from claims" provider
+  pattern, building on ASM's existing `IPrincipalProvider`. `IUserIdProvider` (`Guid CurrentUserId`) is
+  trivially generic; promote a generic `ISettableUserDataProvider<TUser>` interface + an abstract base
+  with an overridable `MapFromClaims`. The concrete claim URIs and `User` projection stay in MooBank.
+- **Effort/risk**: Medium; independently promotable (no dependency on the audit seam).
+
+## Backlog — Tier 3 (low priority / optional)
+
+- **MCP bearer-forwarding + resource-metadata helper** → `Asm.ModelContextProtocol`. From the
+  `.AddMcp(...)` block in `Program.cs`. A thin wrapper (validate via existing JwtBearer, keep the
+  MCP-owned 401 challenge, advertise protected-resource-metadata); every value is app-specific and
+  becomes a parameter. Main value is capturing the hard-won Entra v2 knowledge in the comments
+  (AADSTS9010010, resource-must-match-URL).
+- **`RequireScope(scope)` authorization helper** → `Asm.AspNetCore` / `Asm.OAuth`. The `scp` /
+  long-form scope-claim splitting from the `MapMcp` policy; only the scope string is app-specific.
+- **Audit-scope logging helper** → `Asm.Logging` / `Asm.Serilog`. A `logger.BeginAuditScope(category)`
+  idiom extracted from `src/MooBank/Audit/AuditLogger.cs`. Low value (one `BeginScope` call); the
+  surrounding `IAuditLogger` is MooBank-domain and stays.
+- **`HexColourConverter` (EF value converter)** → beside `Asm.Drawing.HexColour` (which already lives in
+  ASM), if/when ASM grows an EF value-converter surface. From
+  `src/MooBank.Infrastructure/ValueConverters/HexColourConverter.cs`. Niche.
+
+## Considered and rejected
+
+Domain-bound or already-covered: MooBank's `Security`/`ISecurity` assert-and-audit wrapper, `Policies`
+and policy-builder helpers, `ClaimTypes`, all Instrument/Group/Family/Budget/Tag/Forecast requirements
+and handlers (they correctly derive from ASM's existing bases), `BindHelper.BindWithInstrumentIdAsync`,
+`ExistingTagByIdInterceptor`, `CacheKeys`, hand-rolled entity↔DTO `ToModel()` mappers, `MooBankContext`
+/ repositories / `AuditingUnitOfWork` (built on `Asm.Domain.Infrastructure` bases), the forced-`https`
+middleware (covered by `ForwardedHeaders`), and the `JsonOptions` two-liner.

--- a/src/Asm.AspNetCore.Api/OpenApi/AsmAspNetCoreApiOpenApiOptionsExtensions.cs
+++ b/src/Asm.AspNetCore.Api/OpenApi/AsmAspNetCoreApiOpenApiOptionsExtensions.cs
@@ -1,0 +1,60 @@
+using System.Reflection;
+using Asm.AspNetCore.Api;
+
+namespace Microsoft.AspNetCore.OpenApi;
+
+/// <summary>
+/// Extensions for <see cref="OpenApiOptions"/> providing common, reusable document and schema conventions.
+/// </summary>
+public static class AsmAspNetCoreApiOpenApiOptionsExtensions
+{
+    extension(OpenApiOptions options)
+    {
+        /// <summary>
+        /// Marks non-nullable reference-type properties as <c>required</c> in generated schemas, filling the
+        /// gap where .NET's OpenAPI generator reports them as optional.
+        /// </summary>
+        /// <returns>The same <see cref="OpenApiOptions"/>, for chaining.</returns>
+        public OpenApiOptions AddRequiredForNonNullableProperties()
+        {
+            options.AddSchemaTransformer(new RequiredForNonNullableSchemaTransformer());
+            return options;
+        }
+
+        /// <summary>
+        /// Relocates a common path prefix (e.g. <c>/api</c>) into a relative server URL and strips it from
+        /// every operation path.
+        /// </summary>
+        /// <param name="pathPrefix">The path prefix to relocate, e.g. <c>/api</c>.</param>
+        /// <returns>The same <see cref="OpenApiOptions"/>, for chaining.</returns>
+        public OpenApiOptions RelocatePathPrefixToServer(string pathPrefix)
+        {
+            options.AddDocumentTransformer(new ServerPathPrefixDocumentTransformer(pathPrefix));
+            return options;
+        }
+
+        /// <summary>
+        /// Sets the document title and derives its version from the file version of an assembly
+        /// (the entry assembly by default).
+        /// </summary>
+        /// <param name="title">The document title.</param>
+        /// <param name="assembly">The assembly whose file version supplies the document version.</param>
+        /// <returns>The same <see cref="OpenApiOptions"/>, for chaining.</returns>
+        public OpenApiOptions AddDocumentInfo(string title, Assembly? assembly = null)
+        {
+            options.AddDocumentTransformer(new DocumentInfoTransformer(title, assembly));
+            return options;
+        }
+
+        /// <summary>
+        /// Names schemas from a type's <see cref="System.ComponentModel.DisplayNameAttribute"/> where present,
+        /// falling back to the default algorithm. See <see cref="DisplayNameSchemaReferenceIds"/>.
+        /// </summary>
+        /// <returns>The same <see cref="OpenApiOptions"/>, for chaining.</returns>
+        public OpenApiOptions UseDisplayNameSchemaReferenceIds()
+        {
+            options.CreateSchemaReferenceId = DisplayNameSchemaReferenceIds.Resolve;
+            return options;
+        }
+    }
+}

--- a/src/Asm.AspNetCore.Api/OpenApi/DisplayNameSchemaReferenceIds.cs
+++ b/src/Asm.AspNetCore.Api/OpenApi/DisplayNameSchemaReferenceIds.cs
@@ -1,0 +1,36 @@
+using System.ComponentModel;
+using System.Reflection;
+using System.Text.Json.Serialization.Metadata;
+using Microsoft.AspNetCore.OpenApi;
+
+namespace Asm.AspNetCore.Api;
+
+/// <summary>
+/// Resolves OpenAPI schema reference IDs from a type's <see cref="DisplayNameAttribute"/>, falling back to
+/// the framework's default algorithm. Useful for giving schemas stable, friendly names and for resolving
+/// name collisions between types that would otherwise share a default reference ID.
+/// </summary>
+public static class DisplayNameSchemaReferenceIds
+{
+    /// <summary>
+    /// Returns the <see cref="DisplayNameAttribute.DisplayName"/> of the object type where present, otherwise
+    /// the default reference ID from <see cref="OpenApiOptions.CreateDefaultSchemaReferenceId"/>.
+    /// </summary>
+    /// <param name="jsonTypeInfo">The serialization metadata for the type being named.</param>
+    /// <returns>The schema reference ID, or <c>null</c> to omit the schema from components.</returns>
+    public static string? Resolve(JsonTypeInfo jsonTypeInfo)
+    {
+        ArgumentNullException.ThrowIfNull(jsonTypeInfo);
+
+        if (jsonTypeInfo.Kind == JsonTypeInfoKind.Object)
+        {
+            var displayName = jsonTypeInfo.Type.GetCustomAttribute<DisplayNameAttribute>(inherit: false)?.DisplayName;
+            if (!String.IsNullOrEmpty(displayName))
+            {
+                return displayName;
+            }
+        }
+
+        return OpenApiOptions.CreateDefaultSchemaReferenceId(jsonTypeInfo);
+    }
+}

--- a/src/Asm.AspNetCore.Api/OpenApi/DocumentInfoTransformer.cs
+++ b/src/Asm.AspNetCore.Api/OpenApi/DocumentInfoTransformer.cs
@@ -1,0 +1,47 @@
+using System.Diagnostics;
+using System.Reflection;
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi;
+
+namespace Asm.AspNetCore.Api;
+
+/// <summary>
+/// An <see cref="IOpenApiDocumentTransformer"/> that sets the document's title and derives its version from
+/// the file version of an assembly (the entry assembly by default).
+/// </summary>
+public sealed class DocumentInfoTransformer : IOpenApiDocumentTransformer
+{
+    private readonly string _title;
+    private readonly Assembly _assembly;
+
+    /// <summary>
+    /// Initialises the transformer.
+    /// </summary>
+    /// <param name="title">The document title.</param>
+    /// <param name="assembly">The assembly whose file version supplies the document version. Defaults to the entry assembly.</param>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="title"/> is <c>null</c> or empty.</exception>
+    public DocumentInfoTransformer(string title, Assembly? assembly = null)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(title);
+        _title = title;
+        _assembly = assembly ?? Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
+    }
+
+    /// <inheritdoc />
+    public Task TransformAsync(OpenApiDocument document, OpenApiDocumentTransformerContext context, CancellationToken cancellationToken)
+    {
+        document.Info ??= new OpenApiInfo();
+        document.Info.Title = _title;
+
+        var version = GetFileVersion(_assembly);
+        if (!String.IsNullOrEmpty(version))
+        {
+            document.Info.Version = version;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static string? GetFileVersion(Assembly assembly) =>
+        String.IsNullOrEmpty(assembly.Location) ? null : FileVersionInfo.GetVersionInfo(assembly.Location).FileVersion;
+}

--- a/src/Asm.AspNetCore.Api/OpenApi/RequiredForNonNullableSchemaTransformer.cs
+++ b/src/Asm.AspNetCore.Api/OpenApi/RequiredForNonNullableSchemaTransformer.cs
@@ -1,0 +1,55 @@
+using System.Reflection;
+using System.Text.Json.Serialization.Metadata;
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi;
+
+namespace Asm.AspNetCore.Api;
+
+/// <summary>
+/// An <see cref="IOpenApiSchemaTransformer"/> that marks every non-nullable reference-type property as
+/// <c>required</c> in the generated schema. .NET's OpenAPI generator does not infer <c>required</c> from
+/// nullable-reference-type annotations, so without this a non-nullable property is reported as optional.
+/// </summary>
+public sealed class RequiredForNonNullableSchemaTransformer : IOpenApiSchemaTransformer
+{
+    /// <inheritdoc />
+    public Task TransformAsync(OpenApiSchema schema, OpenApiSchemaTransformerContext context, CancellationToken cancellationToken)
+    {
+        MarkNonNullableAsRequired(schema, context.JsonTypeInfo);
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Adds every non-nullable reference-type property of <paramref name="jsonTypeInfo"/> to the schema's
+    /// <see cref="OpenApiSchema.Required"/> set. No-op for non-object types.
+    /// </summary>
+    /// <param name="schema">The schema to mutate.</param>
+    /// <param name="jsonTypeInfo">The serialization metadata describing the type's properties.</param>
+    public static void MarkNonNullableAsRequired(OpenApiSchema schema, JsonTypeInfo jsonTypeInfo)
+    {
+        ArgumentNullException.ThrowIfNull(schema);
+        ArgumentNullException.ThrowIfNull(jsonTypeInfo);
+
+        if (jsonTypeInfo.Kind != JsonTypeInfoKind.Object)
+        {
+            return;
+        }
+
+        // NullabilityInfoContext is not thread-safe, so use a fresh instance per invocation.
+        var nullabilityContext = new NullabilityInfoContext();
+
+        foreach (var property in jsonTypeInfo.Properties)
+        {
+            if (property.AttributeProvider is not PropertyInfo propertyInfo)
+            {
+                continue;
+            }
+
+            if (nullabilityContext.Create(propertyInfo).WriteState != NullabilityState.Nullable)
+            {
+                schema.Required ??= new HashSet<string>();
+                schema.Required.Add(property.Name);
+            }
+        }
+    }
+}

--- a/src/Asm.AspNetCore.Api/OpenApi/ServerPathPrefixDocumentTransformer.cs
+++ b/src/Asm.AspNetCore.Api/OpenApi/ServerPathPrefixDocumentTransformer.cs
@@ -1,0 +1,53 @@
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi;
+
+namespace Asm.AspNetCore.Api;
+
+/// <summary>
+/// An <see cref="IOpenApiDocumentTransformer"/> that moves a common path prefix (e.g. <c>/api</c>) into a
+/// relative server URL and strips it from every operation path, so the document reads as <c>/accounts</c>
+/// rather than <c>/api/accounts</c>. The relative server is resolved by clients (Swagger UI, generated
+/// SDKs) against the current origin, so requests still reach <c>/api/accounts</c>.
+/// </summary>
+public sealed class ServerPathPrefixDocumentTransformer : IOpenApiDocumentTransformer
+{
+    private readonly string _pathPrefix;
+
+    /// <summary>
+    /// Initialises the transformer.
+    /// </summary>
+    /// <param name="pathPrefix">The path prefix to relocate, e.g. <c>/api</c>.</param>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="pathPrefix"/> is <c>null</c> or empty.</exception>
+    public ServerPathPrefixDocumentTransformer(string pathPrefix)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(pathPrefix);
+        _pathPrefix = pathPrefix;
+    }
+
+    /// <inheritdoc />
+    public Task TransformAsync(OpenApiDocument document, OpenApiDocumentTransformerContext context, CancellationToken cancellationToken)
+    {
+        document.Servers = [new OpenApiServer { Url = _pathPrefix }];
+
+        if (document.Paths is null)
+        {
+            return Task.CompletedTask;
+        }
+
+        var rewritten = new OpenApiPaths();
+        foreach (var (path, item) in document.Paths)
+        {
+            var trimmed = path.StartsWith(_pathPrefix, StringComparison.OrdinalIgnoreCase) ? path[_pathPrefix.Length..] : path;
+            if (trimmed.Length == 0)
+            {
+                trimmed = "/";
+            }
+
+            rewritten.Add(trimmed, item);
+        }
+
+        document.Paths = rewritten;
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Asm.Hosting/AsmHostingServiceCollectionExtensions.cs
+++ b/src/Asm.Hosting/AsmHostingServiceCollectionExtensions.cs
@@ -1,0 +1,22 @@
+using Asm.Hosting;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Hosting-related extensions for <see cref="IServiceCollection"/>.
+/// </summary>
+public static class AsmHostingServiceCollectionExtensions
+{
+    extension(IServiceCollection services)
+    {
+        /// <summary>
+        /// Registers a singleton in-memory <see cref="IBackgroundWorkQueue{T}"/> for work items of type
+        /// <typeparamref name="T"/>. Pair it with a <see cref="QueuedHostedService{T}"/> registered via
+        /// <c>AddHostedService</c>.
+        /// </summary>
+        /// <typeparam name="T">The type of work item.</typeparam>
+        /// <returns>The service collection, for chaining.</returns>
+        public IServiceCollection AddBackgroundWorkQueue<T>() =>
+            services.AddSingleton<IBackgroundWorkQueue<T>, BackgroundWorkQueue<T>>();
+    }
+}

--- a/src/Asm.Hosting/BackgroundWorkQueue.cs
+++ b/src/Asm.Hosting/BackgroundWorkQueue.cs
@@ -1,0 +1,66 @@
+using System.Collections.Concurrent;
+
+namespace Asm.Hosting;
+
+/// <summary>
+/// A queue of background work items of type <typeparamref name="T"/>, produced by application code and
+/// consumed by a <see cref="QueuedHostedService{T}"/>.
+/// </summary>
+/// <typeparam name="T">The type of work item.</typeparam>
+public interface IBackgroundWorkQueue<T>
+{
+    /// <summary>
+    /// Enqueues a work item for background processing.
+    /// </summary>
+    /// <param name="workItem">The work item to enqueue.</param>
+    void Queue(T workItem);
+
+    /// <summary>
+    /// Waits for and removes the next work item.
+    /// </summary>
+    /// <param name="cancellationToken">A token that cancels the wait.</param>
+    /// <returns>The next work item.</returns>
+    Task<T> DequeueAsync(CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// A thread-safe, in-memory <see cref="IBackgroundWorkQueue{T}"/> backed by a <see cref="ConcurrentQueue{T}"/>
+/// and a <see cref="SemaphoreSlim"/>. Register it as a singleton (see
+/// <c>AddBackgroundWorkQueue&lt;T&gt;()</c>) so producers and the hosted consumer share one instance.
+/// </summary>
+/// <typeparam name="T">The type of work item.</typeparam>
+public sealed class BackgroundWorkQueue<T> : IBackgroundWorkQueue<T>, IDisposable
+{
+    private readonly ConcurrentQueue<T> _workItems = new();
+    private readonly SemaphoreSlim _signal = new(0);
+    private bool _disposed;
+
+    /// <inheritdoc />
+    public void Queue(T workItem)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        _workItems.Enqueue(workItem);
+        _signal.Release();
+    }
+
+    /// <inheritdoc />
+    public async Task<T> DequeueAsync(CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        await _signal.WaitAsync(cancellationToken);
+        _workItems.TryDequeue(out var workItem);
+        return workItem!;
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _signal.Dispose();
+        _disposed = true;
+    }
+}

--- a/src/Asm.Hosting/QueuedHostedService.cs
+++ b/src/Asm.Hosting/QueuedHostedService.cs
@@ -1,0 +1,62 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Asm.Hosting;
+
+/// <summary>
+/// A <see cref="BackgroundService"/> that consumes work items from an <see cref="IBackgroundWorkQueue{T}"/>,
+/// processing each within its own dependency-injection scope. Derive from this and implement
+/// <see cref="ProcessAsync"/>; the base class owns the dequeue loop, per-item scoping, and error logging
+/// (a failing item is logged and the loop continues).
+/// </summary>
+/// <typeparam name="T">The type of work item.</typeparam>
+/// <param name="workQueue">The queue to consume from.</param>
+/// <param name="serviceScopeFactory">Factory used to create a scope per work item.</param>
+/// <param name="loggerFactory">Factory used to create the logger, categorised by the derived type.</param>
+public abstract class QueuedHostedService<T>(IBackgroundWorkQueue<T> workQueue, IServiceScopeFactory serviceScopeFactory, ILoggerFactory loggerFactory) : BackgroundService
+{
+    /// <summary>
+    /// Processes a single work item. A fresh DI scope is created per item and supplied as
+    /// <paramref name="services"/>; resolve scoped dependencies from it.
+    /// </summary>
+    /// <param name="services">The scoped service provider for this work item.</param>
+    /// <param name="workItem">The work item to process.</param>
+    /// <param name="cancellationToken">A token signalled when the host is stopping.</param>
+    protected abstract ValueTask ProcessAsync(IServiceProvider services, T workItem, CancellationToken cancellationToken);
+
+    /// <inheritdoc />
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var logger = loggerFactory.CreateLogger(GetType());
+        logger.LogInformation("{Service} is starting.", GetType().Name);
+
+        try
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                var workItem = await workQueue.DequeueAsync(stoppingToken);
+
+                try
+                {
+                    using var scope = serviceScopeFactory.CreateScope();
+                    await ProcessAsync(scope.ServiceProvider, workItem, stoppingToken);
+                }
+                catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Error processing a work item in {Service}.", GetType().Name);
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Normal shutdown — the stopping token was signalled.
+        }
+
+        logger.LogInformation("{Service} is stopping.", GetType().Name);
+    }
+}

--- a/src/Asm/Extensions/AsmEnumerableExtensions.cs
+++ b/src/Asm/Extensions/AsmEnumerableExtensions.cs
@@ -52,4 +52,33 @@ public static class AsmEnumerableExtensions
     /// <returns><c>true</c> if the enumerable is empty; otherwise, <c>false</c>.</returns>
     public static bool Empty<T>(this IEnumerable<T> enumerable) =>
         !enumerable.Any();
+
+    extension<TSource>(IEnumerable<TSource> source)
+    {
+        /// <summary>
+        /// Projects each element of a sequence using an asynchronous selector, awaiting each element in turn.
+        /// </summary>
+        /// <remarks>
+        /// Elements are awaited sequentially rather than concurrently, making this safe for selectors that
+        /// share non-thread-safe state such as an Entity Framework Core <c>DbContext</c>.
+        /// </remarks>
+        /// <typeparam name="TResult">The type of the projected elements.</typeparam>
+        /// <param name="selector">An asynchronous transform function to apply to each element.</param>
+        /// <returns>A list of the projected elements, in source order.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="source"/> or <paramref name="selector"/> is <c>null</c>.</exception>
+        public async Task<List<TResult>> SelectAsync<TResult>(Func<TSource, Task<TResult>> selector)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(selector);
+
+            List<TResult> results = source.TryGetNonEnumeratedCount(out var count) ? new(count) : [];
+
+            foreach (var item in source)
+            {
+                results.Add(await selector(item));
+            }
+
+            return results;
+        }
+    }
 }

--- a/src/Asm/Extensions/System.DateOnly.cs
+++ b/src/Asm/Extensions/System.DateOnly.cs
@@ -46,5 +46,17 @@ public static class DateOnlyExtensions
                    later.Day - earlier.Day > 0 ? months + 1 :
                    months;
         }
+
+        /// <summary>
+        /// Gets the first day of the month.
+        /// </summary>
+        /// <returns>A <see cref="DateOnly"/> for the first day of the same month and year.</returns>
+        public DateOnly ToStartOfMonth() => new(date.Year, date.Month, 1);
+
+        /// <summary>
+        /// Gets the last day of the month.
+        /// </summary>
+        /// <returns>A <see cref="DateOnly"/> for the last day of the same month and year.</returns>
+        public DateOnly ToEndOfMonth() => new DateOnly(date.Year, date.Month, 1).AddMonths(1).AddDays(-1);
     }
 }

--- a/src/Asm/Extensions/System.DateTime.cs
+++ b/src/Asm/Extensions/System.DateTime.cs
@@ -118,6 +118,18 @@ public static class DateTimeExtensions
         /// Gets the current time.
         /// </summary>
         public TimeOnly TimeOnly => TimeOnly.FromDateTime(dt);
+
+        /// <summary>
+        /// Gets the first day of the month, with the time component set to midnight.
+        /// </summary>
+        /// <returns>A <see cref="DateTime"/> for the first day of the same month and year.</returns>
+        public DateTime ToStartOfMonth() => new(dt.Year, dt.Month, 1);
+
+        /// <summary>
+        /// Gets the last day of the month, with the time component set to midnight.
+        /// </summary>
+        /// <returns>A <see cref="DateTime"/> for the last day of the same month and year.</returns>
+        public DateTime ToEndOfMonth() => new DateTime(dt.Year, dt.Month, 1).AddMonths(1).AddDays(-1);
     }
 
 }

--- a/tests/Asm.AspNetCore.Api.Tests/Asm.AspNetCore.Api.Tests.csproj
+++ b/tests/Asm.AspNetCore.Api.Tests/Asm.AspNetCore.Api.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <CoverletInclude>[Asm.AspNetCore.Api]*</CoverletInclude>
+    <CoverletExcludeByFile>**/*</CoverletExcludeByFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Asm.AspNetCore.Api\Asm.AspNetCore.Api.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Asm.AspNetCore.Api.Tests/OpenApiDocumentTransformerTests.cs
+++ b/tests/Asm.AspNetCore.Api.Tests/OpenApiDocumentTransformerTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Asm.AspNetCore.Api;
+using Microsoft.OpenApi;
+
+namespace Asm.AspNetCore.Api.Tests;
+
+public class OpenApiDocumentTransformerTests
+{
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task ServerPathPrefixMovesPrefixToServerAndTrimsPaths()
+    {
+        var document = new OpenApiDocument { Paths = new OpenApiPaths() };
+        document.Paths.Add("/api/accounts", new OpenApiPathItem());
+        document.Paths.Add("/api/tags", new OpenApiPathItem());
+
+        await new ServerPathPrefixDocumentTransformer("/api").TransformAsync(document, null!, CancellationToken.None);
+
+        Assert.Single(document.Servers);
+        Assert.Equal("/api", document.Servers[0].Url);
+        Assert.True(document.Paths.ContainsKey("/accounts"));
+        Assert.True(document.Paths.ContainsKey("/tags"));
+        Assert.False(document.Paths.ContainsKey("/api/accounts"));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task ServerPathPrefixMapsBarePrefixToRoot()
+    {
+        var document = new OpenApiDocument { Paths = new OpenApiPaths() };
+        document.Paths.Add("/api", new OpenApiPathItem());
+
+        await new ServerPathPrefixDocumentTransformer("/api").TransformAsync(document, null!, CancellationToken.None);
+
+        Assert.True(document.Paths.ContainsKey("/"));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void ServerPathPrefixRequiresANonEmptyPrefix()
+    {
+        Assert.Throws<ArgumentException>(() => new ServerPathPrefixDocumentTransformer(""));
+        Assert.Throws<ArgumentNullException>(() => new ServerPathPrefixDocumentTransformer(null));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task DocumentInfoSetsTitleAndVersionFromAssembly()
+    {
+        var document = new OpenApiDocument();
+
+        // System.Private.CoreLib always carries a file version.
+        await new DocumentInfoTransformer("My API", typeof(string).Assembly).TransformAsync(document, null!, CancellationToken.None);
+
+        Assert.NotNull(document.Info);
+        Assert.Equal("My API", document.Info.Title);
+        Assert.False(String.IsNullOrEmpty(document.Info.Version));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void DocumentInfoRequiresATitle()
+    {
+        Assert.Throws<ArgumentException>(() => new DocumentInfoTransformer(""));
+    }
+}

--- a/tests/Asm.AspNetCore.Api.Tests/OpenApiSchemaConventionsTests.cs
+++ b/tests/Asm.AspNetCore.Api.Tests/OpenApiSchemaConventionsTests.cs
@@ -1,0 +1,81 @@
+using System.ComponentModel;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using Asm.AspNetCore.Api;
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi;
+
+namespace Asm.AspNetCore.Api.Tests;
+
+public class OpenApiSchemaConventionsTests
+{
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void MarkNonNullableAsRequiredMarksOnlyNonNullableProperties()
+    {
+        var jsonTypeInfo = JsonSerializerOptions.Default.GetTypeInfo(typeof(Model));
+        var schema = new OpenApiSchema();
+
+        RequiredForNonNullableSchemaTransformer.MarkNonNullableAsRequired(schema, jsonTypeInfo);
+
+        Assert.NotNull(schema.Required);
+        Assert.Contains("Name", schema.Required);
+        Assert.Contains("Age", schema.Required);
+        Assert.DoesNotContain("Nickname", schema.Required);
+        Assert.DoesNotContain("OptionalAge", schema.Required);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void MarkNonNullableAsRequiredIgnoresNonObjectTypes()
+    {
+        var jsonTypeInfo = JsonSerializerOptions.Default.GetTypeInfo(typeof(int));
+        var schema = new OpenApiSchema();
+
+        RequiredForNonNullableSchemaTransformer.MarkNonNullableAsRequired(schema, jsonTypeInfo);
+
+        Assert.True(schema.Required is null || schema.Required.Count == 0);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void DisplayNameSchemaReferenceIdUsesDisplayNameWhenPresent()
+    {
+        var jsonTypeInfo = JsonSerializerOptions.Default.GetTypeInfo(typeof(Attributed));
+
+        Assert.Equal("CustomName", DisplayNameSchemaReferenceIds.Resolve(jsonTypeInfo));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void DisplayNameSchemaReferenceIdFallsBackToDefault()
+    {
+        var jsonTypeInfo = JsonSerializerOptions.Default.GetTypeInfo(typeof(Plain));
+
+        Assert.Equal(OpenApiOptions.CreateDefaultSchemaReferenceId(jsonTypeInfo), DisplayNameSchemaReferenceIds.Resolve(jsonTypeInfo));
+    }
+
+#nullable enable
+    private sealed class Model
+    {
+        public string Name { get; set; } = "";
+
+        public string? Nickname { get; set; }
+
+        public int Age { get; set; }
+
+        public int? OptionalAge { get; set; }
+    }
+#nullable restore
+
+    [DisplayName("CustomName")]
+    private sealed class Attributed
+    {
+        public int Value { get; set; }
+    }
+
+    private sealed class Plain
+    {
+        public int Value { get; set; }
+    }
+}

--- a/tests/Asm.Hosting.Tests/Asm.Hosting.Tests.csproj
+++ b/tests/Asm.Hosting.Tests/Asm.Hosting.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <CoverletInclude>[Asm.Hosting]*</CoverletInclude>
+    <CoverletExcludeByFile>**/*</CoverletExcludeByFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Asm.Hosting\Asm.Hosting.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Asm.Hosting.Tests/BackgroundWorkQueueTests.cs
+++ b/tests/Asm.Hosting.Tests/BackgroundWorkQueueTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Asm.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Asm.Hosting.Tests;
+
+public class BackgroundWorkQueueTests
+{
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task DequeueReturnsQueuedItem()
+    {
+        var queue = new BackgroundWorkQueue<int>();
+        queue.Queue(42);
+
+        var item = await queue.DequeueAsync(CancellationToken.None);
+
+        Assert.Equal(42, item);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task DequeueReturnsItemsInFifoOrder()
+    {
+        var queue = new BackgroundWorkQueue<int>();
+        queue.Queue(1);
+        queue.Queue(2);
+        queue.Queue(3);
+
+        Assert.Equal(1, await queue.DequeueAsync(CancellationToken.None));
+        Assert.Equal(2, await queue.DequeueAsync(CancellationToken.None));
+        Assert.Equal(3, await queue.DequeueAsync(CancellationToken.None));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task DequeueWaitsUntilAnItemIsQueued()
+    {
+        var queue = new BackgroundWorkQueue<int>();
+
+        var dequeueTask = queue.DequeueAsync(CancellationToken.None);
+        Assert.False(dequeueTask.IsCompleted);
+
+        queue.Queue(99);
+
+        var item = await dequeueTask.WaitAsync(TimeSpan.FromSeconds(1));
+        Assert.Equal(99, item);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void QueueAfterDisposeThrows()
+    {
+        var queue = new BackgroundWorkQueue<int>();
+        queue.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => queue.Queue(1));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void AddBackgroundWorkQueueRegistersSingleton()
+    {
+        var services = new ServiceCollection();
+        services.AddBackgroundWorkQueue<int>();
+        using var provider = services.BuildServiceProvider();
+
+        var first = provider.GetRequiredService<IBackgroundWorkQueue<int>>();
+        var second = provider.GetRequiredService<IBackgroundWorkQueue<int>>();
+
+        Assert.Same(first, second);
+        Assert.IsType<BackgroundWorkQueue<int>>(first);
+    }
+}

--- a/tests/Asm.Hosting.Tests/QueuedHostedServiceTests.cs
+++ b/tests/Asm.Hosting.Tests/QueuedHostedServiceTests.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Asm.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Asm.Hosting.Tests;
+
+public class QueuedHostedServiceTests
+{
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task ProcessesQueuedItemsInOrder()
+    {
+        var queue = new BackgroundWorkQueue<int>();
+        using var provider = BuildProvider();
+        var service = new RecordingHostedService(queue, provider.GetRequiredService<IServiceScopeFactory>(), NullLoggerFactory.Instance);
+
+        await service.StartAsync(CancellationToken.None);
+        queue.Queue(1);
+        queue.Queue(2);
+        queue.Queue(3);
+        await WaitForAsync(() => service.Processed.Count == 3);
+        await service.StopAsync(CancellationToken.None);
+
+        Assert.Equal([1, 2, 3], service.Processed.ToArray());
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task ContinuesAfterAProcessingError()
+    {
+        var queue = new BackgroundWorkQueue<int>();
+        using var provider = BuildProvider();
+        var service = new RecordingHostedService(queue, provider.GetRequiredService<IServiceScopeFactory>(), NullLoggerFactory.Instance);
+
+        await service.StartAsync(CancellationToken.None);
+        queue.Queue(-1); // throws inside ProcessAsync
+        queue.Queue(7);
+        await WaitForAsync(() => service.Processed.Contains(7));
+        await service.StopAsync(CancellationToken.None);
+
+        Assert.Contains(7, service.Processed);
+        Assert.DoesNotContain(-1, service.Processed);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task CreatesAFreshScopePerItem()
+    {
+        var queue = new BackgroundWorkQueue<int>();
+        using var provider = BuildProvider();
+        var service = new RecordingHostedService(queue, provider.GetRequiredService<IServiceScopeFactory>(), NullLoggerFactory.Instance);
+
+        await service.StartAsync(CancellationToken.None);
+        queue.Queue(1);
+        queue.Queue(2);
+        await WaitForAsync(() => service.ScopeIds.Count == 2);
+        await service.StopAsync(CancellationToken.None);
+
+        Assert.Equal(2, service.ScopeIds.Distinct().Count());
+    }
+
+    private static ServiceProvider BuildProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddScoped<ScopedMarker>();
+        return services.BuildServiceProvider();
+    }
+
+    private static async Task WaitForAsync(Func<bool> condition, int timeoutMs = 2000)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (!condition() && stopwatch.ElapsedMilliseconds < timeoutMs)
+        {
+            await Task.Delay(20);
+        }
+
+        Assert.True(condition(), "Condition was not met within the timeout.");
+    }
+
+    private sealed class RecordingHostedService(IBackgroundWorkQueue<int> queue, IServiceScopeFactory scopeFactory, ILoggerFactory loggerFactory)
+        : QueuedHostedService<int>(queue, scopeFactory, loggerFactory)
+    {
+        public ConcurrentQueue<int> Processed { get; } = new();
+
+        public ConcurrentQueue<Guid> ScopeIds { get; } = new();
+
+        protected override ValueTask ProcessAsync(IServiceProvider services, int workItem, CancellationToken cancellationToken)
+        {
+            if (workItem < 0)
+            {
+                throw new InvalidOperationException("Simulated processing failure.");
+            }
+
+            ScopeIds.Enqueue(services.GetRequiredService<ScopedMarker>().Id);
+            Processed.Enqueue(workItem);
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class ScopedMarker
+    {
+        public Guid Id { get; } = Guid.NewGuid();
+    }
+}

--- a/tests/Asm.Tests/Extensions/DateMonthExtensionsTests.cs
+++ b/tests/Asm.Tests/Extensions/DateMonthExtensionsTests.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace Asm.Tests.Extensions;
+
+public class DateMonthExtensionsTests
+{
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void DateOnlyToStartOfMonthReturnsFirstDay()
+    {
+        Assert.Equal(new DateOnly(2026, 7, 1), new DateOnly(2026, 7, 15).ToStartOfMonth());
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void DateOnlyToEndOfMonthReturnsLastDay()
+    {
+        Assert.Equal(new DateOnly(2026, 7, 31), new DateOnly(2026, 7, 15).ToEndOfMonth());
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void DateOnlyToEndOfMonthHandlesLeapFebruary()
+    {
+        Assert.Equal(new DateOnly(2024, 2, 29), new DateOnly(2024, 2, 10).ToEndOfMonth());
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void DateTimeToStartOfMonthReturnsFirstDayAtMidnight()
+    {
+        Assert.Equal(new DateTime(2026, 7, 1, 0, 0, 0), new DateTime(2026, 7, 15, 13, 45, 30).ToStartOfMonth());
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void DateTimeToEndOfMonthReturnsLastDayAtMidnight()
+    {
+        Assert.Equal(new DateTime(2026, 2, 28, 0, 0, 0), new DateTime(2026, 2, 10, 8, 0, 0).ToEndOfMonth());
+    }
+}

--- a/tests/Asm.Tests/Extensions/EnumerableAsyncExtensionsTests.cs
+++ b/tests/Asm.Tests/Extensions/EnumerableAsyncExtensionsTests.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Asm.Tests.Extensions;
+
+public class EnumerableAsyncExtensionsTests
+{
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task SelectAsyncProjectsInSourceOrder()
+    {
+        var result = await new[] { 1, 2, 3 }.SelectAsync(async x => { await Task.Yield(); return x * 2; });
+
+        Assert.Equal(new[] { 2, 4, 6 }, result);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task SelectAsyncEmptySourceReturnsEmpty()
+    {
+        var result = await Array.Empty<int>().SelectAsync(x => Task.FromResult(x));
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task SelectAsyncAwaitsSequentially()
+    {
+        int concurrent = 0;
+        int maxConcurrent = 0;
+
+        await Enumerable.Range(0, 5).SelectAsync(async x =>
+        {
+            var current = Interlocked.Increment(ref concurrent);
+            maxConcurrent = Math.Max(maxConcurrent, current);
+            await Task.Delay(10);
+            Interlocked.Decrement(ref concurrent);
+            return x;
+        });
+
+        Assert.Equal(1, maxConcurrent);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task SelectAsyncNullSourceThrows()
+    {
+        IEnumerable<int> source = null;
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => source.SelectAsync(x => Task.FromResult(x)));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task SelectAsyncNullSelectorThrows()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() => new[] { 1 }.SelectAsync<int, int>(null));
+    }
+}


### PR DESCRIPTION
First batch of reusable infrastructure identified in MooBank issue [#886](https://github.com/AndrewMcLachlan/MooBank/issues/886), cross-checked as genuine gaps in ASM and extracted with tests. New extension methods use the C# `extension { }` member syntax.

## What's promoted (Tier 1)

**`Asm.AspNetCore.Api`** — `OpenApiOptions` conventions:
- `AddRequiredForNonNullableProperties()` — marks non-nullable reference-type properties as `required` (fills the .NET OpenAPI gap). `RequiredForNonNullableSchemaTransformer`.
- `UseDisplayNameSchemaReferenceIds()` — names schemas from `[DisplayName]`, falling back to the default algorithm. `DisplayNameSchemaReferenceIds`.
- `RelocatePathPrefixToServer(prefix)` — moves a common path prefix (e.g. `/api`) into a relative server URL and strips it from operation paths. `ServerPathPrefixDocumentTransformer`.
- `AddDocumentInfo(title, assembly?)` — sets the document title and derives its version from an assembly's file version. `DocumentInfoTransformer`.

**`Asm.Hosting`** — generic background work queue:
- `IBackgroundWorkQueue<T>` / `BackgroundWorkQueue<T>` + `IServiceCollection.AddBackgroundWorkQueue<T>()`.
- `QueuedHostedService<T>` — abstract scoped-dispatch hosted worker (override `ProcessAsync`). Collapses three near-identical queue/worker pairs in MooBank into one.

**`Asm`** — utility extensions:
- `DateOnly`/`DateTime` `ToStartOfMonth()` / `ToEndOfMonth()`.
- `IEnumerable<T>.SelectAsync()` — sequential async projection (safe for selectors sharing a `DbContext`).

## Notes

- **Tag-sorting was dropped.** MooBank's OpenAPI "sort tags" transformer was a no-op (it re-added already-present tags to a `HashSet`, which never reorders). Not promoted; documented rather than shipped.
- Schema transformer + reference-id resolver expose their core logic as static methods, so they're unit-tested directly without constructing ASP.NET's transformer-context types.

## Tests

Adds `Asm.Hosting.Tests` and `Asm.AspNetCore.Api.Tests`; extends `Asm.Tests`. Full solution builds clean (no new warnings); new tests pass — **Asm.Tests 408, Asm.Hosting.Tests 8, Asm.AspNetCore.Api.Tests 9**.

## Follow-up

- `docs/reusable-code-promotion.md` records this batch plus the Tier 2/3 backlog (integration-test auth harness → a new `Asm.Testing.AspNetCore`; tolerant route auth handler + auditable role, gated on a small `IAuthorisationAuditor` denial-audit seam; settable user provider; MCP/audit/EF-converter helpers).
- MooBank's duplicated code (Program.cs OpenAPI block, `Queues/*` + `Services/Background/*`, date + `SelectAsync` extensions) is removed in a separate MooBank PR once a release carrying this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
