### PR TITLE
feat(hosting): opt-in, log-safe work item context in QueuedHostedService

### DIFF
--- a/src/Asm.Hosting/QueuedHostedService.cs
+++ b/src/Asm.Hosting/QueuedHostedService.cs
@@ -25,6 +25,20 @@ public abstract class QueuedHostedService<T>(IBackgroundWorkQueue<T> workQueue, 
     /// <param name="cancellationToken">A token signalled when the host is stopping.</param>
     protected abstract ValueTask ProcessAsync(IServiceProvider services, T workItem, CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Returns a value describing <paramref name="workItem"/> to include in the error log when
+    /// <see cref="ProcessAsync"/> throws — typically a non-sensitive identifier such as an id.
+    /// </summary>
+    /// <remarks>
+    /// Returns <c>null</c> by default, so <b>no work-item content is logged</b> unless a derived class
+    /// opts in. The base class cannot know which parts of <typeparamref name="T"/> are sensitive, so the
+    /// safe default is to log nothing about the item. When overriding, return only values that are safe to
+    /// appear in logs — never personal data, secrets, or payloads (e.g. an imported file's contents).
+    /// </remarks>
+    /// <param name="workItem">The work item that failed.</param>
+    /// <returns>A log-safe descriptor, or <c>null</c> to omit the item from the error log.</returns>
+    protected virtual object? DescribeWorkItem(T workItem) => null;
+
     /// <inheritdoc />
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -48,7 +62,17 @@ public abstract class QueuedHostedService<T>(IBackgroundWorkQueue<T> workQueue, 
                 }
                 catch (Exception ex)
                 {
-                    logger.LogError(ex, "Error processing work item {WorkItem} in {Service}.", workItem, GetType().Name);
+                    // Only log a descriptor the derived class has explicitly deemed safe (default: none),
+                    // so sensitive parts of the work item never leak into logs.
+                    var description = DescribeWorkItem(workItem);
+                    if (description is null)
+                    {
+                        logger.LogError(ex, "Error processing a work item in {Service}.", GetType().Name);
+                    }
+                    else
+                    {
+                        logger.LogError(ex, "Error processing work item {WorkItem} in {Service}.", description, GetType().Name);
+                    }
                 }
             }
         }

--- a/src/Asm.Hosting/QueuedHostedService.cs
+++ b/src/Asm.Hosting/QueuedHostedService.cs
@@ -48,7 +48,7 @@ public abstract class QueuedHostedService<T>(IBackgroundWorkQueue<T> workQueue, 
                 }
                 catch (Exception ex)
                 {
-                    logger.LogError(ex, "Error processing a work item in {Service}.", GetType().Name);
+                    logger.LogError(ex, "Error processing work item {WorkItem} in {Service}.", workItem, GetType().Name);
                 }
             }
         }

--- a/tests/Asm.Hosting.Tests/QueuedHostedServiceTests.cs
+++ b/tests/Asm.Hosting.Tests/QueuedHostedServiceTests.cs
@@ -68,6 +68,25 @@ public class QueuedHostedServiceTests
 
     [Fact]
     [Trait("Category", "Unit")]
+    public async Task DoesNotLogWorkItemContentByDefault()
+    {
+        var queue = new BackgroundWorkQueue<int>();
+        using var provider = BuildProvider();
+        var loggerFactory = new CapturingLoggerFactory();
+        var service = new AlwaysThrowingHostedService(queue, provider.GetRequiredService<IServiceScopeFactory>(), loggerFactory);
+
+        await service.StartAsync(CancellationToken.None);
+        queue.Queue(-1);
+        await WaitForAsync(() => loggerFactory.Messages.Any(m => m.Contains("Error processing")));
+        await service.StopAsync(CancellationToken.None);
+
+        // The default descriptor is null, so the item's value must not appear in the log.
+        Assert.Contains(loggerFactory.Messages, m => m.Contains("Error processing a work item"));
+        Assert.DoesNotContain(loggerFactory.Messages, m => m.Contains("-1"));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
     public async Task CreatesAFreshScopePerItem()
     {
         var queue = new BackgroundWorkQueue<int>();
@@ -119,6 +138,17 @@ public class QueuedHostedServiceTests
             Processed.Enqueue(workItem);
             return ValueTask.CompletedTask;
         }
+
+        // An int is not sensitive, so opt in to logging it.
+        protected override object DescribeWorkItem(int workItem) => workItem;
+    }
+
+    // Throws for every item and does not override DescribeWorkItem, exercising the safe default.
+    private sealed class AlwaysThrowingHostedService(IBackgroundWorkQueue<int> queue, IServiceScopeFactory scopeFactory, ILoggerFactory loggerFactory)
+        : QueuedHostedService<int>(queue, scopeFactory, loggerFactory)
+    {
+        protected override ValueTask ProcessAsync(IServiceProvider services, int workItem, CancellationToken cancellationToken)
+            => throw new InvalidOperationException("Simulated processing failure.");
     }
 
     private sealed class ScopedMarker

--- a/tests/Asm.Hosting.Tests/QueuedHostedServiceTests.cs
+++ b/tests/Asm.Hosting.Tests/QueuedHostedServiceTests.cs
@@ -51,6 +51,23 @@ public class QueuedHostedServiceTests
 
     [Fact]
     [Trait("Category", "Unit")]
+    public async Task LogsTheFailingWorkItemOnError()
+    {
+        var queue = new BackgroundWorkQueue<int>();
+        using var provider = BuildProvider();
+        var loggerFactory = new CapturingLoggerFactory();
+        var service = new RecordingHostedService(queue, provider.GetRequiredService<IServiceScopeFactory>(), loggerFactory);
+
+        await service.StartAsync(CancellationToken.None);
+        queue.Queue(-1); // throws inside ProcessAsync
+        await WaitForAsync(() => loggerFactory.Messages.Any(m => m.Contains("Error processing work item")));
+        await service.StopAsync(CancellationToken.None);
+
+        Assert.Contains(loggerFactory.Messages, m => m.Contains("Error processing work item -1"));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
     public async Task CreatesAFreshScopePerItem()
     {
         var queue = new BackgroundWorkQueue<int>();
@@ -107,5 +124,33 @@ public class QueuedHostedServiceTests
     private sealed class ScopedMarker
     {
         public Guid Id { get; } = Guid.NewGuid();
+    }
+
+    private sealed class CapturingLoggerFactory : ILoggerFactory
+    {
+        public ConcurrentQueue<string> Messages { get; } = new();
+
+        public ILogger CreateLogger(string categoryName) => new CapturingLogger(Messages);
+
+        public void AddProvider(ILoggerProvider provider) { }
+
+        public void Dispose() { }
+    }
+
+    private sealed class CapturingLogger(ConcurrentQueue<string> messages) : ILogger
+    {
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullDisposable.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            => messages.Enqueue(formatter(state, exception));
+    }
+
+    private sealed class NullDisposable : IDisposable
+    {
+        public static readonly NullDisposable Instance = new();
+
+        public void Dispose() { }
     }
 }


### PR DESCRIPTION
Follow-up to #428. When `ProcessAsync` throws, `QueuedHostedService<T>` logged a generic message that dropped per-item context. This adds context back **without risking a data leak**.

Because the generic base cannot know which parts of a work item are sensitive (a `T` might carry PII, secrets, or a file payload), it does **not** log the item by default. Instead:

- New `protected virtual object? DescribeWorkItem(T workItem) => null;` — override to return a **log-safe** descriptor (typically an id).
- On failure: if the descriptor is non-null, log `"Error processing work item {WorkItem} in {Service}."`; otherwise the safe default `"Error processing a work item in {Service}."`. The exception + stack are logged either way.

So nothing about the item reaches the log unless a derived class opts in with data it has deemed safe.

Tests (capturing logger): the default logs no item content; an opt-in descriptor appears in the log. `Asm.Hosting.Tests` builds clean and passes (10 tests).
