### PR TITLE
Accept an absolute URL in the canonical tag helper

### DIFF
--- a/src/Asm.AspNetCore.Mvc/TagHelpers/CanonicalTagHelper.cs
+++ b/src/Asm.AspNetCore.Mvc/TagHelpers/CanonicalTagHelper.cs
@@ -13,8 +13,12 @@ namespace Asm.AspNetCore.Mvc.TagHelpers;
 public class CanonicalTagHelper : TagHelper
 {
     /// <summary>
-    /// Gets or sets the path to the canonical URL.
+    /// Gets or sets the canonical URL.
     /// </summary>
+    /// <remarks>
+    /// Accepts either an absolute URL, which is emitted unchanged, or a site-relative path, which
+    /// is resolved against the current request's scheme and host.
+    /// </remarks>
     [HtmlAttributeName("path")]
     public required string Path
     {
@@ -31,11 +35,24 @@ public class CanonicalTagHelper : TagHelper
     /// <inheritdoc />
     public override void Process(TagHelperContext context, TagHelperOutput output)
     {
-        string href = $"{ViewContext.HttpContext.Request.Scheme}://{ViewContext.HttpContext.Request.Host}" + ($"/{Path}".Replace("//", "/").TrimEnd('/'));
-
         output.TagName = "link";
 
         output.Attributes.Add("rel", "canonical");
-        output.Attributes.Add("href", href);
+        output.Attributes.Add("href", ResolveHref());
+    }
+
+    // A canonical URL is absolute by definition, so callers may supply one directly. Only a
+    // relative path needs the request's scheme and host grafted on.
+    private string ResolveHref()
+    {
+        if (Uri.TryCreate(Path, UriKind.Absolute, out var absolute) &&
+            (absolute.Scheme == Uri.UriSchemeHttp || absolute.Scheme == Uri.UriSchemeHttps))
+        {
+            return Path.TrimEnd('/');
+        }
+
+        var request = ViewContext.HttpContext.Request;
+
+        return $"{request.Scheme}://{request.Host}/{Path.TrimStart('/')}".TrimEnd('/');
     }
 }

--- a/tests/Asm.AspNetCore.Mvc.Tests/TagHelpers/CanonicalTagHelperTests.cs
+++ b/tests/Asm.AspNetCore.Mvc.Tests/TagHelpers/CanonicalTagHelperTests.cs
@@ -58,4 +58,52 @@ public class CanonicalTagHelperTests
 
         Assert.Equal("https://example.com", output.Attributes["href"].Value);
     }
+
+    /// <summary>
+    /// Given a canonical tag helper with a rooted path
+    /// When it is processed
+    /// Then the href has a single separator between the host and the path
+    /// </summary>
+    [Fact]
+    public void ProcessEmitsSingleSeparatorForRootedPath()
+    {
+        var (context, output) = CreateContextAndOutput();
+        var helper = new CanonicalTagHelper { Path = "/about", ViewContext = ViewContextFor("https", "example.com") };
+
+        helper.Process(context, output);
+
+        Assert.Equal("https://example.com/about", output.Attributes["href"].Value);
+    }
+
+    /// <summary>
+    /// Given a canonical tag helper with an absolute URL
+    /// When it is processed
+    /// Then the URL is emitted unchanged rather than having the host prefixed again
+    /// </summary>
+    [Fact]
+    public void ProcessEmitsAbsoluteUrlUnchanged()
+    {
+        var (context, output) = CreateContextAndOutput();
+        var helper = new CanonicalTagHelper { Path = "https://example.com/about", ViewContext = ViewContextFor("https", "example.com") };
+
+        helper.Process(context, output);
+
+        Assert.Equal("https://example.com/about", output.Attributes["href"].Value);
+    }
+
+    /// <summary>
+    /// Given a canonical tag helper with an absolute URL for a different host
+    /// When it is processed
+    /// Then the supplied host is preserved rather than the request's host
+    /// </summary>
+    [Fact]
+    public void ProcessPreservesHostFromAbsoluteUrl()
+    {
+        var (context, output) = CreateContextAndOutput();
+        var helper = new CanonicalTagHelper { Path = "https://www.example.com/about", ViewContext = ViewContextFor("https", "example.com") };
+
+        helper.Process(context, output);
+
+        Assert.Equal("https://www.example.com/about", output.Attributes["href"].Value);
+    }
 }


### PR DESCRIPTION
`CanonicalTagHelper` only accepted a site-relative path and built the absolute URL itself from the request's scheme and host. That forced every caller to keep a *relative* value in something named `Canonical`, and anything else reading that value emitted a relative URL — which is invalid for both `og:url` and schema.org's `url`. andrewmclachlan.com is currently shipping `<meta property="og:url" content="/articles/postie" />` for exactly this reason.

## Change

An absolute `http`/`https` URL now passes through unchanged. A relative path is resolved against the request as before, so existing callers are unaffected.

Also drops the `"//" -> "/"` collapse. It would have turned an absolute URL into `https:/host/...`, and it corrupts any path legitimately containing a double slash. The rooted-path case it was actually covering (`/about`) is now handled by `TrimStart('/')` and has a test of its own.

## Tests

Five tests on the helper — the two existing ones plus:

- rooted path (`/about`) produces a single separator, covering the behaviour `Replace` was providing
- an absolute URL is emitted unchanged
- an absolute URL's host wins over the request's host

`dotnet test tests/Asm.AspNetCore.Mvc.Tests` — 48 passed, 0 failed.

## Downstream

This unblocks AmCom setting `ViewBag.Canonical = Model.Url(mode: UrlMode.Absolute)`, which fixes `og:url` and the `url` in four JSON-LD blocks. That needs a release before it can be picked up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)