### PR TITLE
Docs: rewrite Asm.Cqrs and Asm.Cqrs.AspNetCore READMEs against the real API

### DIFF
--- a/src/Asm.Cqrs.AspNetCore/README.md
+++ b/src/Asm.Cqrs.AspNetCore/README.md
@@ -1,84 +1,103 @@
 # Asm.Cqrs.AspNetCore
 
-The `Asm.Cqrs.AspNetCore` project provides extensions and utilities to integrate the Command Query Responsibility Segregation (CQRS) pattern into ASP.NET Core applications. It simplifies the setup and usage of CQRS in web APIs by providing middleware, model binding, and dependency injection support.
+Maps [Asm.Cqrs](https://github.com/AndrewMcLachlan/ASM/tree/main/src/Asm.Cqrs) commands and queries directly
+to ASP.NET Core minimal API endpoints, removing the boilerplate handler lambda between the route and the
+dispatcher.
 
 ## Features
 
-- **Command and Query Dispatching**: Seamless integration of `ICommandDispatcher` and `IQueryDispatcher` into ASP.NET Core.
-- **Model Binding for Commands and Queries**: Automatically bind HTTP request data to commands and queries.
-- **Middleware Support**: Add cross-cutting concerns like validation, logging, and exception handling to the CQRS pipeline.
-- **Dependency Injection Integration**: Easily register CQRS components in the ASP.NET Core DI container.
+- **Query endpoints**: `MapQuery` (GET) and `MapPagedQuery` (GET with an `X-Total-Count` header).
+- **Command endpoints**: `MapCommand` (POST), `MapPutCommand`, `MapPatchCommand` and `MapDelete`.
+- **Create endpoints**: `MapPostCreate` and `MapPutCreate`, returning `201 Created` with a `Location` header via a named route.
+- **Binding control**: bind the request from route/query parameters, the request body, or a mix of both.
+- **OpenAPI metadata**: endpoints declare their response types via `Produces`.
+- `CommandQueryController` base class for apps still using MVC controllers.
 
 ## Installation
 
-To install the `Asm.Cqrs.AspNetCore` library, use the .NET CLI:
-
-Or via the NuGet Package Manager:
-
+```
+dotnet add package Asm.Cqrs.AspNetCore
+```
 
 ## Usage
 
-### Registering CQRS Services
-
-In your `Program.cs` or `Startup.cs`, register the CQRS services:
+The mapping extension methods live in the `Asm.AspNetCore` namespace.
 
 ```csharp
-using Asm.Cqrs.AspNetCore;
+using Asm.AspNetCore;
+
 var builder = WebApplication.CreateBuilder(args);
-// Register CQRS services builder.Services.AddCqrs();
-var app = builder.Build(); app.Run();
+
+builder.Services.AddQueryHandlers(typeof(GetOrder).Assembly);
+builder.Services.AddCommandHandlers(typeof(CreateOrder).Assembly);
+
+var app = builder.Build();
+
+var orders = app.MapGroup("/orders");
+
+orders.MapQuery<GetOrders, IEnumerable<Order>>("/");
+orders.MapQuery<GetOrder, Order>("/{id}")
+      .WithName("GetOrder");
+orders.MapPostCreate<CreateOrder, Order>("/", routeName: "GetOrder", o => new { id = o.Id });
+orders.MapPutCommand<UpdateOrder, Order>("/{id}");
+orders.MapDelete<DeleteOrder>("/{id}");
+
+app.Run();
 ```
 
-### Defining a Command and Handler
+Each method returns the `RouteHandlerBuilder`, so the endpoint can be customised further
+(`.WithName(...)`, `.RequireAuthorization(...)`, etc.).
 
-Define a command and its handler:
+### Request binding
+
+Queries are always bound with `[AsParameters]`: each property of the query is bound from the route,
+query string or headers using the standard minimal API rules.
 
 ```csharp
-using Asm.Cqrs;
-public class CreateOrderCommand : ICommand { public string OrderId { get; set; } public string CustomerName { get; set; } }
-public class CreateOrderCommandHandler : ICommandHandler<CreateOrderCommand> { public Task HandleAsync(CreateOrderCommand command, CancellationToken cancellationToken) { // Handle the command logic here Console.WriteLine($"Order created for {command.CustomerName}"); return Task.CompletedTask; } }
+// GET /orders/42 -> GetOrder(42)
+public record GetOrder(int Id) : IQuery<Order>;
 ```
 
+Command mappings take a `CommandBinding` argument that controls how the command is built from the request:
 
-### Defining a Query and Handler
+- `CommandBinding.Parameters` (the default) — the command is bound with `[AsParameters]`. Combine with
+  attributes on individual properties to mix sources, e.g. an ID from the route and a payload from the body:
 
-Define a query and its handler:
+  ```csharp
+  // PUT /orders/42 with a JSON body -> UpdateOrder(42, <body>)
+  public record UpdateOrder([FromRoute] int Id, [FromBody] OrderDetails Details) : ICommand<Order>;
+  ```
+
+- `CommandBinding.Body` — the whole command is deserialised from the JSON request body.
+
+  ```csharp
+  orders.MapCommand<CreateOrder, Order>("/", binding: CommandBinding.Body);
+  ```
+
+- `CommandBinding.None` — no binding attribute is applied; the framework's default inference applies
+  (for a complex type this is usually the request body).
+
+### Status codes
+
+Command mappings return `200 OK` (or `204 No Content` for commands without a response, and `201 Created`
+for the create mappings) by default. Pass a status code to override:
 
 ```csharp
-using Asm.Cqrs;
-public class GetOrderQuery : IQuery<Order> { public string OrderId { get; set; } }
-public class GetOrderQueryHandler : IQueryHandler<GetOrderQuery, Order> { public Task<Order> HandleAsync(GetOrderQuery query, CancellationToken cancellationToken) { // Handle the query logic here return Task.FromResult(new Order { OrderId = query.OrderId, CustomerName = "John Doe" }); } }
+orders.MapCommand<SubmitOrder, OrderReceipt>("/submit", StatusCodes.Status202Accepted);
 ```
 
-### Using Commands and Queries in Controllers
+### Error responses
 
-Use commands and queries in your ASP.NET Core controllers:
+Handlers are free to throw; this package does not translate exceptions. Pair it with
+[Asm.AspNetCore](https://github.com/AndrewMcLachlan/ASM/tree/main/src/Asm.AspNetCore), whose exception
+handler maps the `Asm` exception types (`NotFoundException`, `ExistsException`, `NotAuthorisedException`,
+FluentValidation's `ValidationException`) to RFC 9457 problem-details responses, or register your own
+`IExceptionHandler`.
 
-```csharp
-using Asm.Cqrs; using Microsoft.AspNetCore.Mvc;
-[ApiController] [Route("api/orders")] public class OrdersController : ControllerBase { private readonly ICommandDispatcher _commandDispatcher; private readonly IQueryDispatcher _queryDispatcher;
-public OrdersController(ICommandDispatcher commandDispatcher, IQueryDispatcher queryDispatcher)
-{
-    _commandDispatcher = commandDispatcher;
-    _queryDispatcher = queryDispatcher;
-}
+### MVC controllers
 
-[HttpPost]
-public async Task<IActionResult> CreateOrder([FromBody] CreateOrderCommand command)
-{
-    await _commandDispatcher.DispatchAsync(command);
-    return CreatedAtAction(nameof(GetOrder), new { orderId = command.OrderId }, command);
-}
-
-[HttpGet("{orderId}")]
-public async Task<IActionResult> GetOrder(string orderId)
-{
-    var query = new GetOrderQuery { OrderId = orderId };
-    var order = await _queryDispatcher.DispatchAsync(query);
-    return Ok(order);
-}
-}
-```
+For apps using MVC controllers, `CommandQueryController` provides a base class with `QueryDispatcher` and
+`CommandDispatcher` properties. It is decorated with `[ApiController]` and `[Authorize]`.
 
 ## Contributing
 

--- a/src/Asm.Cqrs/README.md
+++ b/src/Asm.Cqrs/README.md
@@ -1,92 +1,125 @@
 # Asm.Cqrs
 
-The `Asm.Cqrs` project provides a lightweight framework for implementing the Command Query Responsibility Segregation (CQRS) pattern in .NET applications. It includes abstractions and utilities for handling commands, queries, and events in a clean and maintainable way.
+A lightweight implementation of the Command Query Responsibility Segregation (CQRS) pattern for .NET.
+Commands and queries are first-class, separate concepts with their own handler and dispatcher interfaces,
+dispatched via cached compiled delegates (no per-call reflection).
 
 ## Features
 
-- **Command Handling**: Define and process commands with dedicated handlers.
-- **Query Handling**: Simplify query execution with query handlers.
-- **Event Dispatching**: Publish and handle domain events.
-- **Pipeline Behaviors**: Add cross-cutting concerns (e.g., logging, validation) to command and query pipelines.
-- **Dependency Injection Integration**: Seamless integration with ASP.NET Core's DI container.
+- **Separate command and query abstractions**: `ICommand`, `ICommand<TResponse>` and `IQuery<TResponse>` with matching handler interfaces.
+- **Separate dispatchers**: `ICommandDispatcher` and `IQueryDispatcher`, so the write and read sides of an application can be segregated at the injection point.
+- **`ValueTask`-based** handler and dispatcher signatures.
+- **Dependency injection integration**: register handlers by assembly scan or individually.
 
 ## Installation
 
-To install the `Asm.Cqrs` library, use the .NET CLI:
-
-`dotnet add package Asm.Cqrs`
-
-Or via the NuGet Package Manager:
-
-`Install-Package Asm.Cqrs`
+```
+dotnet add package Asm.Cqrs
+```
 
 ## Usage
 
-### Defining a Command
+### Defining a query
 
-Create a command by implementing the `ICommand` interface:
+Implement `IQuery<TResponse>`:
 
 ```csharp
-using Asm.Cqrs;
-public class CreateOrderCommand : ICommand { public string OrderId { get; set; } public string CustomerName { get; set; } }
+using Asm.Cqrs.Queries;
+
+public record GetOrder(int Id) : IQuery<Order>;
 ```
 
-### Handling a Command
+### Handling a query
 
-Create a command handler by implementing the `ICommandHandler<TCommand>` interface:
+Implement `IQueryHandler<TQuery, TResponse>`:
 
 ```csharp
-using Asm.Cqrs;
-public class CreateOrderCommandHandler : ICommandHandler<CreateOrderCommand> { public Task HandleAsync(CreateOrderCommand command, CancellationToken cancellationToken) { // Handle the command logic here Console.WriteLine($"Order created for {command.CustomerName}"); return Task.CompletedTask; } }
+using Asm.Cqrs.Queries;
+
+public class GetOrderHandler : IQueryHandler<GetOrder, Order>
+{
+    public ValueTask<Order> Handle(GetOrder query, CancellationToken cancellationToken) =>
+        ValueTask.FromResult(new Order { Id = query.Id, CustomerName = "Joe Bloggs" });
+}
 ```
 
-### Defining a Query
+### Defining a command
 
-Create a query by implementing the `IQuery<TResult>` interface:
+Implement `ICommand<TResponse>` for a command that returns a response, or `ICommand` for one that does not:
 
 ```csharp
-using Asm.Cqrs;
-public class GetOrderQuery : IQuery<Order> { public string OrderId { get; set; } }
+using Asm.Cqrs.Commands;
+
+public record CreateOrder(string CustomerName) : ICommand<Order>;
+
+public record DeleteOrder(int Id) : ICommand;
 ```
 
-### Handling a Query
+### Handling a command
 
-Create a query handler by implementing the `IQueryHandler<TQuery, TResult>` interface:
-
-```csharp
-public class GetOrderQueryHandler : IQueryHandler<GetOrderQuery, Order> { public Task<Order> HandleAsync(GetOrderQuery query, CancellationToken cancellationToken) { // Handle the query logic here return Task.FromResult(new Order { OrderId = query.OrderId, CustomerName = "Joe Bloggs" }); } }
-```
-
-### Dispatching Commands and Queries
-
-Use the `ICommandDispatcher` and `IQueryDispatcher` to dispatch commands and queries:
+Implement `ICommandHandler<TCommand, TResponse>` or `ICommandHandler<TCommand>`:
 
 ```csharp
-using Asm.Cqrs;
-public class OrderService
-{ 
-    private readonly ICommandDispatcher _commandDispatcher;
-    private readonly IQueryDispatcher _queryDispatcher;
+using Asm.Cqrs.Commands;
 
-    public OrderService(ICommandDispatcher commandDispatcher, IQueryDispatcher queryDispatcher)
+public class CreateOrderHandler : ICommandHandler<CreateOrder, Order>
+{
+    public ValueTask<Order> Handle(CreateOrder command, CancellationToken cancellationToken)
     {
-        _commandDispatcher = commandDispatcher;
-        _queryDispatcher = queryDispatcher;
+        // Create the order...
     }
+}
 
-    public async Task CreateOrderAsync()
+public class DeleteOrderHandler : ICommandHandler<DeleteOrder>
+{
+    public ValueTask Handle(DeleteOrder command, CancellationToken cancellationToken)
     {
-        var command = new CreateOrderCommand { OrderId = "123", CustomerName = "Jane Doe" };
-        await _commandDispatcher.DispatchAsync(command);
-    }
-
-    public async Task<Order> GetOrderAsync(string orderId)
-    {
-        var query = new GetOrderQuery { OrderId = orderId };
-        return await _queryDispatcher.DispatchAsync(query);
+        // Delete the order...
     }
 }
 ```
+
+### Registering handlers
+
+Register all handlers in an assembly:
+
+```csharp
+builder.Services.AddCommandHandlers(typeof(CreateOrder).Assembly);
+builder.Services.AddQueryHandlers(typeof(GetOrder).Assembly);
+```
+
+Or register handlers individually:
+
+```csharp
+builder.Services.AddCommandHandler<CreateOrderHandler, CreateOrder, Order>();
+builder.Services.AddCommandHandler<DeleteOrderHandler, DeleteOrder>();
+builder.Services.AddQueryHandler<GetOrderHandler, GetOrder, Order>();
+```
+
+### Dispatching
+
+Inject `IQueryDispatcher` and `ICommandDispatcher`:
+
+```csharp
+public class OrderService(ICommandDispatcher commandDispatcher, IQueryDispatcher queryDispatcher)
+{
+    public async Task<Order> CreateOrderAsync(string customerName, CancellationToken cancellationToken) =>
+        await commandDispatcher.Dispatch(new CreateOrder(customerName), cancellationToken);
+
+    public async Task DeleteOrderAsync(int id, CancellationToken cancellationToken) =>
+        await commandDispatcher.Execute(new DeleteOrder(id), cancellationToken);
+
+    public async Task<Order> GetOrderAsync(int id, CancellationToken cancellationToken) =>
+        await queryDispatcher.Dispatch(new GetOrder(id), cancellationToken);
+}
+```
+
+Commands that return a response are dispatched with `Dispatch`; commands that do not are executed with `Execute`.
+
+## ASP.NET Core
+
+See [Asm.Cqrs.AspNetCore](https://github.com/AndrewMcLachlan/ASM/tree/main/src/Asm.Cqrs.AspNetCore) to map
+commands and queries directly to minimal API endpoints.
 
 ## Contributing
 


### PR DESCRIPTION
The previous READMEs for both CQRS packages documented an API that does not exist (`AddCqrs()`, `DispatchAsync`, `HandleAsync`, pipeline behaviors, event dispatching, middleware support). These files ship inside the nupkgs as the package front page.

Replaced with accurate content:

- **Asm.Cqrs**: real interfaces (`IQuery<T>`, `ICommand`/`ICommand<T>`, handlers with `ValueTask Handle`), assembly-scan and individual registration, `Dispatch`/`Execute` semantics.
- **Asm.Cqrs.AspNetCore**: the `MapQuery`/`MapPagedQuery`/`MapCommand`/`MapPostCreate`/`MapDelete` endpoint surface, `CommandBinding` semantics including the hybrid route+body pattern, status-code overrides, the `Asm.AspNetCore` exception-handler pairing, and `CommandQueryController`.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)