### PR TITLE
Enable nullable in test projects

### DIFF
--- a/src/Asm.Domain/AsmDomainQueryableExtensions.cs
+++ b/src/Asm.Domain/AsmDomainQueryableExtensions.cs
@@ -14,7 +14,7 @@ public static class AsmDomainQueryableExtensions
     /// <param name="query">The queryable that this method extends.</param>
     /// <param name="specification">The specification to be applied.</param>
     /// <returns>The <paramref name="query"/> with the specification applied.</returns>
-    public static IQueryable<T> Specify<T>(this IQueryable<T> query, ISpecification<T> specification) where T : class
+    public static IQueryable<T> Specify<T>(this IQueryable<T> query, ISpecification<T>? specification) where T : class
         => specification == null ? query : specification.Apply(query);
 
     /// <summary>

--- a/src/Asm.Domain/IdentifiableEqualityComparer.cs
+++ b/src/Asm.Domain/IdentifiableEqualityComparer.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Asm.Domain;
 
 /// <summary>
@@ -26,7 +28,7 @@ public class IdentifiableEqualityComparer<TType, TKey> : EqualityComparer<TType>
     }
 
     /// <inheritdoc />
-    public override int GetHashCode(TType obj)
+    public override int GetHashCode([AllowNull] TType obj)
     {
         // The contract allows GetHashCode(null); return 0 rather than throwing.
         if (obj is null || obj.Id is null) return 0;

--- a/src/Asm.Umbraco/Extensions/AsmUmbracoPublishedContentExtensions.cs
+++ b/src/Asm.Umbraco/Extensions/AsmUmbracoPublishedContentExtensions.cs
@@ -11,9 +11,9 @@ public static class AsmUmbracoPublishedContentExtensions
     /// Returns the content item's <c>Name</c> as a lowercase, hyphen-separated CSS class name.
     /// </summary>
     /// <param name="model">The content item.</param>
-    /// <returns>The CSS-safe class name, or <c>null</c> if the model is null.</returns>
-    public static string? NameAsCssClass(this IPublishedContent model) =>
-        model?.Name.ToLower().Replace(' ', '-');
+    /// <returns>The CSS-safe class name, or <c>null</c> if the model or its name is null.</returns>
+    public static string? NameAsCssClass(this IPublishedContent? model) =>
+        model?.Name?.ToLower().Replace(' ', '-');
 
     /// <summary>
     /// Returns the value of the named property if it has a value, otherwise the supplied default.

--- a/src/Asm.Umbraco/TagHelpers/ImgSetTagHelper.cs
+++ b/src/Asm.Umbraco/TagHelpers/ImgSetTagHelper.cs
@@ -31,7 +31,7 @@ public class ImgSetTagHelper(IWebHostEnvironment webHostEnvironment, IMemoryCach
     /// contributes a <c>srcset</c> entry using its <c>scaling</c> property.
     /// </summary>
     [HtmlAttributeName("images")]
-    public IEnumerable<IPublishedContent> Images { get; set; } = [];
+    public IEnumerable<IPublishedContent>? Images { get; set; } = [];
 
     /// <summary>
     /// The web host environment.

--- a/tests/Asm.AspNetCore.Api.Tests/OpenApiDocumentTransformerTests.cs
+++ b/tests/Asm.AspNetCore.Api.Tests/OpenApiDocumentTransformerTests.cs
@@ -18,6 +18,7 @@ public class OpenApiDocumentTransformerTests
 
         await new ServerPathPrefixDocumentTransformer("/api").TransformAsync(document, null!, CancellationToken.None);
 
+        Assert.NotNull(document.Servers);
         Assert.Single(document.Servers);
         Assert.Equal("/api", document.Servers[0].Url);
         Assert.True(document.Paths.ContainsKey("/accounts"));
@@ -42,7 +43,7 @@ public class OpenApiDocumentTransformerTests
     public void ServerPathPrefixRequiresANonEmptyPrefix()
     {
         Assert.Throws<ArgumentException>(() => new ServerPathPrefixDocumentTransformer(""));
-        Assert.Throws<ArgumentNullException>(() => new ServerPathPrefixDocumentTransformer(null));
+        Assert.Throws<ArgumentNullException>(() => new ServerPathPrefixDocumentTransformer(null!));
     }
 
     [Fact]

--- a/tests/Asm.AspNetCore.Modules.Tests/Extensions/IEndpointConventionBuilderExtensionsSteps.cs
+++ b/tests/Asm.AspNetCore.Modules.Tests/Extensions/IEndpointConventionBuilderExtensionsSteps.cs
@@ -8,10 +8,10 @@ namespace Asm.AspNetCore.Modules.Tests.Extensions;
 [Scope(Feature = "IEndpointConventionBuilderExtensions")]
 public class IEndpointConventionBuilderExtensionsSteps
 {
-    private WebApplication _app;
-    private RouteHandlerBuilder _endpoint;
-    private RouteGroupBuilder _routeGroupBuilder;
-    private IEndpointConventionBuilder _builder;
+    private WebApplication _app = null!;
+    private RouteHandlerBuilder? _endpoint;
+    private RouteGroupBuilder? _routeGroupBuilder;
+    private IEndpointConventionBuilder? _builder;
 
     [Given(@"I have an endpoint")]
     public void GivenIHaveAnEndpoint()

--- a/tests/Asm.AspNetCore.Modules.Tests/Routing/EndpointGroupBaseSteps.cs
+++ b/tests/Asm.AspNetCore.Modules.Tests/Routing/EndpointGroupBaseSteps.cs
@@ -62,12 +62,12 @@ public class EndpointGroupBaseSteps
         }
     }
 
-    private EndpointGroupBase _simpleEndpointGroup;
-    private EndpointGroupBase _minimalEndpointGroup;
-    private EndpointGroupBase _customAuthGroup;
-    private EndpointGroupBase _anonymousEndpointGroup;
-    private IEndpointRouteBuilder _endpointRouteBuilder;
-    private RouteGroupBuilder _routeGroupBuilder;
+    private EndpointGroupBase? _simpleEndpointGroup;
+    private EndpointGroupBase? _minimalEndpointGroup;
+    private EndpointGroupBase? _customAuthGroup;
+    private EndpointGroupBase? _anonymousEndpointGroup;
+    private IEndpointRouteBuilder _endpointRouteBuilder = null!;
+    private RouteGroupBuilder? _routeGroupBuilder;
 
     [Given(@"I have a simple endpoint group")]
     public void GivenIHaveASimpleEndpointGroup()
@@ -124,30 +124,35 @@ public class EndpointGroupBaseSteps
     [Then(@"the group path should be '(.*)'")]
     public void ThenTheGroupPathShouldBe(string expectedPath)
     {
+        Assert.NotNull(_simpleEndpointGroup);
         Assert.Equal(expectedPath, _simpleEndpointGroup.Path);
     }
 
     [Then(@"the group tag should be empty")]
     public void ThenTheGroupTagShouldBeEmpty()
     {
+        Assert.NotNull(_minimalEndpointGroup);
         Assert.True(String.IsNullOrEmpty(_minimalEndpointGroup.Tag));
     }
 
     [Then(@"the group tag should be '(.*)'")]
     public void ThenTheGroupTagShouldBe(string expectedTag)
     {
+        Assert.NotNull(_simpleEndpointGroup);
         Assert.Equal(expectedTag, _simpleEndpointGroup.Tag);
     }
 
     [Then(@"the authorization policy should be empty")]
     public void ThenTheAuthorizationPolicyShouldBeEmpty()
     {
+        Assert.NotNull(_minimalEndpointGroup);
         Assert.True(String.IsNullOrEmpty(_minimalEndpointGroup.AuthorisationPolicy));
     }
 
     [Then(@"the authorization policy should be '(.*)'")]
     public void ThenTheAuthorizationPolicyShouldBe(string expectedPolicy)
     {
+        Assert.NotNull(_simpleEndpointGroup);
         Assert.Equal(expectedPolicy, _simpleEndpointGroup.AuthorisationPolicy);
     }
 

--- a/tests/Asm.AspNetCore.Modules.Tests/Routing/IEndpointGroupSteps.cs
+++ b/tests/Asm.AspNetCore.Modules.Tests/Routing/IEndpointGroupSteps.cs
@@ -19,9 +19,9 @@ public class IEndpointGroupSteps
         }
     }
 
-    private TestEndpointGroup _testEndpointGroup;
-    private IEndpointRouteBuilder _endpointRouteBuilder;
-    private RouteGroupBuilder _routeGroupBuilder;
+    private TestEndpointGroup _testEndpointGroup = null!;
+    private IEndpointRouteBuilder _endpointRouteBuilder = null!;
+    private RouteGroupBuilder _routeGroupBuilder = null!;
 
     [Given(@"I have a test endpoint group")]
     public void GivenIHaveATestEndpointGroup()

--- a/tests/Asm.AspNetCore.Modules.Tests/Routing/IModuleSteps.cs
+++ b/tests/Asm.AspNetCore.Modules.Tests/Routing/IModuleSteps.cs
@@ -31,9 +31,9 @@ public class IModuleSteps
 
     private interface IModuleTestService;
 
-    private TestModule _testModule;
-    private IServiceCollection _serviceCollection;
-    private IEndpointRouteBuilder _endpointRouteBuilder;
+    private TestModule _testModule = null!;
+    private IServiceCollection _serviceCollection = null!;
+    private IEndpointRouteBuilder _endpointRouteBuilder = null!;
 
     [Given(@"I have a test module")]
     public void GivenIHaveATestModule()

--- a/tests/Asm.AspNetCore.Mvc.Tests/ActionConstraints/ActionConstraintTests.cs
+++ b/tests/Asm.AspNetCore.Mvc.Tests/ActionConstraints/ActionConstraintTests.cs
@@ -8,7 +8,7 @@ namespace Asm.AspNetCore.Mvc.Tests.ActionConstraints;
 [Trait("Category", "Unit")]
 public class RegexActionConstraintTests
 {
-    private static ActionConstraintContext ContextForAction(string action)
+    private static ActionConstraintContext ContextForAction(string? action)
     {
         var routeData = new RouteData();
         if (action is not null)

--- a/tests/Asm.AspNetCore.Mvc.Tests/ModelBinding/BannedWordsValidatorTests.cs
+++ b/tests/Asm.AspNetCore.Mvc.Tests/ModelBinding/BannedWordsValidatorTests.cs
@@ -6,7 +6,7 @@ namespace Asm.AspNetCore.Mvc.Tests.ModelBinding;
 [Trait("Category", "Unit")]
 public class BannedWordsValidatorTests
 {
-    private static ValidationResult Validate(object value, params string[] bannedWords)
+    private static ValidationResult? Validate(object value, params string[] bannedWords)
     {
         var attribute = new BannedWordsValidatorAttribute(bannedWords);
         var context = new ValidationContext(new object()) { DisplayName = "Field" };

--- a/tests/Asm.AspNetCore.Mvc.Tests/ModelBinding/DataTypeValidatorTests.cs
+++ b/tests/Asm.AspNetCore.Mvc.Tests/ModelBinding/DataTypeValidatorTests.cs
@@ -7,7 +7,7 @@ namespace Asm.AspNetCore.Mvc.Tests.ModelBinding;
 
 public class DataTypeValidatorTests
 {
-    private static ValidationResult Validate(string value)
+    private static ValidationResult? Validate(string value)
     {
         var attribute = new DataTypeValidatorAttribute(DataType.EmailAddress);
         var context = new ValidationContext(new object()) { DisplayName = "Email" };

--- a/tests/Asm.AspNetCore.Tests/Authentication/StandardJwtBearerOptionsSteps.cs
+++ b/tests/Asm.AspNetCore.Tests/Authentication/StandardJwtBearerOptionsSteps.cs
@@ -7,9 +7,9 @@ namespace Asm.AspNetCore.Tests.Authentication;
 [Binding]
 public class StandardJwtBearerOptionsSteps
 {
-    private OAuthOptions _oAuthOptions;
-    private JwtBearerEvents _customEvents;
-    private StandardJwtBearerOptions _standardJwtBearerOptions;
+    private OAuthOptions _oAuthOptions = null!;
+    private JwtBearerEvents _customEvents = null!;
+    private StandardJwtBearerOptions _standardJwtBearerOptions = null!;
 
     [Given(@"I have OAuthOptions with domain '(.*)' and audience '(.*)' and clientId '(.*)'")]
     public void GivenIHaveOAuthOptionsWithDomainAndAudienceAndClientId(string domain, string audience, string clientId)

--- a/tests/Asm.AspNetCore.Tests/Authorisation/OneOfAuthorisationRequirementSteps.cs
+++ b/tests/Asm.AspNetCore.Tests/Authorisation/OneOfAuthorisationRequirementSteps.cs
@@ -6,8 +6,8 @@ namespace Asm.AspNetCore.Tests.Authorisation;
 [Binding]
 public class OneOfAuthorisationRequirementSteps
 {
-    private IAuthorizationRequirement[] _requirements;
-    private OneOfAuthorisationRequirement _oneOfRequirement;
+    private IAuthorizationRequirement[] _requirements = null!;
+    private OneOfAuthorisationRequirement _oneOfRequirement = null!;
 
     [Given(@"I have authorization requirements")]
     public void GivenIHaveAuthorizationRequirements(Table table)

--- a/tests/Asm.AspNetCore.Tests/Authorisation/RouteParamAuthorisationRequirementSteps.cs
+++ b/tests/Asm.AspNetCore.Tests/Authorisation/RouteParamAuthorisationRequirementSteps.cs
@@ -5,7 +5,7 @@ namespace Asm.AspNetCore.Tests.Authorisation;
 [Binding]
 public class RouteParamAuthorisationRequirementSteps
 {
-    private RouteParamAuthorisationRequirement _requirement;
+    private RouteParamAuthorisationRequirement _requirement = null!;
 
     [When(@"I create a RouteParamAuthorisationRequirement with name '(.*)'")]
     public void WhenICreateARouteParamAuthorisationRequirementWithName(string name)

--- a/tests/Asm.AspNetCore.Tests/Extensions/HttpContextExtensionsSteps.cs
+++ b/tests/Asm.AspNetCore.Tests/Extensions/HttpContextExtensionsSteps.cs
@@ -6,8 +6,8 @@ namespace Asm.AspNetCore.Tests.Extensions;
 [Binding]
 public class HttpContextExtensionsSteps(ScenarioContext context)
 {
-    private HttpContext _httpContext;
-    private string _result;
+    private HttpContext? _httpContext;
+    private string _result = null!;
 
     [Given(@"I have an HttpContext with user claims")]
     public void GivenIHaveAnHttpContextWithUserClaims(Table table)
@@ -33,7 +33,7 @@ public class HttpContextExtensionsSteps(ScenarioContext context)
     {
         _httpContext = new DefaultHttpContext
         {
-            User = null
+            User = null!
         };
     }
 

--- a/tests/Asm.AspNetCore.Tests/Extensions/IApplicationBuilderExtensionsSecurityTests.cs
+++ b/tests/Asm.AspNetCore.Tests/Extensions/IApplicationBuilderExtensionsSecurityTests.cs
@@ -149,7 +149,7 @@ public class IApplicationBuilderExtensionsSecurityTests
     {
         public IServiceProvider ApplicationServices { get; set; } = null!;
         public Microsoft.AspNetCore.Http.Features.IFeatureCollection ServerFeatures { get; } = new Microsoft.AspNetCore.Http.Features.FeatureCollection();
-        public IDictionary<string, object> Properties { get; } = new Dictionary<string, object>();
+        public IDictionary<string, object?> Properties { get; } = new Dictionary<string, object?>();
         public RequestDelegate Build() => _ => Task.CompletedTask;
         public IApplicationBuilder New() => new FakeApplicationBuilder();
         public IApplicationBuilder Use(Func<RequestDelegate, RequestDelegate> middleware) => this;

--- a/tests/Asm.AspNetCore.Tests/Extensions/IApplicationBuilderExtensionsStandardSecurityTests.cs
+++ b/tests/Asm.AspNetCore.Tests/Extensions/IApplicationBuilderExtensionsStandardSecurityTests.cs
@@ -27,9 +27,9 @@ public class IApplicationBuilderExtensionsStandardSecurityTests
     /// registered and a terminal HTML-200 handler.
     /// </summary>
     private static async Task<(IHost host, HttpClient client)> BuildAsync(
-        Action<IServiceCollection> configureServices = null,
-        string[] exemptPrefixes = null,
-        Action<HeaderPolicyCollection> extend = null,
+        Action<IServiceCollection>? configureServices = null,
+        string[]? exemptPrefixes = null,
+        Action<HeaderPolicyCollection>? extend = null,
         string responseContentType = "text/html")
     {
         exemptPrefixes ??= [];

--- a/tests/Asm.AspNetCore.Tests/HealthChecks/ResponseWriterSteps.cs
+++ b/tests/Asm.AspNetCore.Tests/HealthChecks/ResponseWriterSteps.cs
@@ -8,10 +8,10 @@ namespace Asm.AspNetCore.Tests.HealthChecks;
 [Binding]
 public class ResponseWriterSteps
 {
-    private HealthReport _healthReport;
-    private DefaultHttpContext _httpContext;
-    private MemoryStream _responseStream;
-    private JsonDocument _responseJson;
+    private HealthReport _healthReport = null!;
+    private DefaultHttpContext _httpContext = null!;
+    private MemoryStream _responseStream = null!;
+    private JsonDocument _responseJson = null!;
     private readonly Dictionary<string, HealthReportEntry> _entries = [];
     private TimeSpan _duration = TimeSpan.FromMilliseconds(100);
 

--- a/tests/Asm.AspNetCore.Tests/Infrastructure/AsmExceptionHandlerTests.cs
+++ b/tests/Asm.AspNetCore.Tests/Infrastructure/AsmExceptionHandlerTests.cs
@@ -126,7 +126,7 @@ public class AsmExceptionHandlerTests
         Assert.Null(context);
     }
 
-    private static async Task<(bool Handled, ProblemDetailsContext Context, int StatusCode)> HandleAsync(Exception exception)
+    private static async Task<(bool Handled, ProblemDetailsContext? Context, int StatusCode)> HandleAsync(Exception exception)
     {
         var service = new CapturingProblemDetailsService();
         var handler = new AsmExceptionHandler(service);
@@ -141,7 +141,7 @@ public class AsmExceptionHandlerTests
 
     private sealed class CapturingProblemDetailsService : IProblemDetailsService
     {
-        public ProblemDetailsContext Captured { get; private set; }
+        public ProblemDetailsContext? Captured { get; private set; }
 
         public ValueTask WriteAsync(ProblemDetailsContext context)
         {

--- a/tests/Asm.AspNetCore.Tests/Integration/SharedIntegrationSteps.cs
+++ b/tests/Asm.AspNetCore.Tests/Integration/SharedIntegrationSteps.cs
@@ -28,7 +28,9 @@ public class SharedIntegrationSteps(IntegrationTestContext context)
     [Then(@"the response content type should be '(.*)'")]
     public void ThenTheResponseContentTypeShouldBe(string contentType)
     {
-        Assert.NotNull(context.Response!.Content.Headers.ContentType);
-        Assert.StartsWith(contentType, context.Response.Content.Headers.ContentType.ToString());
+        Assert.NotNull(context.Response);
+        var contentTypeHeader = context.Response.Content.Headers.ContentType;
+        Assert.NotNull(contentTypeHeader);
+        Assert.StartsWith(contentType, contentTypeHeader.ToString());
     }
 }

--- a/tests/Asm.AspNetCore.Tests/Middleware/CanonicalUrlMiddlewareTests.cs
+++ b/tests/Asm.AspNetCore.Tests/Middleware/CanonicalUrlMiddlewareTests.cs
@@ -24,7 +24,7 @@ public class CanonicalUrlMiddlewareTests
     /// assert on the 301 location header directly.
     /// </summary>
     private static async Task<(IHost host, HttpClient client)> BuildAsync(
-        Action<CanonicalUrlOptions> configure = null)
+        Action<CanonicalUrlOptions>? configure = null)
     {
         var host = await new HostBuilder()
             .ConfigureWebHost(webHost =>
@@ -52,7 +52,7 @@ public class CanonicalUrlMiddlewareTests
         return (host, client);
     }
 
-    private static string Location(HttpResponseMessage r) =>
+    private static string? Location(HttpResponseMessage r) =>
         r.Headers.Location?.ToString();
 
     // ──────────────────────────────────────────────────────────────────────────

--- a/tests/Asm.AspNetCore.Tests/Reporting/IEndpointRouteBuilderExtensionsTests.cs
+++ b/tests/Asm.AspNetCore.Tests/Reporting/IEndpointRouteBuilderExtensionsTests.cs
@@ -32,15 +32,15 @@ public class IEndpointRouteBuilderExtensionsTests
             string category,
             List<(string, LogLevel, string)> entries) : ILogger
         {
-            public IDisposable BeginScope<TState>(TState state) where TState : notnull => null;
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
             public bool IsEnabled(LogLevel logLevel) => true;
 
             public void Log<TState>(
                 LogLevel logLevel,
                 EventId eventId,
                 TState state,
-                Exception exception,
-                Func<TState, Exception, string> formatter)
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
             {
                 entries.Add((category, logLevel, formatter(state, exception)));
             }
@@ -52,7 +52,7 @@ public class IEndpointRouteBuilderExtensionsTests
     // ──────────────────────────────────────────────────────────────────────────
 
     private static async Task<(IHost host, HttpClient client, CapturingLoggerProvider logProvider)>
-        BuildHostAsync(Action<SecurityReportingOptions> configureReporting = null)
+        BuildHostAsync(Action<SecurityReportingOptions>? configureReporting = null)
     {
         var logProvider = new CapturingLoggerProvider();
 

--- a/tests/Asm.AspNetCore.Tests/Security/HttpContextPrincipalProviderSteps.cs
+++ b/tests/Asm.AspNetCore.Tests/Security/HttpContextPrincipalProviderSteps.cs
@@ -7,10 +7,10 @@ namespace Asm.AspNetCore.Tests.Security;
 [Binding]
 public class HttpContextPrincipalProviderSteps
 {
-    private Mock<IHttpContextAccessor> _httpContextAccessorMock;
-    private HttpContextPrincipalProvider _provider;
-    private ClaimsPrincipal _result;
-    private ClaimsPrincipal _expectedPrincipal;
+    private Mock<IHttpContextAccessor> _httpContextAccessorMock = null!;
+    private HttpContextPrincipalProvider _provider = null!;
+    private ClaimsPrincipal? _result;
+    private ClaimsPrincipal _expectedPrincipal = null!;
 
     [Given(@"I have an HttpContextAccessor with a user principal")]
     public void GivenIHaveAnHttpContextAccessorWithAUserPrincipal()
@@ -32,7 +32,7 @@ public class HttpContextPrincipalProviderSteps
     public void GivenIHaveAnHttpContextAccessorWithNoHttpContext()
     {
         _httpContextAccessorMock = new Mock<IHttpContextAccessor>();
-        _httpContextAccessorMock.Setup(x => x.HttpContext).Returns((HttpContext)null);
+        _httpContextAccessorMock.Setup(x => x.HttpContext).Returns((HttpContext?)null);
     }
 
     [Given(@"I have an HttpContextAccessor with HttpContext but no user")]
@@ -40,7 +40,9 @@ public class HttpContextPrincipalProviderSteps
     {
         _httpContextAccessorMock = new Mock<IHttpContextAccessor>();
         var httpContextMock = new Mock<HttpContext>();
-        httpContextMock.Setup(x => x.User).Returns((ClaimsPrincipal)null);
+        // HttpContext.User is declared non-nullable, but a mocked context can still yield null;
+        // this scenario proves the provider tolerates that.
+        httpContextMock.Setup(x => x.User).Returns((ClaimsPrincipal)null!);
         _httpContextAccessorMock.Setup(x => x.HttpContext).Returns(httpContextMock.Object);
     }
 
@@ -66,6 +68,9 @@ public class HttpContextPrincipalProviderSteps
     [Then(@"the principal should have the expected identity")]
     public void ThenThePrincipalShouldHaveTheExpectedIdentity()
     {
+        Assert.NotNull(_expectedPrincipal.Identity);
+        Assert.NotNull(_result);
+        Assert.NotNull(_result.Identity);
         Assert.Equal(_expectedPrincipal.Identity.Name, _result.Identity.Name);
     }
 }

--- a/tests/Asm.AspNetCore.Tests/Validators/DescribedValidatorSteps.cs
+++ b/tests/Asm.AspNetCore.Tests/Validators/DescribedValidatorSteps.cs
@@ -6,10 +6,10 @@ namespace Asm.AspNetCore.Tests.Validators;
 [Binding]
 public class DescribedValidatorSteps
 {
-    private TestDescribedObject _describedObject;
+    private TestDescribedObject _describedObject = null!;
     private DescribedValidator<TestDescribedObject> _validator;
-    private DescribedValidator<TestDescribedObject> _customValidator;
-    private ValidationResult _validationResult;
+    private DescribedValidator<TestDescribedObject> _customValidator = null!;
+    private ValidationResult _validationResult = null!;
 
     public DescribedValidatorSteps()
     {
@@ -25,7 +25,7 @@ public class DescribedValidatorSteps
     [Given(@"I have a described object with null name and description '(.*)'")]
     public void GivenIHaveADescribedObjectWithNullNameAndDescription(string description)
     {
-        _describedObject = new TestDescribedObject { Name = null, Description = description };
+        _describedObject = new TestDescribedObject { Name = null!, Description = description };
     }
 
     [Given(@"I have a described object with name exceeding (.*) characters and description '(.*)'")]
@@ -92,7 +92,7 @@ public class DescribedValidatorSteps
 
     private class TestDescribedObject : IDescribed, INamed
     {
-        public string Name { get; init; }
-        public string Description { get; init; }
+        public string Name { get; init; } = null!;
+        public string? Description { get; init; }
     }
 }

--- a/tests/Asm.Cqrs.AspNetCore.Tests/CommandQueryControllerSteps.cs
+++ b/tests/Asm.Cqrs.AspNetCore.Tests/CommandQueryControllerSteps.cs
@@ -6,8 +6,8 @@ namespace Asm.Cqrs.AspNetCore.Tests;
 [Binding]
 public class CommandQueryControllerSteps
 {
-    private TestableCommandQueryController _controller;
-    private string _controllerNameResult;
+    private TestableCommandQueryController _controller = null!;
+    private string _controllerNameResult = null!;
 
     [Given(@"I have a CommandQueryController instance")]
     public void GivenIHaveACommandQueryControllerInstance()

--- a/tests/Asm.Cqrs.AspNetCore.Tests/HandlersSteps.cs
+++ b/tests/Asm.Cqrs.AspNetCore.Tests/HandlersSteps.cs
@@ -7,13 +7,13 @@ namespace Asm.Cqrs.AspNetCore.Tests;
 [Binding]
 public class HandlersSteps
 {
-    private Mock<IQueryDispatcher> _queryDispatcherMock;
-    private Mock<ICommandDispatcher> _commandDispatcherMock;
-    private DefaultHttpContext _httpContext;
-    private IResult _result;
+    private Mock<IQueryDispatcher> _queryDispatcherMock = null!;
+    private Mock<ICommandDispatcher> _commandDispatcherMock = null!;
+    private DefaultHttpContext _httpContext = null!;
+    private IResult _result = null!;
     private bool _commandExecuted;
-    private object _expectedResult;
-    private Delegate _lastHandler;
+    private object _expectedResult = null!;
+    private Delegate _lastHandler = null!;
     private CommandBinding _lastBinding;
 
     // Test Query/Command types
@@ -29,7 +29,7 @@ public class HandlersSteps
     private static readonly Type ProductionHandlers =
         typeof(Asm.AspNetCore.AsmCqrsAspNetCoreEndpointRouteBuilderExtensions).Assembly.GetType("Asm.AspNetCore.Handlers")!;
 
-    private static MethodInfo Factory(string name, int genericArgs, Func<MethodInfo, bool> filter = null) =>
+    private static MethodInfo Factory(string name, int genericArgs, Func<MethodInfo, bool>? filter = null) =>
         ProductionHandlers.GetMethods(BindingFlags.Static | BindingFlags.NonPublic)
             .Where(m => m.Name == name && m.GetGenericArguments().Length == genericArgs)
             .First(m => filter?.Invoke(m) ?? true);

--- a/tests/Asm.Cqrs.AspNetCore.Tests/IEndpointRouteBuilderExtensionsSteps.cs
+++ b/tests/Asm.Cqrs.AspNetCore.Tests/IEndpointRouteBuilderExtensionsSteps.cs
@@ -6,8 +6,8 @@ namespace Asm.Cqrs.AspNetCore.Tests;
 [Binding]
 public class IEndpointRouteBuilderExtensionsSteps
 {
-    private IEndpointRouteBuilder _endpoints;
-    private RouteHandlerBuilder _routeHandlerBuilder;
+    private IEndpointRouteBuilder _endpoints = null!;
+    private RouteHandlerBuilder _routeHandlerBuilder = null!;
 
     [Given(@"I have an IEndpointRouteBuilder")]
     public void GivenIHaveAnIEndpointRouteBuilder()

--- a/tests/Asm.Cqrs.Tests/Commands/TestCommand.cs
+++ b/tests/Asm.Cqrs.Tests/Commands/TestCommand.cs
@@ -4,5 +4,5 @@ namespace Asm.Cqrs.Tests.Commands;
 
 internal class TestCommand : ICommand<bool>
 {
-    public string Input { get; init; }
+    public required string Input { get; init; }
 }

--- a/tests/Asm.Cqrs.Tests/Queries/TestQuery.cs
+++ b/tests/Asm.Cqrs.Tests/Queries/TestQuery.cs
@@ -4,5 +4,5 @@ namespace Asm.Cqrs.Tests.Queries;
 
 internal class TestQuery : IQuery<string>
 {
-    public string Input { get; init; }
+    public required string Input { get; init; }
 }

--- a/tests/Asm.Domain.Infrastructure.Tests/DomainEventsSteps.cs
+++ b/tests/Asm.Domain.Infrastructure.Tests/DomainEventsSteps.cs
@@ -7,7 +7,7 @@ namespace Asm.Domain.Infrastructure.Tests;
 [Binding]
 public class DomainEventsSteps(ScenarioContext context)
 {
-    private IServiceProvider _serviceProvider;
+    private IServiceProvider _serviceProvider = null!;
 
     [BeforeScenario]
     public void Setup()

--- a/tests/Asm.Domain.Tests/EntitySteps.cs
+++ b/tests/Asm.Domain.Tests/EntitySteps.cs
@@ -3,7 +3,7 @@ namespace Asm.Domain.Tests;
 [Binding]
 public class EntitySteps
 {
-    private TestEntity _entity;
+    private TestEntity _entity = null!;
 
     [When(@"I create a new test entity")]
     public void WhenICreateANewTestEntity()

--- a/tests/Asm.Domain.Tests/IdentifiableEqualityComparerSteps.cs
+++ b/tests/Asm.Domain.Tests/IdentifiableEqualityComparerSteps.cs
@@ -5,8 +5,8 @@ namespace Asm.Domain.Tests;
 [Binding]
 public class IdentifiableEqualityComparerSteps(ScenarioContext context)
 {
-    private TestKeyedEntity _first;
-    private TestKeyedEntity _second;
+    private TestKeyedEntity? _first;
+    private TestKeyedEntity? _second;
     private IdentifiableEqualityComparer<TestKeyedEntity, int> _comparer = new();
     private int _hashCode;
 
@@ -31,18 +31,20 @@ public class IdentifiableEqualityComparerSteps(ScenarioContext context)
     [When(@"I get the hash code using IIdentifiableEqualityComparer")]
     public void WhenIGetTheHashCodeUsingIIdentifiableEqualityComparer()
     {
+        Assert.NotNull(_first);
         _hashCode = _comparer.GetHashCode(_first);
     }
 
     [When(@"I get the hash code of null using IIdentifiableEqualityComparer")]
     public void WhenIGetTheHashCodeOfNullUsingIIdentifiableEqualityComparer()
     {
-        _hashCode = _comparer.GetHashCode(null!);
+        _hashCode = _comparer.GetHashCode(null);
     }
 
     [Then(@"the hash code should equal the ID hash code")]
     public void ThenTheHashCodeShouldEqualTheIdHashCode()
     {
+        Assert.NotNull(_first);
         Assert.Equal(_first.Id.GetHashCode(), _hashCode);
     }
 

--- a/tests/Asm.Domain.Tests/KeyedEntityEqualityTests.cs
+++ b/tests/Asm.Domain.Tests/KeyedEntityEqualityTests.cs
@@ -15,7 +15,9 @@ public class KeyedEntityEqualityTests
 
         // Reflexivity must hold even for a transient (default-key) entity.
         Assert.True(entity.Equals(entity));
+#pragma warning disable CS1718 // Comparison to same variable is deliberate: this asserts reflexivity of ==.
         Assert.True(entity == entity);
+#pragma warning restore CS1718
     }
 
     /// <summary>

--- a/tests/Asm.Domain.Tests/KeyedEntityTestsSteps.cs
+++ b/tests/Asm.Domain.Tests/KeyedEntityTestsSteps.cs
@@ -3,8 +3,8 @@ namespace Asm.Domain.Tests;
 [Binding]
 public class KeyedEntityTestsSteps(ScenarioContext context)
 {
-    private TestKeyedEntity _first;
-    private TestKeyedEntity _second;
+    private TestKeyedEntity? _first;
+    private TestKeyedEntity? _second;
 
     [Given(@"I have a keyed entity with ID (.*)")]
     public void GivenIHaveAKeyedEntityWithID(int? id)
@@ -21,6 +21,7 @@ public class KeyedEntityTestsSteps(ScenarioContext context)
     [When(@"I call first\.Equals\(second\)")]
     public void WhenICallFirst_EqualsSecond()
     {
+        Assert.NotNull(_first);
         context.AddResult(_first.Equals(_second));
     }
 

--- a/tests/Asm.Domain.Tests/NamedEntityTestsSteps.cs
+++ b/tests/Asm.Domain.Tests/NamedEntityTestsSteps.cs
@@ -3,8 +3,8 @@ namespace Asm.Domain.Tests;
 [Binding]
 public class NamedEntityTestsSteps(ScenarioContext context)
 {
-    private TestNamedEntity _first;
-    private TestNamedEntity _second;
+    private TestNamedEntity _first = null!;
+    private TestNamedEntity _second = null!;
 
     [Given(@"I have a named entity with name '(.*)'")]
     public void GivenIHaveANamedEntityWithName(string name)

--- a/tests/Asm.Domain.Tests/SpecificationSteps.cs
+++ b/tests/Asm.Domain.Tests/SpecificationSteps.cs
@@ -3,8 +3,8 @@ namespace Asm.Domain.Tests;
 [Binding]
 public class SpecificationSteps
 {
-    private IQueryable<TestSpecifiableEntity> _query;
-    private IQueryable<TestSpecifiableEntity> _result;
+    private IQueryable<TestSpecifiableEntity> _query = null!;
+    private IQueryable<TestSpecifiableEntity> _result = null!;
 
     [Given(@"I have a collection of test entities with IDs \[(.*)\]")]
     public void GivenIHaveACollectionOfTestEntitiesWithIds(string ids)
@@ -23,7 +23,7 @@ public class SpecificationSteps
     [When(@"I apply a null specification")]
     public void WhenIApplyANullSpecification()
     {
-        _result = _query.Specify((ISpecification<TestSpecifiableEntity>)null);
+        _result = _query.Specify(null);
     }
 
     [When(@"I apply the GreaterThanTwoSpecification using type parameter")]

--- a/tests/Asm.Hosting.Tests/BackgroundWorkQueueTests.cs
+++ b/tests/Asm.Hosting.Tests/BackgroundWorkQueueTests.cs
@@ -45,7 +45,7 @@ public class BackgroundWorkQueueTests
 
         queue.Queue(99);
 
-        var item = await dequeueTask.WaitAsync(TimeSpan.FromSeconds(1));
+        var item = await dequeueTask.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
         Assert.Equal(99, item);
     }
 

--- a/tests/Asm.Hosting.Tests/QueuedHostedServiceTests.cs
+++ b/tests/Asm.Hosting.Tests/QueuedHostedServiceTests.cs
@@ -173,7 +173,7 @@ public class QueuedHostedServiceTests
 
         public bool IsEnabled(LogLevel logLevel) => true;
 
-        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
             => messages.Enqueue(formatter(state, exception));
     }
 

--- a/tests/Asm.Net.Tests/IPAddressExtensionsSteps.cs
+++ b/tests/Asm.Net.Tests/IPAddressExtensionsSteps.cs
@@ -11,10 +11,10 @@ public class IPAddressExtensionsSteps(ScenarioContext context, ScenarioData scen
 
     public class ScenarioData
     {
-        public IPAddress IPAddress { get; set; }
-        public IPAddress SubnetMask { get; set; }
+        public IPAddress IPAddress { get; set; } = null!;
+        public IPAddress SubnetMask { get; set; } = null!;
 
-        public string Cidr { get; set; }
+        public string Cidr { get; set; } = null!;
 
         public uint IPAddressAsUInt32 { get; set; }
     }

--- a/tests/Asm.Tests/BoundedTests.cs
+++ b/tests/Asm.Tests/BoundedTests.cs
@@ -186,7 +186,7 @@ public class BoundedTests
     public async Task ConditionAsyncAlwaysTrueThrowsAfterMaxIterations()
     {
         await Assert.ThrowsAsync<BoundExceededException>(
-            () => Bounded.WhileAsync(() => true, _ => Task.CompletedTask, maxIterations: 10));
+            () => Bounded.WhileAsync(() => true, _ => Task.CompletedTask, maxIterations: 10, cancellationToken: TestContext.Current.CancellationToken));
     }
 
     /// <summary>

--- a/tests/Asm.Tests/ByteArraySteps.cs
+++ b/tests/Asm.Tests/ByteArraySteps.cs
@@ -6,9 +6,9 @@ public class ByteArraySteps(ScenarioContext context)
     private ByteArray _byteArray;
     private ByteArray _byteArray2;
     private ByteArray _resultByteArray;
-    private char[] _resultCharArray;
-    private byte[] _rawByteArray;
-    private byte[] _resultRawByteArray;
+    private char[] _resultCharArray = null!;
+    private byte[] _rawByteArray = null!;
+    private byte[] _resultRawByteArray = null!;
 
     [Given(@"a ByteArray with values (.*) and (.*) endian")]
     public void GivenAByteArrayWithValues(string values, string endian)

--- a/tests/Asm.Tests/ExtendedBitArraySteps.cs
+++ b/tests/Asm.Tests/ExtendedBitArraySteps.cs
@@ -5,14 +5,14 @@ namespace Asm.Tests;
 [Binding]
 public class ExtendedBitArraySteps(ScenarioContext context)
 {
-    private BitArray _bitArray;
+    private BitArray _bitArray = null!;
     private Endian _endian;
-    private ExtendedBitArray _extendedBitArray;
-    private ExtendedBitArray _extendedBitArray2;
-    private byte[] _byteArray;
-    private object _conversionResult;
-    private string _conversionResultString;
-    private bool[] _rangeResult;
+    private ExtendedBitArray _extendedBitArray = null!;
+    private ExtendedBitArray _extendedBitArray2 = null!;
+    private byte[] _byteArray = null!;
+    private object? _conversionResult;
+    private string? _conversionResultString;
+    private bool[] _rangeResult = null!;
 
     // Primitive value holders for constructors
     private byte _singleByte;
@@ -168,7 +168,7 @@ public class ExtendedBitArraySteps(ScenarioContext context)
     {
         context.CatchException(() =>
         {
-            ExtendedBitArray nullArray = null;
+            ExtendedBitArray nullArray = null!;
             _extendedBitArray.CopyTo(nullArray, index);
         });
     }

--- a/tests/Asm.Tests/Extensions/ArrayExtensionsSteps.cs
+++ b/tests/Asm.Tests/Extensions/ArrayExtensionsSteps.cs
@@ -3,8 +3,8 @@ namespace Asm.Tests.Extensions;
 [Binding]
 public class ArrayExtensionsSteps(ScenarioContext context)
 {
-    private int[] _array;
-    private int[] _originalValues;
+    private int[]? _array;
+    private int[] _originalValues = null!;
 
     [Given(@"I have an array with values \[(.*)\]")]
     public void GivenIHaveAnArrayWithValues(string values)
@@ -28,7 +28,7 @@ public class ArrayExtensionsSteps(ScenarioContext context)
     [When(@"I call Shuffle on the array")]
     public void WhenICallShuffleOnTheArray()
     {
-        context.CatchException(() => _array.Shuffle());
+        context.CatchException(() => _array!.Shuffle());
     }
 
     [When(@"I call IsNullOrEmpty on the array")]
@@ -40,12 +40,13 @@ public class ArrayExtensionsSteps(ScenarioContext context)
     [When(@"I call Empty on the array")]
     public void WhenICallEmptyOnTheArray()
     {
-        context.AddResult(_array.Empty());
+        context.AddResult(_array!.Empty());
     }
 
     [Then(@"the array should contain all original elements")]
     public void ThenTheArrayShouldContainAllOriginalElements()
     {
+        Assert.NotNull(_array);
         var sorted = _array.OrderBy(x => x).ToArray();
         var originalSorted = _originalValues.OrderBy(x => x).ToArray();
         Assert.Equal(originalSorted, sorted);
@@ -54,6 +55,7 @@ public class ArrayExtensionsSteps(ScenarioContext context)
     [Then(@"the array should have (.*) elements")]
     public void ThenTheArrayShouldHaveElements(int count)
     {
+        Assert.NotNull(_array);
         Assert.Equal(count, _array.Length);
     }
 }

--- a/tests/Asm.Tests/Extensions/ClaimsPrincipalExtensionsSteps.cs
+++ b/tests/Asm.Tests/Extensions/ClaimsPrincipalExtensionsSteps.cs
@@ -5,7 +5,7 @@ namespace Asm.Tests.Extensions;
 [Binding]
 public class ClaimsPrincipalExtensionsSteps(ScenarioContext context)
 {
-    private ClaimsPrincipal _claimsPrincipal;
+    private ClaimsPrincipal _claimsPrincipal = null!;
 
     [Given(@"I have a ClaimsPrincipal with a claim of type ""(.*)"" and value ""(.*)""")]
     public void GivenIHaveAClaimsPrincipalWithAClaimOfTypeAndValue(string claimType, string claimValue)

--- a/tests/Asm.Tests/Extensions/DateTimeExtensionsSteps.cs
+++ b/tests/Asm.Tests/Extensions/DateTimeExtensionsSteps.cs
@@ -9,7 +9,7 @@ public class DateTimeExtensionsSteps(ScenarioContext context)
     {
         public DateTime Date { get; set; }
         public DateTime OtherDate { get; set; }
-        public IFormatProvider FormatProvider { get; set; }
+        public IFormatProvider? FormatProvider { get; set; }
     }
 
     private ScenarioInput _input = new();

--- a/tests/Asm.Tests/Extensions/DecimalExtensionsSteps.cs
+++ b/tests/Asm.Tests/Extensions/DecimalExtensionsSteps.cs
@@ -27,6 +27,7 @@ public class DecimalExtensionsSteps(ScenarioContext context)
     [When(@"I call ToRoundedCurrencyString expecting an exception")]
     public void WhenICallToRoundedCurrencyStringExpectingAnException()
     {
+        Assert.NotNull(_places);
         context.CatchException(() => _input.ToRoundedCurrencyString(_places.Value));
     }
 

--- a/tests/Asm.Tests/Extensions/EnumerableAsyncExtensionsTests.cs
+++ b/tests/Asm.Tests/Extensions/EnumerableAsyncExtensionsTests.cs
@@ -49,7 +49,7 @@ public class EnumerableAsyncExtensionsTests
     [Trait("Category", "Unit")]
     public async Task SelectAsyncNullSourceThrows()
     {
-        IEnumerable<int> source = null;
+        IEnumerable<int> source = null!;
 
         await Assert.ThrowsAsync<ArgumentNullException>(() => source.SelectAsync(x => Task.FromResult(x)));
     }
@@ -58,6 +58,6 @@ public class EnumerableAsyncExtensionsTests
     [Trait("Category", "Unit")]
     public async Task SelectAsyncNullSelectorThrows()
     {
-        await Assert.ThrowsAsync<ArgumentNullException>(() => new[] { 1 }.SelectAsync<int, int>(null));
+        await Assert.ThrowsAsync<ArgumentNullException>(() => new[] { 1 }.SelectAsync<int, int>(null!));
     }
 }

--- a/tests/Asm.Tests/Extensions/ICollectionExtensionsSteps.cs
+++ b/tests/Asm.Tests/Extensions/ICollectionExtensionsSteps.cs
@@ -3,8 +3,8 @@ namespace Asm.Tests.Extensions;
 [Binding]
 public class ICollectionExtensionsSteps(ScenarioContext context)
 {
-    private ICollection<int> _collection;
-    private IEnumerable<int> _itemsToAdd;
+    private ICollection<int>? _collection;
+    private IEnumerable<int>? _itemsToAdd;
 
     [Given(@"I have a collection with values \[(.*)\]")]
     public void GivenIHaveACollectionWithValues(string values)
@@ -54,7 +54,7 @@ public class ICollectionExtensionsSteps(ScenarioContext context)
     {
         try
         {
-            _collection.AddRange(_itemsToAdd!);
+            _collection!.AddRange(_itemsToAdd!);
         }
         catch (Exception ex)
         {

--- a/tests/Asm.Tests/Extensions/IEnumerableExtensionsSteps.cs
+++ b/tests/Asm.Tests/Extensions/IEnumerableExtensionsSteps.cs
@@ -3,10 +3,10 @@ namespace Asm.Tests.Extensions;
 [Binding]
 public class IEnumerableExtensionsSteps(ScenarioContext context)
 {
-    private IEnumerable<int> _enumerable;
-    private IEnumerable<int> _result;
+    private IEnumerable<int>? _enumerable;
+    private IEnumerable<int> _result = null!;
     private bool _boolResult;
-    private Exception _exception;
+    private Exception? _exception;
 
     [Given(@"I have an enumerable with values \[(.*)\]")]
     public void GivenIHaveAnEnumerableWithValues(string values)

--- a/tests/Asm.Tests/Extensions/IListExtensionsSteps.cs
+++ b/tests/Asm.Tests/Extensions/IListExtensionsSteps.cs
@@ -3,8 +3,8 @@ namespace Asm.Tests.Extensions;
 [Binding]
 public class IListExtensionsSteps(ScenarioContext context)
 {
-    private IList<int> _list;
-    private IList<int> _originalValues;
+    private IList<int>? _list;
+    private IList<int> _originalValues = null!;
     private bool _boolResult;
 
     [Given(@"I have a list with values \[(.*)\]")]

--- a/tests/Asm.Tests/Extensions/IQueryableExtensionsSteps.cs
+++ b/tests/Asm.Tests/Extensions/IQueryableExtensionsSteps.cs
@@ -8,16 +8,16 @@ public class IQueryableExtensionsSteps
     private class Item
     {
         public int Id { get; set; }
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
 
-        public override bool Equals(object obj) =>
+        public override bool Equals(object? obj) =>
             obj is Item item && item.Id == Id && item.Name == Name;
 
         public override int GetHashCode() => HashCode.Combine(Id, Name);
     }
 
-    private IQueryable<Item> _dataSource;
-    private IQueryable<Item> _result;
+    private IQueryable<Item> _dataSource = null!;
+    private IQueryable<Item> _result = null!;
 
     [Given(@"I have a data source with the following items")]
     public void GivenIHaveADataSourceWithTheFollowingItems(Table table)

--- a/tests/Asm.Tests/Extensions/StringBuilderExtensionsSteps.cs
+++ b/tests/Asm.Tests/Extensions/StringBuilderExtensionsSteps.cs
@@ -6,7 +6,7 @@ namespace Asm.Tests.Extensions;
 [Binding]
 public class StringBuilderExtensionsSteps
 {
-    private StringBuilder _stringBuilder;
+    private StringBuilder _stringBuilder = null!;
 
     [Given(@"I have a StringBuilder with content '(.*)'")]
     public void GivenIHaveAStringBuilderWithContent(string content)

--- a/tests/Asm.Tests/HexColourSteps.cs
+++ b/tests/Asm.Tests/HexColourSteps.cs
@@ -7,14 +7,14 @@ namespace Asm.Tests;
 [Scope(Feature = "HexColour")]
 public class HexColourSteps(ScenarioContext context)
 {
-    private string _hexColour = null;
+    private string? _hexColour = null;
     private uint _uintColour;
     private HexColour _result;
     private HexColour _result2;
-    private string _jsonResult;
-    private string _jsonInput;
-    private object _conversionResult;
-    private string _conversionResultString;
+    private string _jsonResult = null!;
+    private string _jsonInput = null!;
+    private object _conversionResult = null!;
+    private string _conversionResultString = null!;
     private bool _conversionResultBool;
 
     [Given("I have a string {string}")]
@@ -56,13 +56,13 @@ public class HexColourSteps(ScenarioContext context)
     [When("I create a new HexColour from the string")]
     public void WhenICreateANewHexColourFromTheString()
     {
-        context.CatchException(() => _result = new HexColour(_hexColour));
+        context.CatchException(() => _result = new HexColour(_hexColour!));
     }
 
     [When("I parse a new HexColour from the string")]
     public void WhenIParseANewHexColourFromTheString()
     {
-        context.CatchException(() => _result = HexColour.Parse(_hexColour));
+        context.CatchException(() => _result = HexColour.Parse(_hexColour!));
     }
 
     [When("I try parse a new HexColour from the string")]
@@ -136,7 +136,7 @@ public class HexColourSteps(ScenarioContext context)
     [When("I check equality with null object")]
     public void WhenICheckEqualityWithNullObject()
     {
-        _conversionResultBool = _result.Equals((object)null);
+        _conversionResultBool = _result.Equals((object?)null);
     }
 
     [When("I check equality with another HexColour value")]

--- a/tests/Asm.Tests/NybbleSteps.cs
+++ b/tests/Asm.Tests/NybbleSteps.cs
@@ -8,10 +8,10 @@ public class NybbleSteps(ScenarioContext context)
     private byte _byteValue;
     private uint _uintValue;
     private int _intValue;
-    private byte[] _bytes;
+    private byte[] _bytes = null!;
     private Nybble _nybble1;
     private Nybble _nybble2;
-    private Nybble[] _nybbleArray;
+    private Nybble[] _nybbleArray = null!;
     private int _hashCode;
 
     [Given(@"I have a value (.*)")]

--- a/tests/Asm.Tests/PagedResultSteps.cs
+++ b/tests/Asm.Tests/PagedResultSteps.cs
@@ -3,8 +3,8 @@ namespace Asm.Tests;
 [Binding]
 public class PagedResultSteps
 {
-    private List<int> _items;
-    private PagedResult<int> _result;
+    private List<int> _items = null!;
+    private PagedResult<int> _result = null!;
 
     [Given(@"I have a list of items \[(.*)\]")]
     public void GivenIHaveAListOfItems(string values)

--- a/tests/Asm.Tests/StringExtensionsSteps.cs
+++ b/tests/Asm.Tests/StringExtensionsSteps.cs
@@ -4,8 +4,8 @@
 [Scope(Feature = "String Extensions")]
 public class StringExtensionsSteps(ScenarioContext context)
 {
-    private string _input;
-    private string _separator;
+    private string _input = null!;
+    private string _separator = null!;
 
     [Given(@"I have a string '(.*)'")]
     public void GivenIHaveAString(string input)

--- a/tests/Asm.Umbraco.Authentication.Tests/EntraId/IUmbracoBuilderExtensionsTests.cs
+++ b/tests/Asm.Umbraco.Authentication.Tests/EntraId/IUmbracoBuilderExtensionsTests.cs
@@ -153,7 +153,7 @@ public class IUmbracoBuilderExtensionsTests
     [Trait("Category", "Unit")]
     public void AddEntraIdAuthenticationWithNullBuilderThrowsArgumentNullException()
     {
-        IUmbracoBuilder nullBuilder = null;
+        IUmbracoBuilder nullBuilder = null!;
 
         Assert.Throws<ArgumentNullException>(() =>
             nullBuilder.AddEntraIdAuthentication(o =>
@@ -176,7 +176,7 @@ public class IUmbracoBuilderExtensionsTests
         var (builder, _) = CreateBuilder();
 
         Assert.Throws<ArgumentNullException>(() =>
-            builder.AddEntraIdAuthentication((Action<EntraIdOptions>)null));
+            builder.AddEntraIdAuthentication((Action<EntraIdOptions>)null!));
     }
 
     // -----------------------------------------------------------------------
@@ -289,7 +289,7 @@ public class IUmbracoBuilderExtensionsTests
         var (builder, _) = CreateBuilder();
 
         Assert.Throws<ArgumentNullException>(() =>
-            builder.AddEntraIdAuthentication((IConfigurationSection)null));
+            builder.AddEntraIdAuthentication((IConfigurationSection)null!));
     }
 
     /// <summary>
@@ -301,7 +301,7 @@ public class IUmbracoBuilderExtensionsTests
     [Trait("Category", "Unit")]
     public void AddEntraIdAuthenticationWithConfigSectionNullBuilderThrowsArgumentNullException()
     {
-        IUmbracoBuilder nullBuilder = null;
+        IUmbracoBuilder nullBuilder = null!;
 
         Assert.Throws<ArgumentNullException>(() =>
             nullBuilder.AddEntraIdAuthentication(BuildConfigSection()));
@@ -317,7 +317,7 @@ public class IUmbracoBuilderExtensionsTests
         string clientSecret = "default-secret")
     {
         var config = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string>
+            .AddInMemoryCollection(new Dictionary<string, string?>
             {
                 ["EntraId:TenantId"] = tenantId,
                 ["EntraId:ClientId"] = clientId,

--- a/tests/Asm.Umbraco.Tests/Extensions/IPublishedContentExtensionsTests.cs
+++ b/tests/Asm.Umbraco.Tests/Extensions/IPublishedContentExtensionsTests.cs
@@ -35,7 +35,7 @@ public class IPublishedContentExtensionsTests
     [Trait("Category", "Unit")]
     public void NameAsCssClassReturnsNullWhenContentIsNull()
     {
-        IPublishedContent content = null;
+        IPublishedContent? content = null;
         var result = content.NameAsCssClass();
         Assert.Null(result);
     }

--- a/tests/Asm.Umbraco.Tests/MachineInfo/IUmbracoBuilderExtensionsTests.cs
+++ b/tests/Asm.Umbraco.Tests/MachineInfo/IUmbracoBuilderExtensionsTests.cs
@@ -91,7 +91,7 @@ public class IUmbracoBuilderExtensionsTests
         var (builder, services) = CreateBuilder();
 
         var config = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string>
+            .AddInMemoryCollection(new Dictionary<string, string?>
             {
                 ["MachineInfo:MachineName"] = "section-machine",
                 ["MachineInfo:EnvironmentVariableName"] = "SECTION_VAR"
@@ -117,7 +117,7 @@ public class IUmbracoBuilderExtensionsTests
         var (builder, services) = CreateBuilder();
 
         var config = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string>
+            .AddInMemoryCollection(new Dictionary<string, string?>
             {
                 ["MachineInfo:MachineName"] = "section-machine",
                 ["MachineInfo:EnvironmentVariableName"] = "SECTION_VAR"
@@ -144,7 +144,7 @@ public class IUmbracoBuilderExtensionsTests
         var (builder, _) = CreateBuilder();
 
         var config = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string> { ["MachineInfo:MachineName"] = "m" })
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["MachineInfo:MachineName"] = "m" })
             .Build();
 
         var returned = builder.AddFixedMachineInfoFactory(config.GetSection("MachineInfo"));
@@ -161,7 +161,7 @@ public class IUmbracoBuilderExtensionsTests
     [Trait("Category", "Unit")]
     public void AddFixedMachineInfoFactoryWithNullBuilderThrowsArgumentNullException()
     {
-        IUmbracoBuilder nullBuilder = null;
+        IUmbracoBuilder nullBuilder = null!;
         Assert.Throws<ArgumentNullException>(() =>
             nullBuilder.AddFixedMachineInfoFactory(opts => opts.MachineName = "x"));
     }
@@ -177,6 +177,6 @@ public class IUmbracoBuilderExtensionsTests
     {
         var (builder, _) = CreateBuilder();
         Assert.Throws<ArgumentNullException>(() =>
-            builder.AddFixedMachineInfoFactory((Action<FixedMachineInfoFactoryOptions>)null));
+            builder.AddFixedMachineInfoFactory((Action<FixedMachineInfoFactoryOptions>)null!));
     }
 }

--- a/tests/Asm.Umbraco.Tests/TagHelpers/ImgSetTagHelperTests.cs
+++ b/tests/Asm.Umbraco.Tests/TagHelpers/ImgSetTagHelperTests.cs
@@ -31,7 +31,7 @@ public class ImgSetTagHelperTests
             attributes: new TagHelperAttributeList(),
             getChildContentAsync: (_, _) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
 
-    private ImgSetTagHelper CreateTagHelper(IEnumerable<IPublishedContent> images = null)
+    private ImgSetTagHelper CreateTagHelper(IEnumerable<IPublishedContent>? images = null)
     {
         var envMock = new Mock<IWebHostEnvironment>();
         envMock.Setup(e => e.EnvironmentName).Returns("Production");

--- a/tests/Asm.Win32.Tests/HostsSteps.cs
+++ b/tests/Asm.Win32.Tests/HostsSteps.cs
@@ -182,7 +182,7 @@ public class HostsSteps(ScenarioContext context) : IDisposable
         // Repeatedly refresh on one thread while another enumerates the read-only
         // snapshot. A non-thread-safe implementation would tear or throw here.
         using CancellationTokenSource cts = new();
-        Exception failure = null;
+        Exception? failure = null;
 
         Thread reader = new(() =>
         {
@@ -272,7 +272,7 @@ public class HostsSteps(ScenarioContext context) : IDisposable
     [Then(@"the exception message should contain ""(.*)""")]
     public void ThenTheExceptionMessageShouldContain(string fragment)
     {
-        Exception ex = context.GetException();
+        Exception? ex = context.GetException();
         Assert.NotNull(ex);
         Assert.Contains(fragment, ex.Message);
     }

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -6,7 +6,7 @@
     <OutputType>Exe</OutputType>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
-    <Nullable>disable</Nullable>
+    <Nullable>enable</Nullable>
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>
   


### PR DESCRIPTION
## Summary

Flips `tests/Directory.Build.props` from `<Nullable>disable</Nullable>` to `enable`, aligning the test projects with the root build props, and clears the ~169 warnings that surfaced. Solution builds with **0 warnings**; all **1042 tests pass**.

## Approach to the test fixes

The governing rule was **annotate `T?` where null is genuinely possible, `= null!` only where the Reqnroll lifecycle guarantees assignment** — not a blanket `= null!` sweep, which would clear the warnings while discarding the information nullable exists to surface.

- **`T?` where null is real** — null-input scenarios (`[Given] I have a null array`), captured exceptions where "none thrown" is the passing state, and results a `[Then]` asserts *are* null. Notably, the MVC validator helpers return `ValidationResult?` because `ValidationResult.Success` **is** `null` and the tests assert against it.
- **`= null!`** — step fields assigned in a `[Given]`/`[When]` before any `[Then]` reads them.
- **`Assert.NotNull(x)` over `x!`** for possibly-null dereferences — xUnit v3 annotates it `[NotNull]`, so it narrows the compiler's null-state *and* strengthens the assertion.
- **Test fakes corrected** to match the nullability of the interface members they implement: `CapturingLogger.Log` (`ILogger.Log`), `FakeApplicationBuilder.Properties` (`IApplicationBuilder.Properties`), `TestDescribedObject.Description` (`IDescribed.Description`).

The one `#pragma` in the diff is a deliberate `CS1718` suppression on `Assert.True(entity == entity)` — a reflexivity test of the `==` operator, where the self-comparison is the point.

## Production changes (`src/`)

The exercise surfaced four production annotations that forbade null while the implementation already handled it. **All are source- and binary-compatible widenings** — no caller breaks, so no major-version bump:

| File | Change |
|---|---|
| `AsmDomainQueryableExtensions.Specify<T>` | Parameter → `ISpecification<T>?` (body already branches on `== null`) |
| `IdentifiableEqualityComparer.GetHashCode` | `[AllowNull]`, weakening the base `[DisallowNull]` precondition to match the null-tolerant body |
| `AsmUmbracoPublishedContentExtensions.NameAsCssClass` | Parameter → `IPublishedContent?`, **and** `model?.Name?.ToLower()` fixes a latent NRE when a content item's `Name` is itself null |
| `ImgSetTagHelper.Images` | Property → `IEnumerable<IPublishedContent>?`; its null guard is load-bearing |

## Notes for the reviewer

- Two pre-existing, non-nullable **xUnit1051** warnings (`BoundedTests`, `BackgroundWorkQueueTests`) were fixed in passing — adding `TestContext.Current.CancellationToken` — since they otherwise block a genuinely 0-warning build. Behaviour is unchanged.
- **Design question, not folded in:** this makes `IdentifiableEqualityComparer` null-tolerant while the sibling `KeyedEntityEqualityComparer` still *throws* on null. `[AllowNull]` faithfully documents that existing divergence; unifying the two would be a deliberate behavioural change for a separate PR.
- `NameAsCssClass`'s null-`Name` path is now handled but not directly covered by a test (the existing test exercises null *content*).

🤖 Generated with [Claude Code](https://claude.com/claude-code)