### PR TITLE
Raise branch coverage back above 80%

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,10 +76,12 @@ jobs:
           - { name: "Asm.AspNetCore.Tests", path: "tests/Asm.AspNetCore.Tests" }
           - { name: "Asm.AspNetCore.Modules.Tests", path: "tests/Asm.AspNetCore.Modules.Tests" }
           - { name: "Asm.AspNetCore.Mvc.Tests", path: "tests/Asm.AspNetCore.Mvc.Tests" }
+          - { name: "Asm.AspNetCore.Api.Tests", path: "tests/Asm.AspNetCore.Api.Tests" }
           - { name: "Asm.Cqrs.Tests", path: "tests/Asm.Cqrs.Tests" }
           - { name: "Asm.Cqrs.AspNetCore.Tests", path: "tests/Asm.Cqrs.AspNetCore.Tests" }
           - { name: "Asm.Domain.Tests", path: "tests/Asm.Domain.Tests" }
           - { name: "Asm.Domain.Infrastructure.Tests", path: "tests/Asm.Domain.Infrastructure.Tests" }
+          - { name: "Asm.Hosting.Tests", path: "tests/Asm.Hosting.Tests" }
           - { name: "Asm.OAuth.Tests", path: "tests/Asm.OAuth.Tests" }
           - { name: "Asm.Net.Tests", path: "tests/Asm.Net.Tests" }
           - { name: "Asm.Serilog.Tests", path: "tests/Asm.Serilog.Tests" }

--- a/tests/Asm.AspNetCore.Api.Tests/OpenApiDocumentTransformerTests.cs
+++ b/tests/Asm.AspNetCore.Api.Tests/OpenApiDocumentTransformerTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Reflection;
+using System.Reflection.Emit;
 using System.Threading;
 using System.Threading.Tasks;
 using Asm.AspNetCore.Api;
@@ -40,6 +42,31 @@ public class OpenApiDocumentTransformerTests
 
     [Fact]
     [Trait("Category", "Unit")]
+    public async Task ServerPathPrefixLeavesNonMatchingPathsUntouched()
+    {
+        var document = new OpenApiDocument { Paths = new OpenApiPaths() };
+        document.Paths.Add("/health", new OpenApiPathItem());
+
+        await new ServerPathPrefixDocumentTransformer("/api").TransformAsync(document, null!, CancellationToken.None);
+
+        Assert.True(document.Paths.ContainsKey("/health"));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task ServerPathPrefixWithoutPathsStillSetsServer()
+    {
+        var document = new OpenApiDocument { Paths = null! };
+
+        await new ServerPathPrefixDocumentTransformer("/api").TransformAsync(document, null!, CancellationToken.None);
+
+        Assert.NotNull(document.Servers);
+        Assert.Equal("/api", document.Servers[0].Url);
+        Assert.Null(document.Paths);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
     public void ServerPathPrefixRequiresANonEmptyPrefix()
     {
         Assert.Throws<ArgumentException>(() => new ServerPathPrefixDocumentTransformer(""));
@@ -58,6 +85,47 @@ public class OpenApiDocumentTransformerTests
         Assert.NotNull(document.Info);
         Assert.Equal("My API", document.Info.Title);
         Assert.False(String.IsNullOrEmpty(document.Info.Version));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task DocumentInfoPreservesExistingInfoInstance()
+    {
+        var info = new OpenApiInfo { Description = "kept" };
+        var document = new OpenApiDocument { Info = info };
+
+        await new DocumentInfoTransformer("My API", typeof(string).Assembly).TransformAsync(document, null!, CancellationToken.None);
+
+        Assert.Same(info, document.Info);
+        Assert.Equal("My API", document.Info.Title);
+        Assert.Equal("kept", document.Info.Description);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task DocumentInfoDefaultsToEntryAssembly()
+    {
+        var document = new OpenApiDocument();
+
+        // No assembly supplied — the transformer falls back to the entry/executing assembly.
+        await new DocumentInfoTransformer("My API").TransformAsync(document, null!, CancellationToken.None);
+
+        Assert.NotNull(document.Info);
+        Assert.Equal("My API", document.Info.Title);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task DocumentInfoOmitsVersionWhenAssemblyHasNoFileVersion()
+    {
+        // A dynamic assembly has an empty Location, so no file version can be read.
+        var dynamicAssembly = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Dynamic"), AssemblyBuilderAccess.Run);
+        var document = new OpenApiDocument();
+
+        await new DocumentInfoTransformer("My API", dynamicAssembly).TransformAsync(document, null!, CancellationToken.None);
+
+        Assert.Equal("My API", document.Info.Title);
+        Assert.True(String.IsNullOrEmpty(document.Info.Version));
     }
 
     [Fact]

--- a/tests/Asm.AspNetCore.Api.Tests/OpenApiSchemaConventionsTests.cs
+++ b/tests/Asm.AspNetCore.Api.Tests/OpenApiSchemaConventionsTests.cs
@@ -55,6 +55,20 @@ public class OpenApiSchemaConventionsTests
         Assert.Equal(OpenApiOptions.CreateDefaultSchemaReferenceId(jsonTypeInfo), DisplayNameSchemaReferenceIds.Resolve(jsonTypeInfo));
     }
 
+    /// <summary>
+    /// Given a non-object type (which cannot carry a DisplayName)
+    /// When its schema reference ID is resolved
+    /// Then the default algorithm is used rather than inspecting for a DisplayName
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void DisplayNameSchemaReferenceIdFallsBackForNonObjectTypes()
+    {
+        var jsonTypeInfo = JsonSerializerOptions.Default.GetTypeInfo(typeof(int));
+
+        Assert.Equal(OpenApiOptions.CreateDefaultSchemaReferenceId(jsonTypeInfo), DisplayNameSchemaReferenceIds.Resolve(jsonTypeInfo));
+    }
+
 #nullable enable
     private sealed class Model
     {

--- a/tests/Asm.AspNetCore.Mvc.Tests/ModelBinding/DataTypeValidatorTests.cs
+++ b/tests/Asm.AspNetCore.Mvc.Tests/ModelBinding/DataTypeValidatorTests.cs
@@ -1,5 +1,12 @@
 using System.ComponentModel.DataAnnotations;
 using Asm.AspNetCore.Mvc.ModelBinding.Validation;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Asm.AspNetCore.Mvc.Tests.ModelBinding;
 
@@ -7,11 +14,19 @@ namespace Asm.AspNetCore.Mvc.Tests.ModelBinding;
 
 public class DataTypeValidatorTests
 {
-    private static ValidationResult? Validate(string value)
+    private static ValidationResult? Validate(object? value, DataType dataType = DataType.EmailAddress)
     {
-        var attribute = new DataTypeValidatorAttribute(DataType.EmailAddress);
+        var attribute = new DataTypeValidatorAttribute(dataType);
         var context = new ValidationContext(new object()) { DisplayName = "Email" };
         return attribute.GetValidationResult(value, context);
+    }
+
+    private static ClientModelValidationContext ClientContext(out IDictionary<string, string> attributes, ModelMetadata? metadata = null)
+    {
+        var provider = new EmptyModelMetadataProvider();
+        var actionContext = new ActionContext(new DefaultHttpContext(), new RouteData(), new ActionDescriptor());
+        attributes = new Dictionary<string, string>();
+        return new ClientModelValidationContext(actionContext, metadata ?? provider.GetMetadataForType(typeof(string)), provider, attributes);
     }
 
     /// <summary>
@@ -42,5 +57,98 @@ public class DataTypeValidatorTests
     public void InvalidEmailFailsValidation(string email)
     {
         Assert.NotEqual(ValidationResult.Success, Validate(email));
+    }
+
+    /// <summary>
+    /// Given an email-address value that is empty
+    /// When it is validated
+    /// Then the empty-string short-circuit is taken and validation succeeds
+    /// </summary>
+    [Fact]
+    public void EmptyValuePassesValidation()
+    {
+        Assert.Equal(ValidationResult.Success, Validate(""));
+    }
+
+    /// <summary>
+    /// Given a value that is not a string
+    /// When it is validated as an email address
+    /// Then the string type-check short-circuits to the base validator and validation succeeds
+    /// </summary>
+    [Fact]
+    public void NonStringValuePassesValidation()
+    {
+        Assert.Equal(ValidationResult.Success, Validate(42));
+    }
+
+    /// <summary>
+    /// Given a validator for a data type other than EmailAddress
+    /// When a malformed-email string is validated
+    /// Then the email rule is not applied and validation succeeds
+    /// </summary>
+    [Fact]
+    public void NonEmailDataTypeSkipsEmailRule()
+    {
+        Assert.Equal(ValidationResult.Success, Validate("not-an-email", DataType.Text));
+    }
+
+    /// <summary>
+    /// Given an EmailAddress validator
+    /// When client validation metadata is added
+    /// Then the regex data-val attributes are emitted
+    /// </summary>
+    [Fact]
+    public void AddValidationEmitsEmailRegexAttributes()
+    {
+        var attribute = new DataTypeValidatorAttribute(DataType.EmailAddress);
+        var context = ClientContext(out var attributes);
+
+        attribute.AddValidation(context);
+
+        Assert.Equal("true", attributes["data-val"]);
+        Assert.True(attributes.ContainsKey("data-val-regex"));
+        Assert.True(attributes.ContainsKey("data-val-regex-pattern"));
+    }
+
+    /// <summary>
+    /// Given a validator for a data type other than EmailAddress
+    /// When client validation metadata is added
+    /// Then no attributes are emitted
+    /// </summary>
+    [Fact]
+    public void AddValidationEmitsNothingForNonEmailDataType()
+    {
+        var attribute = new DataTypeValidatorAttribute(DataType.Text);
+        var context = ClientContext(out var attributes);
+
+        attribute.AddValidation(context);
+
+        Assert.Empty(attributes);
+    }
+
+    /// <summary>
+    /// Given model metadata that carries a display name
+    /// When client validation metadata is added for an email address
+    /// Then the display name flows into the formatted error message
+    /// </summary>
+    [Fact]
+    public void AddValidationUsesModelDisplayName()
+    {
+        // A real MVC metadata provider (unlike EmptyModelMetadataProvider) reads [Display] annotations.
+        using var services = new ServiceCollection().AddMvcCore().AddDataAnnotations().Services.BuildServiceProvider();
+        var provider = services.GetRequiredService<IModelMetadataProvider>();
+        var metadata = provider.GetMetadataForProperty(typeof(Model), nameof(Model.Email));
+        var attribute = new DataTypeValidatorAttribute(DataType.EmailAddress);
+        var context = ClientContext(out var attributes, metadata);
+
+        attribute.AddValidation(context);
+
+        Assert.Contains("Email Address", attributes["data-val-regex"]);
+    }
+
+    private sealed class Model
+    {
+        [Display(Name = "Email Address")]
+        public string Email { get; set; } = "";
     }
 }

--- a/tests/Asm.AspNetCore.Mvc.Tests/TagHelpers/BodyTagHelperTests.cs
+++ b/tests/Asm.AspNetCore.Mvc.Tests/TagHelpers/BodyTagHelperTests.cs
@@ -1,0 +1,82 @@
+using Asm.AspNetCore.Mvc.TagHelpers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.AspNetCore.Routing;
+
+namespace Asm.AspNetCore.Mvc.Tests.TagHelpers;
+
+[Trait("Category", "Unit")]
+public class BodyTagHelperTests
+{
+    private static (TagHelperContext Context, TagHelperOutput Output) CreateContextAndOutput()
+    {
+        var context = new TagHelperContext(new TagHelperAttributeList(), new Dictionary<object, object>(), "test-id");
+        var output = new TagHelperOutput("body", new TagHelperAttributeList(),
+            (_, _) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
+        return (context, output);
+    }
+
+    private static ViewContext ViewContextFor(string? area, string? controller, string? action)
+    {
+        var routeData = new RouteData();
+        if (area is not null) routeData.Values["area"] = area;
+        if (controller is not null) routeData.Values["controller"] = controller;
+        if (action is not null) routeData.Values["action"] = action;
+        return new ViewContext { HttpContext = new DefaultHttpContext(), RouteData = routeData };
+    }
+
+    /// <summary>
+    /// Given a body tag helper with area, controller, and action route values
+    /// When it is processed
+    /// Then it emits a body tag whose class is those values, lowercased
+    /// </summary>
+    [Fact]
+    public void ProcessAddsRouteValuesAsLowercaseClass()
+    {
+        var (context, output) = CreateContextAndOutput();
+        var helper = new BodyTagHelper { ViewContext = ViewContextFor("Admin", "Users", "Index") };
+
+        helper.Process(context, output);
+
+        Assert.Equal("body", output.TagName);
+        Assert.Equal("admin users index", output.Attributes["class"].Value);
+    }
+
+    /// <summary>
+    /// Given a body tag helper with no view context
+    /// When it is processed
+    /// Then it still emits a body tag without throwing
+    /// </summary>
+    [Fact]
+    public void ProcessToleratesMissingViewContext()
+    {
+        var (context, output) = CreateContextAndOutput();
+        var helper = new BodyTagHelper { ViewContext = null };
+
+        helper.Process(context, output);
+
+        Assert.Equal("body", output.TagName);
+        Assert.True(output.Attributes.ContainsName("class"));
+    }
+
+    /// <summary>
+    /// Given a body tag helper whose output already carries a class attribute
+    /// When it is processed
+    /// Then the existing class is merged with the route-derived class
+    /// </summary>
+    [Fact]
+    public void ProcessMergesExistingClassAttribute()
+    {
+        var (context, output) = CreateContextAndOutput();
+        output.Attributes.Add(new TagHelperAttribute("class", "existing"));
+        var helper = new BodyTagHelper { ViewContext = ViewContextFor("Admin", "Users", "Index") };
+
+        helper.Process(context, output);
+
+        var className = output.Attributes["class"].Value.ToString();
+        Assert.Contains("admin users index", className);
+        Assert.Contains("existing", className);
+    }
+}

--- a/tests/Asm.Hosting.Tests/BackgroundWorkQueueTests.cs
+++ b/tests/Asm.Hosting.Tests/BackgroundWorkQueueTests.cs
@@ -59,6 +59,23 @@ public class BackgroundWorkQueueTests
         Assert.Throws<ObjectDisposedException>(() => queue.Queue(1));
     }
 
+    /// <summary>
+    /// Given a queue that has already been disposed
+    /// When Dispose is called a second time
+    /// Then the call returns without throwing (dispose is idempotent)
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void DisposeIsIdempotent()
+    {
+        var queue = new BackgroundWorkQueue<int>();
+        queue.Dispose();
+
+        var exception = Record.Exception(() => queue.Dispose());
+
+        Assert.Null(exception);
+    }
+
     [Fact]
     [Trait("Category", "Unit")]
     public void AddBackgroundWorkQueueRegistersSingleton()

--- a/tests/Asm.Umbraco.Tests/Extensions/IPublishedContentExtensionsTests.cs
+++ b/tests/Asm.Umbraco.Tests/Extensions/IPublishedContentExtensionsTests.cs
@@ -41,6 +41,23 @@ public class IPublishedContentExtensionsTests
     }
 
     /// <summary>
+    /// Given non-null published content whose Name is null
+    /// When NameAsCssClass is called
+    /// Then null is returned rather than throwing
+    /// </summary>
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void NameAsCssClassReturnsNullWhenNameIsNull()
+    {
+        var contentMock = new Mock<IPublishedContent>();
+        contentMock.Setup(c => c.Name).Returns((string)null!);
+
+        var result = contentMock.Object.NameAsCssClass();
+
+        Assert.Null(result);
+    }
+
+    /// <summary>
     /// Given published content whose Name contains multiple spaces
     /// When NameAsCssClass is called
     /// Then each space is replaced with a hyphen in the returned CSS class name


### PR DESCRIPTION
## Summary

Branch coverage had slipped just under the 80% bar (CI reported **79.9%**). This brings the **CI-aggregated** score comfortably over 80% — reproduced locally at **81%** (647/798) using CI's own scoped, matrix-only measurement — and closes the gap that made the first attempt miss. Every test addition exercises real behaviour; no coverage-gaming. Full suite **1059 pass**, solution builds **0 warnings**.

## Why the first pass didn't move the CI number

CI's aggregate is not a plain whole-solution figure. `build.yml`:
1. Ran only the **15 projects in its coverage matrix** — `Asm.AspNetCore.Api.Tests` and `Asm.Hosting.Tests` were **not** in it.
2. **Scopes** each project to its own assembly via `CoverletInclude` before measuring.

So the OpenAPI-transformer and `BackgroundWorkQueue` tests first added landed in the two excluded projects and never counted. Reproducing the scoped, matrix-only measurement locally matched CI (~80%), which is how I found this.

## Two parts

**1. Cover real branches in matrix assemblies:**

| Area | Assembly (in matrix) | Branches |
|---|---|---|
| `BodyTagHelper` — route-value→class mapping, missing view-context path, existing-class merge | `Asm.AspNetCore.Mvc` | ~9 |
| `DataTypeValidatorAttribute` — `AddValidation` (email/non-email/display-name); `IsValid` empty/non-string/non-email short-circuits | `Asm.AspNetCore.Mvc` | ~8 |
| `NameAsCssClass` — null-`Name` branch (from the #431 NRE fix) | `Asm.Umbraco` | +1 |
| OpenAPI transformers — `ServerPathPrefix`, `DocumentInfoTransformer`, `DisplayName` reference IDs | `Asm.AspNetCore.Api` | ~7 |
| `BackgroundWorkQueue.Dispose` idempotency | `Asm.Hosting` | +1 |

**2. Add the two missing projects to the coverage matrix** in `build.yml`. `Asm.AspNetCore.Api.Tests` and `Asm.Hosting.Tests` were absent, so those assemblies were measured by no one and had no coverage gate. With them added — and their tests carry the `Category` traits the coverage filter requires — the aggregate holds at **81%** (647/798), and the OpenAPI/dispose tests above now count.

## Notes

- The largest remaining matrix gaps are `ImgSetTagHelper` (needs full Umbraco composition — its test file documents this as out of scope for unit tests) and Serilog's `LoggingConfigurator` (BDD-covered). Left alone deliberately; that's where more headroom lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
